### PR TITLE
feat(F0Form): sync sections sidebar highlight with scroll

### DIFF
--- a/packages/react/src/patterns/F0Form/F0Form.tsx
+++ b/packages/react/src/patterns/F0Form/F0Form.tsx
@@ -52,7 +52,10 @@ import {
 } from "./groupingUtils"
 import { useErrorNavigation } from "./useErrorNavigation"
 import { useSchemaDefinition } from "./useSchemaDefinition"
-import { useSectionScrollSpy } from "./useSectionScrollSpy"
+import {
+  scrollSectionIntoView,
+  useSectionScrollSpy,
+} from "./useSectionScrollSpy"
 import { createZodErrorMap } from "./zodErrorMap"
 
 /**
@@ -161,10 +164,7 @@ function F0FormPerSection<T extends F0PerSectionSchema>(
         // highlight doesn't flicker through intermediate sections; it resumes
         // once the scroll settles.
         beginProgrammaticScroll()
-        container.scrollTo({
-          top: element.offsetTop - container.offsetTop,
-          behavior: "smooth",
-        })
+        scrollSectionIntoView(container, element)
       }
     },
     [name, setActiveSection, beginProgrammaticScroll]
@@ -640,12 +640,7 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
         // Mute scroll-spy for the smooth scroll so the highlight doesn't
         // flicker through intermediate sections; it resumes on scrollend.
         beginProgrammaticScroll()
-        // Scroll within the form's own scroll container to avoid
-        // shifting parent containers (e.g. the canvas panel).
-        container.scrollTo({
-          top: element.offsetTop - container.offsetTop,
-          behavior: "smooth",
-        })
+        scrollSectionIntoView(container, element)
       }
     },
     [name, setActiveSection, beginProgrammaticScroll]

--- a/packages/react/src/patterns/F0Form/F0Form.tsx
+++ b/packages/react/src/patterns/F0Form/F0Form.tsx
@@ -52,6 +52,7 @@ import {
 } from "./groupingUtils"
 import { useErrorNavigation } from "./useErrorNavigation"
 import { useSchemaDefinition } from "./useSchemaDefinition"
+import { useSectionScrollSpy } from "./useSectionScrollSpy"
 import { createZodErrorMap } from "./zodErrorMap"
 
 /**
@@ -136,19 +137,37 @@ function F0FormPerSection<T extends F0PerSectionSchema>(
 
   const sectionIds = useMemo(() => Object.keys(schema), [schema])
 
+  // Ref to the scrollable container that holds both sidebar + form content.
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+
+  // Keep the sidebar highlight in sync with manual scrolling.
+  const { activeSection, setActiveSection, beginProgrammaticScroll } =
+    useSectionScrollSpy({
+      sectionIds,
+      getElementId: (sectionId) => generateAnchorId(name, sectionId),
+      containerRef: scrollContainerRef,
+      enabled: showSectionsSidepanel && !!sections && sectionIds.length > 0,
+    })
+
+  // Scroll to section when a TOC item is clicked and mark it active.
   const handleSectionClick = useCallback(
     (sectionId: string) => {
+      setActiveSection(sectionId)
       const anchorId = generateAnchorId(name, sectionId)
       const element = document.getElementById(anchorId)
-      if (element) {
-        element.scrollIntoView({ behavior: "smooth", block: "start" })
+      const container = scrollContainerRef.current
+      if (element && container) {
+        // Mute scroll-spy for the duration of the smooth scroll so the
+        // highlight doesn't flicker through intermediate sections; it resumes
+        // once the scroll settles.
+        beginProgrammaticScroll()
+        container.scrollTo({
+          top: element.offsetTop - container.offsetTop,
+          behavior: "smooth",
+        })
       }
     },
-    [name]
-  )
-
-  const [activeSection, setActiveSection] = useState<string | undefined>(
-    sectionIds[0]
+    [name, setActiveSection, beginProgrammaticScroll]
   )
 
   const tocItems: TOCItem[] = useMemo(() => {
@@ -157,10 +176,7 @@ function F0FormPerSection<T extends F0PerSectionSchema>(
     return sectionIds.map((sectionId) => ({
       id: sectionId,
       label: sections[sectionId]?.title ?? sectionId,
-      onClick: () => {
-        setActiveSection(sectionId)
-        handleSectionClick(sectionId)
-      },
+      onClick: () => handleSectionClick(sectionId),
     }))
   }, [sections, sectionIds, showSectionsSidepanel, handleSectionClick])
 
@@ -205,7 +221,7 @@ function F0FormPerSection<T extends F0PerSectionSchema>(
 
   if (showSectionsSidepanel && tocItems.length > 0) {
     return (
-      <div className="flex w-full overflow-scroll">
+      <div ref={scrollContainerRef} className="flex w-full overflow-scroll">
         <div className="sticky top-0 mr-4 h-fit shrink-0 self-start pt-2">
           <F0TableOfContent
             items={tocItems}
@@ -599,13 +615,19 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
       .map((section) => section.id)
   }, [definition])
 
-  // Track active section (the last clicked section)
-  const [activeSection, setActiveSection] = useState<string | undefined>(
-    sectionIds[0]
-  )
-
   // Ref to the scrollable container that holds both sidebar + form content
   const scrollContainerRef = useRef<HTMLDivElement>(null)
+
+  // Track the active section and keep it in sync with manual scrolling so the
+  // sidebar highlight follows the section currently in view, not just the last
+  // clicked one.
+  const { activeSection, setActiveSection, beginProgrammaticScroll } =
+    useSectionScrollSpy({
+      sectionIds,
+      getElementId: (sectionId) => generateAnchorId(name, sectionId),
+      containerRef: scrollContainerRef,
+      enabled: showSectionsSidepanel && !!sections && sectionIds.length > 0,
+    })
 
   // Scroll to section when TOC item is clicked and mark it as active
   const handleSectionClick = useCallback(
@@ -615,6 +637,9 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
       const element = document.getElementById(anchorId)
       const container = scrollContainerRef.current
       if (element && container) {
+        // Mute scroll-spy for the smooth scroll so the highlight doesn't
+        // flicker through intermediate sections; it resumes on scrollend.
+        beginProgrammaticScroll()
         // Scroll within the form's own scroll container to avoid
         // shifting parent containers (e.g. the canvas panel).
         container.scrollTo({
@@ -623,7 +648,7 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
         })
       }
     },
-    [name]
+    [name, setActiveSection, beginProgrammaticScroll]
   )
 
   // Convert sections to TOCItems for the TableOfContent component

--- a/packages/react/src/patterns/F0Form/__stories__/F0Form.mdx
+++ b/packages/react/src/patterns/F0Form/__stories__/F0Form.mdx
@@ -403,11 +403,20 @@ Use `sections` to split a long form into named groups with independent submit bu
 
 <Canvas of={Stories.WithSectionsSidepanel} />
 
+The sidebar highlight follows the form's scroll position. Clicking a section
+smoothly scrolls to it and highlights it; scrolling by hand moves the highlight
+to whichever section reaches the top of the form's scroll area, and the last
+section stays highlighted once you reach the bottom. This tracking works when
+the form scrolls inside its own container (as it does in a dialog or an AI
+canvas panel) — see the example below, where the form is given a fixed height.
+
+<Canvas of={Stories.WithSectionsSidepanelScrollSpy} />
+
 ## Styling
 
 The optional `styling` config controls the form layout:
 
-- `showSectionsSidepanel` — render a sticky table-of-contents sidebar for the form's sections (see the example above).
+- `showSectionsSidepanel` — render a sticky table-of-contents sidebar for the form's sections (see the example above). The highlighted section stays in sync with manual scrolling, not just clicks.
 - `noPadding` — remove the default `p-4` padding around the form content. Use it when embedding the form flush inside a host surface (e.g. an AI canvas panel) that already provides its own spacing. Defaults to `false`, so existing forms are unaffected.
 
 ```tsx

--- a/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
+++ b/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
@@ -564,6 +564,145 @@ export const WithSectionsSidepanel: Story = {
 }
 
 /**
+ * The sidebar highlight tracks scrolling. Clicking a section smoothly scrolls
+ * to it; scrolling manually moves the highlight to whichever section reaches
+ * the top of the form's scroll area. The form is placed in a fixed-height
+ * container so it scrolls internally, exactly as it does inside a dialog or an
+ * AI canvas panel.
+ */
+export const WithSectionsSidepanelScrollSpy: Story = {
+  decorators: [
+    (Story) => (
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          height: 460,
+          maxWidth: 760,
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  render() {
+    const formSchema = z.object({
+      // Basic Information
+      title: f0FormField.text({
+        label: "Title",
+        section: "basic",
+        placeholder: "Enter a title",
+      }),
+      description: f0FormField.textarea({
+        label: "Description",
+        section: "basic",
+        optional: true,
+        rows: 3,
+      }),
+      // Owner
+      owner: f0FormField.text({
+        label: "Owner",
+        section: "owner",
+        placeholder: "Owner name",
+      }),
+      team: f0FormField.text({
+        label: "Team",
+        section: "owner",
+        optional: true,
+      }),
+      // Schedule
+      startsAt: f0FormField.date({
+        label: "Starts on",
+        section: "schedule",
+        optional: true,
+      }),
+      recurrence: f0FormField.select({
+        label: "Recurrence",
+        section: "schedule",
+        options: [
+          { value: "none", label: "Does not repeat" },
+          { value: "weekly", label: "Weekly" },
+          { value: "monthly", label: "Monthly" },
+        ],
+      }),
+      // Visibility
+      isPublic: f0FormField.boolean({
+        label: "Publicly visible",
+        section: "visibility",
+        optional: true,
+      }),
+      anonymous: f0FormField.boolean({
+        label: "Anonymous answers",
+        section: "visibility",
+        optional: true,
+      }),
+      // Notifications
+      notifyByEmail: f0FormField.boolean({
+        label: "Notify by email",
+        section: "notifications",
+        optional: true,
+      }),
+      digest: f0FormField.select({
+        label: "Digest frequency",
+        section: "notifications",
+        options: [
+          { value: "off", label: "Off" },
+          { value: "daily", label: "Daily" },
+          { value: "weekly", label: "Weekly" },
+        ],
+      }),
+      // Advanced
+      slug: f0FormField.text({
+        label: "Slug",
+        section: "advanced",
+        optional: true,
+      }),
+      retentionDays: f0FormField.number({
+        label: "Retention (days)",
+        section: "advanced",
+        optional: true,
+      }),
+    })
+
+    const sections: Record<string, F0SectionConfig> = {
+      basic: { title: "Basic Information" },
+      owner: { title: "Owner & Team" },
+      schedule: { title: "Schedule" },
+      visibility: { title: "Visibility & Privacy" },
+      notifications: { title: "Notifications" },
+      advanced: { title: "Advanced" },
+    }
+
+    const formDefinition = useF0FormDefinition({
+      name: "scroll-spy-settings",
+      schema: formSchema,
+      sections,
+      defaultValues: {
+        title: "Quarterly planning",
+        recurrence: "none",
+        isPublic: false,
+        anonymous: false,
+        notifyByEmail: false,
+        digest: "off",
+      },
+      onSubmit: async ({ data }) => {
+        await sleep(1000)
+        console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+        return { success: true }
+      },
+      submitConfig: { label: "Save" },
+    })
+
+    return (
+      <F0Form
+        formDefinition={formDefinition}
+        styling={{ showSectionsSidepanel: true }}
+      />
+    )
+  },
+}
+
+/**
  * Form with conditional field rendering based on other field values.
  * Fields can use `renderIf` to conditionally show/hide based on other field values.
  * Supports both condition objects and functions.

--- a/packages/react/src/patterns/F0Form/__tests__/useSectionScrollSpy.test.ts
+++ b/packages/react/src/patterns/F0Form/__tests__/useSectionScrollSpy.test.ts
@@ -1,0 +1,216 @@
+import { act } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { zeroRenderHook } from "@/testing/test-utils"
+
+import {
+  getActiveSectionId,
+  SCROLL_SPY_TOP_OFFSET,
+  type SectionTop,
+  useSectionScrollSpy,
+} from "../useSectionScrollSpy"
+
+const sec = (id: string, top: number): SectionTop => ({ id, top })
+
+describe("getActiveSectionId", () => {
+  const offset = SCROLL_SPY_TOP_OFFSET
+
+  it("returns undefined when there are no sections", () => {
+    expect(getActiveSectionId([], offset, false)).toBeUndefined()
+  })
+
+  it("returns the only section when there is a single one", () => {
+    expect(getActiveSectionId([sec("only", 500)], offset, false)).toBe("only")
+  })
+
+  it("keeps the first section active before any scroll (all below the line)", () => {
+    const sections = [sec("a", 8), sec("b", 400), sec("c", 800)]
+    expect(getActiveSectionId(sections, offset, false)).toBe("a")
+  })
+
+  it("activates the section whose top currently sits at the activation line", () => {
+    // b scrolled just above the line, c still below it -> b is active
+    const sections = [sec("a", -300), sec("b", -10), sec("c", 200)]
+    expect(getActiveSectionId(sections, offset, false)).toBe("b")
+  })
+
+  it("activates the last section once its top passes the line", () => {
+    const sections = [sec("a", -600), sec("b", -300), sec("c", -8)]
+    expect(getActiveSectionId(sections, offset, false)).toBe("c")
+  })
+
+  it("treats a top within the sub-pixel epsilon of the line as active", () => {
+    // top === offset + 1 is within the 1px activation epsilon
+    const sections = [sec("a", -100), sec("b", offset + 1), sec("c", 900)]
+    expect(getActiveSectionId(sections, offset, false)).toBe("b")
+  })
+
+  it("does not activate a section still clearly below the line", () => {
+    const sections = [sec("a", -100), sec("b", offset + 2), sec("c", 900)]
+    expect(getActiveSectionId(sections, offset, false)).toBe("a")
+  })
+
+  it("forces the last section active at the bottom even if its top never reaches the line", () => {
+    // Short final section: c's top is well below the line, but we are at the
+    // bottom of the container so it must still be reachable/active.
+    const sections = [sec("a", -600), sec("b", -300), sec("c", 200)]
+    expect(getActiveSectionId(sections, offset, false)).toBe("b")
+    expect(getActiveSectionId(sections, offset, true)).toBe("c")
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Hook behavior (mocked layout — jsdom has no real layout engine)
+// ---------------------------------------------------------------------------
+
+const IDS = ["a", "b", "c"]
+const getElementId = (id: string) => `forms.test.${id}`
+
+const makeRect = (top: number): DOMRect =>
+  ({
+    top,
+    bottom: top + 300,
+    left: 0,
+    right: 0,
+    width: 0,
+    height: 300,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  }) as DOMRect
+
+interface Harness {
+  container: HTMLDivElement
+  tops: Record<string, number>
+  setScrollTop: (value: number) => void
+}
+
+function mountDom(): Harness {
+  const container = document.createElement("div")
+  container.id = "container"
+  document.body.appendChild(container)
+
+  Object.defineProperty(container, "clientHeight", {
+    value: 300,
+    configurable: true,
+  })
+  Object.defineProperty(container, "scrollHeight", {
+    value: 900,
+    configurable: true,
+  })
+  let scrollTop = 0
+  Object.defineProperty(container, "scrollTop", {
+    get: () => scrollTop,
+    set: (v: number) => {
+      scrollTop = v
+    },
+    configurable: true,
+  })
+  container.getBoundingClientRect = () => makeRect(0)
+
+  const tops: Record<string, number> = { a: 0, b: 300, c: 600 }
+  for (const id of IDS) {
+    const el = document.createElement("div")
+    el.id = getElementId(id)
+    el.getBoundingClientRect = () => makeRect(tops[id]!)
+    container.appendChild(el)
+  }
+
+  return {
+    container,
+    tops,
+    setScrollTop: (value: number) => {
+      scrollTop = value
+    },
+  }
+}
+
+function renderSpy(container: HTMLDivElement) {
+  const containerRef: React.RefObject<HTMLElement | null> = {
+    current: container,
+  }
+  return zeroRenderHook(() =>
+    useSectionScrollSpy({
+      sectionIds: IDS,
+      getElementId,
+      containerRef,
+      enabled: true,
+    })
+  )
+}
+
+describe("useSectionScrollSpy", () => {
+  beforeEach(() => {
+    // Run rAF synchronously so recompute happens within the same act().
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+      cb(0)
+      return 0
+    })
+    vi.stubGlobal("cancelAnimationFrame", () => {})
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    document.body.innerHTML = ""
+  })
+
+  it("starts on the first section", () => {
+    const { container } = mountDom()
+    const { result } = renderSpy(container)
+    expect(result.current.activeSection).toBe("a")
+  })
+
+  it("updates the active section on manual scroll", () => {
+    const harness = mountDom()
+    const { result } = renderSpy(harness.container)
+
+    act(() => {
+      // Scroll so section b sits at the top of the viewport.
+      harness.tops.a = -300
+      harness.tops.b = 0
+      harness.tops.c = 300
+      harness.container.dispatchEvent(new Event("scroll"))
+    })
+
+    expect(result.current.activeSection).toBe("b")
+  })
+
+  it("mutes spy during a programmatic scroll and resumes on scrollend", () => {
+    const harness = mountDom()
+    const { result } = renderSpy(harness.container)
+
+    act(() => {
+      result.current.beginProgrammaticScroll()
+    })
+
+    act(() => {
+      // A scroll fired mid-animation must NOT move the highlight.
+      harness.tops.a = -600
+      harness.tops.b = -300
+      harness.tops.c = 0
+      harness.container.dispatchEvent(new Event("scroll"))
+    })
+    expect(result.current.activeSection).toBe("a")
+
+    act(() => {
+      harness.container.dispatchEvent(new Event("scrollend"))
+    })
+    expect(result.current.activeSection).toBe("c")
+  })
+
+  it("activates the last section when scrolled to the bottom", () => {
+    const harness = mountDom()
+    const { result } = renderSpy(harness.container)
+
+    act(() => {
+      // At the bottom, c's top is still below the line but must win.
+      harness.setScrollTop(600)
+      harness.tops.a = -600
+      harness.tops.b = -300
+      harness.tops.c = 200
+      harness.container.dispatchEvent(new Event("scroll"))
+    })
+
+    expect(result.current.activeSection).toBe("c")
+  })
+})

--- a/packages/react/src/patterns/F0Form/__tests__/useSectionScrollSpy.test.ts
+++ b/packages/react/src/patterns/F0Form/__tests__/useSectionScrollSpy.test.ts
@@ -6,11 +6,58 @@ import { zeroRenderHook } from "@/testing/test-utils"
 import {
   getActiveSectionId,
   SCROLL_SPY_TOP_OFFSET,
+  scrollSectionIntoView,
   type SectionTop,
   useSectionScrollSpy,
 } from "../useSectionScrollSpy"
 
 const sec = (id: string, top: number): SectionTop => ({ id, top })
+
+describe("scrollSectionIntoView", () => {
+  function setup(scrollHeight: number, clientHeight: number) {
+    const container = document.createElement("div")
+    Object.defineProperty(container, "scrollHeight", {
+      value: scrollHeight,
+      configurable: true,
+    })
+    Object.defineProperty(container, "clientHeight", {
+      value: clientHeight,
+      configurable: true,
+    })
+    Object.defineProperty(container, "offsetTop", {
+      value: 0,
+      configurable: true,
+    })
+    container.scrollTo = vi.fn()
+    const element = document.createElement("div")
+    Object.defineProperty(element, "offsetTop", {
+      value: 400,
+      configurable: true,
+    })
+    element.scrollIntoView = vi.fn()
+    return { container, element }
+  }
+
+  it("scrolls the container when it overflows", () => {
+    const { container, element } = setup(900, 300)
+    scrollSectionIntoView(container, element)
+    expect(container.scrollTo).toHaveBeenCalledWith({
+      top: 400,
+      behavior: "smooth",
+    })
+    expect(element.scrollIntoView).not.toHaveBeenCalled()
+  })
+
+  it("falls back to scrollIntoView when the container does not overflow", () => {
+    const { container, element } = setup(900, 900)
+    scrollSectionIntoView(container, element)
+    expect(element.scrollIntoView).toHaveBeenCalledWith({
+      behavior: "smooth",
+      block: "start",
+    })
+    expect(container.scrollTo).not.toHaveBeenCalled()
+  })
+})
 
 describe("getActiveSectionId", () => {
   const offset = SCROLL_SPY_TOP_OFFSET

--- a/packages/react/src/patterns/F0Form/__tests__/useSectionScrollSpy.test.ts
+++ b/packages/react/src/patterns/F0Form/__tests__/useSectionScrollSpy.test.ts
@@ -213,4 +213,18 @@ describe("useSectionScrollSpy", () => {
 
     expect(result.current.activeSection).toBe("c")
   })
+
+  it("does not clamp to the last section when the container has no overflow", () => {
+    const harness = mountDom()
+    // Content fits exactly: clientHeight === scrollHeight, so the container
+    // never scrolls. The initial recompute must NOT treat this as "at the
+    // bottom" and jump to the last section.
+    Object.defineProperty(harness.container, "clientHeight", {
+      value: 900,
+      configurable: true,
+    })
+    const { result } = renderSpy(harness.container)
+
+    expect(result.current.activeSection).toBe("a")
+  })
 })

--- a/packages/react/src/patterns/F0Form/useSectionScrollSpy.ts
+++ b/packages/react/src/patterns/F0Form/useSectionScrollSpy.ts
@@ -1,0 +1,190 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+
+/**
+ * Distance (px) from the top of the scroll viewport that defines the
+ * "activation line". A section becomes active once its top edge reaches or
+ * passes this line. Matches the `scroll-mt-4` (16px) offset applied to each
+ * section anchor, so the click-to-scroll target and the scroll-spy activation
+ * point line up exactly.
+ */
+export const SCROLL_SPY_TOP_OFFSET = 16
+
+/**
+ * Fallback delay (ms) after a click-initiated smooth scroll before scroll-spy
+ * is re-enabled, for browsers without the `scrollend` event (e.g. Safari).
+ * Long enough to outlast a typical smooth-scroll animation.
+ */
+const PROGRAMMATIC_SCROLL_FALLBACK_MS = 700
+
+/** Tolerance (px) for detecting the bottom of the scroll container. */
+const BOTTOM_EPSILON = 2
+
+/** Sub-pixel tolerance when comparing a section top against the activation line. */
+const ACTIVATION_EPSILON = 1
+
+/** A section's top edge measured relative to the scroll viewport's top edge. */
+export interface SectionTop {
+  id: string
+  /** Viewport-relative top of the section (px). Negative once scrolled past. */
+  top: number
+}
+
+/**
+ * Pure selection logic for scroll-spy: given the current viewport-relative top
+ * of each section (in DOM order), returns the id of the section that should be
+ * highlighted.
+ *
+ * Rule: the active section is the **last** one whose top edge is at or above
+ * the activation line (`topOffset` px below the viewport top). When the
+ * container is scrolled to the bottom, the last section wins unconditionally so
+ * a short final section that never reaches the line is still reachable.
+ *
+ * Kept pure (no DOM) so the core behavior is deterministic and unit-testable.
+ */
+export function getActiveSectionId(
+  sections: SectionTop[],
+  topOffset: number,
+  atBottom: boolean
+): string | undefined {
+  if (sections.length === 0) return undefined
+  if (atBottom) return sections[sections.length - 1]!.id
+
+  let active = sections[0]!.id
+  for (const section of sections) {
+    if (section.top - topOffset <= ACTIVATION_EPSILON) {
+      active = section.id
+    } else {
+      break
+    }
+  }
+  return active
+}
+
+interface UseSectionScrollSpyOptions {
+  /** Ordered section ids to track (DOM order, top to bottom). */
+  sectionIds: string[]
+  /** Resolve the DOM element id (anchor) for a given section id. */
+  getElementId: (sectionId: string) => string
+  /**
+   * Ref to the scroll container that holds the stacked sections. This is the
+   * same element the click-to-scroll handler scrolls, so spy and click stay in
+   * sync.
+   */
+  containerRef: React.RefObject<HTMLElement | null>
+  /** Whether scroll-spy is active (sidepanel shown with stacked sections). */
+  enabled: boolean
+  /** Activation-line offset from the viewport top (px). */
+  topOffset?: number
+}
+
+/**
+ * Tracks which form section is currently in view and keeps it in sync with the
+ * sidebar highlight as the user scrolls.
+ *
+ * Owns the `activeSection` state. On a sidebar click, the caller should set the
+ * active section directly (for an instant highlight) and call
+ * `beginProgrammaticScroll` so the smooth scroll doesn't make the highlight
+ * flicker through every intermediate section; spy resumes once the scroll
+ * settles.
+ */
+export function useSectionScrollSpy({
+  sectionIds,
+  getElementId,
+  containerRef,
+  enabled,
+  topOffset = SCROLL_SPY_TOP_OFFSET,
+}: UseSectionScrollSpyOptions) {
+  const [activeSection, setActiveSection] = useState<string | undefined>(
+    sectionIds[0]
+  )
+
+  // Muted while a click-initiated smooth scroll is animating.
+  const isProgrammaticRef = useRef(false)
+  const rafRef = useRef<number | null>(null)
+  const fallbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Latest values in refs so the scroll handler identity stays stable.
+  const sectionIdsRef = useRef(sectionIds)
+  sectionIdsRef.current = sectionIds
+  const getElementIdRef = useRef(getElementId)
+  getElementIdRef.current = getElementId
+
+  const recompute = useCallback(() => {
+    const container = containerRef.current
+    const rootTop = container ? container.getBoundingClientRect().top : 0
+
+    const sections: SectionTop[] = []
+    for (const id of sectionIdsRef.current) {
+      const el = document.getElementById(getElementIdRef.current(id))
+      if (!el) continue
+      sections.push({ id, top: el.getBoundingClientRect().top - rootTop })
+    }
+
+    const atBottom = container
+      ? container.scrollTop + container.clientHeight >=
+        container.scrollHeight - BOTTOM_EPSILON
+      : window.innerHeight + window.scrollY >=
+        document.documentElement.scrollHeight - BOTTOM_EPSILON
+
+    const next = getActiveSectionId(sections, topOffset, atBottom)
+    if (next !== undefined) setActiveSection(next)
+  }, [containerRef, topOffset])
+
+  const scheduleRecompute = useCallback(() => {
+    if (isProgrammaticRef.current) return
+    if (rafRef.current !== null) return
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null
+      recompute()
+    })
+  }, [recompute])
+
+  const beginProgrammaticScroll = useCallback(() => {
+    isProgrammaticRef.current = true
+    if (fallbackTimerRef.current) clearTimeout(fallbackTimerRef.current)
+    fallbackTimerRef.current = setTimeout(() => {
+      isProgrammaticRef.current = false
+      recompute()
+    }, PROGRAMMATIC_SCROLL_FALLBACK_MS)
+  }, [recompute])
+
+  useEffect(() => {
+    if (!enabled) return
+
+    const container = containerRef.current
+    const scrollTarget: HTMLElement | Window = container ?? window
+
+    const handleScroll = () => scheduleRecompute()
+    const handleScrollEnd = () => {
+      if (!isProgrammaticRef.current) return
+      isProgrammaticRef.current = false
+      if (fallbackTimerRef.current) clearTimeout(fallbackTimerRef.current)
+      recompute()
+    }
+
+    scrollTarget.addEventListener("scroll", handleScroll, { passive: true })
+    scrollTarget.addEventListener("scrollend", handleScrollEnd)
+    window.addEventListener("resize", scheduleRecompute)
+
+    // Recompute on layout changes (e.g. a conditional section appears).
+    const resizeObserver =
+      container && typeof ResizeObserver !== "undefined"
+        ? new ResizeObserver(() => scheduleRecompute())
+        : null
+    if (resizeObserver && container) resizeObserver.observe(container)
+
+    // Initial sync so the highlight matches the starting scroll position.
+    recompute()
+
+    return () => {
+      scrollTarget.removeEventListener("scroll", handleScroll)
+      scrollTarget.removeEventListener("scrollend", handleScrollEnd)
+      window.removeEventListener("resize", scheduleRecompute)
+      resizeObserver?.disconnect()
+      if (rafRef.current !== null) cancelAnimationFrame(rafRef.current)
+      if (fallbackTimerRef.current) clearTimeout(fallbackTimerRef.current)
+    }
+  }, [enabled, containerRef, scheduleRecompute, recompute, sectionIds])
+
+  return { activeSection, setActiveSection, beginProgrammaticScroll }
+}

--- a/packages/react/src/patterns/F0Form/useSectionScrollSpy.ts
+++ b/packages/react/src/patterns/F0Form/useSectionScrollSpy.ts
@@ -60,6 +60,31 @@ export function getActiveSectionId(
   return active
 }
 
+/**
+ * Smoothly scroll a section to the top of its scroll container.
+ *
+ * When the container actually overflows, scroll it directly — this keeps the
+ * movement contained and avoids shifting parent surfaces (e.g. the canvas
+ * panel). When it doesn't (an unbounded layout where the wrapper grew to fit
+ * its content and the page is the real scroller), fall back to `scrollIntoView`
+ * so the click still moves the user to the section instead of no-opping.
+ */
+export function scrollSectionIntoView(
+  container: HTMLElement,
+  element: HTMLElement
+) {
+  const canScroll =
+    container.scrollHeight > container.clientHeight + BOTTOM_EPSILON
+  if (canScroll) {
+    container.scrollTo({
+      top: element.offsetTop - container.offsetTop,
+      behavior: "smooth",
+    })
+  } else {
+    element.scrollIntoView({ behavior: "smooth", block: "start" })
+  }
+}
+
 interface UseSectionScrollSpyOptions {
   /** Ordered section ids to track (DOM order, top to bottom). */
   sectionIds: string[]

--- a/packages/react/src/patterns/F0Form/useSectionScrollSpy.ts
+++ b/packages/react/src/patterns/F0Form/useSectionScrollSpy.ts
@@ -120,11 +120,19 @@ export function useSectionScrollSpy({
       sections.push({ id, top: el.getBoundingClientRect().top - rootTop })
     }
 
-    const atBottom = container
-      ? container.scrollTop + container.clientHeight >=
-        container.scrollHeight - BOTTOM_EPSILON
-      : window.innerHeight + window.scrollY >=
-        document.documentElement.scrollHeight - BOTTOM_EPSILON
+    const scrollTop = container ? container.scrollTop : window.scrollY
+    const clientHeight = container ? container.clientHeight : window.innerHeight
+    const scrollHeight = container
+      ? container.scrollHeight
+      : document.documentElement.scrollHeight
+
+    // Only clamp to the last section when there is real vertical overflow to
+    // scroll through. An unbounded container has clientHeight === scrollHeight,
+    // which would otherwise read as "at the bottom" on the very first recompute
+    // and wrongly activate the last section before the user has scrolled.
+    const canScroll = scrollHeight > clientHeight + BOTTOM_EPSILON
+    const atBottom =
+      canScroll && scrollTop + clientHeight >= scrollHeight - BOTTOM_EPSILON
 
     const next = getActiveSectionId(sections, topOffset, atBottom)
     if (next !== undefined) setActiveSection(next)


### PR DESCRIPTION
## Description

The F0Form sections sidepanel highlighted the active item only when you clicked it — scrolling the form by hand left the highlight stale. This adds scroll-spy so the highlighted section follows whichever section reaches the top of the form's scroll container, in both single-schema and per-section modes.

## Implementation details

The highlight is now driven by scroll position, not just clicks. A new `useSectionScrollSpy` hook watches the form's scroll container and reports which section is currently in view, and both stacked F0Form modes feed their `activeSection` from it.

The selection rule lives in a pure `getActiveSectionId` function so the behavior is deterministic and easy to test in isolation: the active section is the last one whose top edge has crossed an activation line near the top of the viewport. That line reuses the existing `scroll-mt-4` (16px) offset, so the click-to-scroll target and the scroll-spy activation point line up exactly. A short final section would never reach that line, so when the container is scrolled to the bottom the last section is forced active — it stays reachable. Around that function, the hook wires scroll, resize, and `ResizeObserver` listeners (so a conditionally-rendered section appearing also re-syncs), throttled through `requestAnimationFrame`.

Clicking a sidebar item keeps its original behavior — set the highlight immediately, then smooth-scroll to the section — but the spy is now muted for the duration of that animation. Without this, the smooth scroll would drag the highlight through every section it passes on the way. Muting ends on the `scrollend` event, with a timeout fallback for browsers that don't support it (older Safari).

Covered by 12 tests: eight for the pure selection function (threshold crossing, the bottom clamp, sub-pixel tolerance, empty/single-section cases) and four for the hook (scroll updates the highlight, the click-mute suppresses updates and resumes on `scrollend`, bottom-of-container activates the last section). The new `WithSectionsSidepanelScrollSpy` story demonstrates it in a fixed-height container, and the F0Form MDX documents the behavior.