### PR TITLE
fix(ai): welcome suggestions popover closes when switching to the last group

### DIFF
--- a/packages/react/src/components/F0Button/internal-types.ts
+++ b/packages/react/src/components/F0Button/internal-types.ts
@@ -31,6 +31,14 @@ export type ButtonInternalProps = Pick<
      */
     "aria-expanded"?: boolean
     /**
+     * Identifies the expandable region controlled by the button.
+     */
+    "aria-controls"?: string
+    /**
+     * Describes the type of popup opened by the button.
+     */
+    "aria-haspopup"?: React.AriaAttributes["aria-haspopup"]
+    /**
      * Forwarded to the underlying button. Use `-1` to take the button out of the
      * tab order (e.g. when a parent manages focus via roving tabindex).
      */

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
@@ -1,5 +1,6 @@
-import { Meta, StoryObj } from "@storybook/react-vite"
+import type { Meta, StoryObj } from "@storybook/react-vite"
 import { useRef, useState } from "react"
+import { expect, userEvent, within } from "storybook/test"
 
 import { F0AiChatTextArea } from "../F0AiChatTextArea"
 import type { F0AiChatTextAreaSubmitPayload } from "../types"
@@ -451,6 +452,32 @@ export const WithWelcomeSuggestions: Story = {
     fullscreen: true,
     welcomeScreenSuggestions: WELCOME_SUGGESTIONS,
     disclaimer: DISCLAIMER,
+  },
+  play: async ({ canvasElement, step }) => {
+    const page = within(canvasElement.closest("body")!)
+
+    await step("Open the first suggestion group", async () => {
+      await userEvent.click(page.getByRole("button", { name: "Analyze" }))
+      await expect(
+        page.getByRole("button", {
+          name: "April leave and overtime summary",
+        })
+      ).toBeInTheDocument()
+    })
+
+    await step("Switch to the third suggestion group", async () => {
+      await userEvent.click(page.getByRole("button", { name: "Create" }))
+      await expect(
+        page.getByRole("button", {
+          name: "Draft a Senior Backend job description",
+        })
+      ).toBeInTheDocument()
+      await expect(
+        page.queryByRole("button", {
+          name: "April leave and overtime summary",
+        })
+      ).not.toBeInTheDocument()
+    })
   },
 }
 

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__stories__/F0AiChatTextArea.stories.tsx
@@ -457,7 +457,12 @@ export const WithWelcomeSuggestions: Story = {
     const page = within(canvasElement.closest("body")!)
 
     await step("Open the first suggestion group", async () => {
-      await userEvent.click(page.getByRole("button", { name: "Analyze" }))
+      const analyzeTrigger = page.getByRole("button", { name: "Analyze" })
+      await userEvent.click(analyzeTrigger)
+      const dialog = page.getByRole("dialog", { name: "Analyze" })
+
+      await expect(analyzeTrigger).toHaveAttribute("aria-expanded", "true")
+      await expect(analyzeTrigger).toHaveAttribute("aria-controls", dialog.id)
       await expect(
         page.getByRole("button", {
           name: "April leave and overtime summary",
@@ -466,7 +471,12 @@ export const WithWelcomeSuggestions: Story = {
     })
 
     await step("Switch to the third suggestion group", async () => {
-      await userEvent.click(page.getByRole("button", { name: "Create" }))
+      const createTrigger = page.getByRole("button", { name: "Create" })
+      await userEvent.click(createTrigger)
+      const dialog = page.getByRole("dialog", { name: "Create" })
+
+      await expect(createTrigger).toHaveAttribute("aria-expanded", "true")
+      await expect(createTrigger).toHaveAttribute("aria-controls", dialog.id)
       await expect(
         page.getByRole("button", {
           name: "Draft a Senior Backend job description",

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/WelcomeScreenSuggestionsRow.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/WelcomeScreenSuggestionsRow.test.tsx
@@ -171,4 +171,68 @@ describe("WelcomeScreenSuggestionsRow", () => {
       await screen.findByRole("button", { name: /out of office this week/i })
     ).toBeInTheDocument()
   })
+
+  // Regression: buttons used to be individual Radix PopoverTriggers, and only
+  // the last-mounted one was registered as THE trigger — its built-in toggle
+  // fired after the button's onClick, so switching TO the last group closed
+  // the popover instead of showing it.
+  it("switches to the last group while another group is open", async () => {
+    const user = userEvent.setup()
+    zeroRender(
+      <WelcomeScreenSuggestionsRow
+        suggestions={groups}
+        onItemClick={() => {}}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: /analyze/i }))
+    expect(
+      await screen.findByRole("button", { name: /april leave and overtime/i })
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: /create/i }))
+    expect(
+      await screen.findByRole("button", { name: /draft a job description/i })
+    ).toBeInTheDocument()
+  })
+
+  it("switches back from the last group to another group", async () => {
+    const user = userEvent.setup()
+    zeroRender(
+      <WelcomeScreenSuggestionsRow
+        suggestions={groups}
+        onItemClick={() => {}}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: /create/i }))
+    expect(
+      await screen.findByRole("button", { name: /draft a job description/i })
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: /analyze/i }))
+    expect(
+      await screen.findByRole("button", { name: /april leave and overtime/i })
+    ).toBeInTheDocument()
+  })
+
+  it("closes the popover when the open group's own tag is clicked", async () => {
+    const user = userEvent.setup()
+    zeroRender(
+      <WelcomeScreenSuggestionsRow
+        suggestions={groups}
+        onItemClick={() => {}}
+      />
+    )
+
+    await user.click(screen.getByRole("button", { name: /analyze/i }))
+    expect(
+      await screen.findByRole("button", { name: /april leave and overtime/i })
+    ).toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: /analyze/i }))
+    expect(
+      screen.queryByRole("button", { name: /april leave and overtime/i })
+    ).not.toBeInTheDocument()
+  })
 })

--- a/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/WelcomeScreenSuggestionsRow.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/__tests__/WelcomeScreenSuggestionsRow.test.tsx
@@ -31,7 +31,7 @@ const groups: WelcomeScreenSuggestion[] = [
 ]
 
 describe("WelcomeScreenSuggestionsRow", () => {
-  it("renders one outline trigger per group", () => {
+  it("renders one accessible popup trigger per group", () => {
     zeroRender(
       <WelcomeScreenSuggestionsRow
         suggestions={groups}
@@ -39,9 +39,12 @@ describe("WelcomeScreenSuggestionsRow", () => {
       />
     )
 
-    expect(screen.getByRole("button", { name: /analyze/i })).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: /find/i })).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: /create/i })).toBeInTheDocument()
+    for (const name of ["Analyze", "Find", "Create"]) {
+      const trigger = screen.getByRole("button", { name })
+      expect(trigger).toHaveAttribute("aria-haspopup", "dialog")
+      expect(trigger).toHaveAttribute("aria-expanded", "false")
+      expect(trigger).not.toHaveAttribute("aria-controls")
+    }
   })
 
   it("opens the popover with the group's items when the trigger is clicked", async () => {
@@ -57,7 +60,8 @@ describe("WelcomeScreenSuggestionsRow", () => {
       screen.queryByRole("button", { name: /april leave and overtime/i })
     ).not.toBeInTheDocument()
 
-    await user.click(screen.getByRole("button", { name: /analyze/i }))
+    const trigger = screen.getByRole("button", { name: /analyze/i })
+    await user.click(trigger)
 
     expect(
       await screen.findByRole("button", { name: /april leave and overtime/i })
@@ -65,6 +69,9 @@ describe("WelcomeScreenSuggestionsRow", () => {
     expect(
       screen.getByRole("button", { name: /current gross salary/i })
     ).toBeInTheDocument()
+    const popover = screen.getByRole("dialog", { name: /analyze/i })
+    expect(trigger).toHaveAttribute("aria-expanded", "true")
+    expect(trigger).toHaveAttribute("aria-controls", popover.id)
   })
 
   it("calls onItemClick with the item and its parent group, and closes the popover", async () => {
@@ -77,7 +84,8 @@ describe("WelcomeScreenSuggestionsRow", () => {
       />
     )
 
-    await user.click(screen.getByRole("button", { name: /analyze/i }))
+    const trigger = screen.getByRole("button", { name: /analyze/i })
+    await user.click(trigger)
     const item = await screen.findByRole("button", {
       name: /april leave and overtime/i,
     })
@@ -92,6 +100,35 @@ describe("WelcomeScreenSuggestionsRow", () => {
     expect(
       screen.queryByRole("button", { name: /april leave and overtime/i })
     ).not.toBeInTheDocument()
+    expect(trigger).toHaveFocus()
+  })
+
+  it("preserves focus when onItemClick moves it outside the popover", async () => {
+    const user = userEvent.setup()
+    zeroRender(
+      <>
+        <input aria-label="Focused destination" />
+        <WelcomeScreenSuggestionsRow
+          suggestions={groups}
+          onItemClick={() => {
+            screen
+              .getByRole("textbox", { name: /focused destination/i })
+              .focus()
+          }}
+        />
+      </>
+    )
+
+    await user.click(screen.getByRole("button", { name: /analyze/i }))
+    await user.click(
+      await screen.findByRole("button", {
+        name: /april leave and overtime/i,
+      })
+    )
+
+    expect(
+      screen.getByRole("textbox", { name: /focused destination/i })
+    ).toHaveFocus()
   })
 
   it("fires onItemHover while pointing at a row and clears on leave", async () => {
@@ -185,15 +222,22 @@ describe("WelcomeScreenSuggestionsRow", () => {
       />
     )
 
-    await user.click(screen.getByRole("button", { name: /analyze/i }))
+    const analyzeTrigger = screen.getByRole("button", { name: /analyze/i })
+    await user.click(analyzeTrigger)
     expect(
       await screen.findByRole("button", { name: /april leave and overtime/i })
     ).toBeInTheDocument()
 
-    await user.click(screen.getByRole("button", { name: /create/i }))
+    const createTrigger = screen.getByRole("button", { name: /create/i })
+    await user.click(createTrigger)
     expect(
       await screen.findByRole("button", { name: /draft a job description/i })
     ).toBeInTheDocument()
+    const popover = screen.getByRole("dialog", { name: /create/i })
+    expect(analyzeTrigger).toHaveAttribute("aria-expanded", "false")
+    expect(analyzeTrigger).not.toHaveAttribute("aria-controls")
+    expect(createTrigger).toHaveAttribute("aria-expanded", "true")
+    expect(createTrigger).toHaveAttribute("aria-controls", popover.id)
   })
 
   it("switches back from the last group to another group", async () => {
@@ -234,5 +278,51 @@ describe("WelcomeScreenSuggestionsRow", () => {
     expect(
       screen.queryByRole("button", { name: /april leave and overtime/i })
     ).not.toBeInTheDocument()
+  })
+
+  it("restores focus to the active group when Escape closes the popover", async () => {
+    const user = userEvent.setup()
+    zeroRender(
+      <WelcomeScreenSuggestionsRow
+        suggestions={groups}
+        onItemClick={() => {}}
+      />
+    )
+
+    const trigger = screen.getByRole("button", { name: /analyze/i })
+    await user.click(trigger)
+    await screen.findByRole("dialog", { name: /analyze/i })
+
+    await user.keyboard("{Escape}")
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    expect(trigger).toHaveAttribute("aria-expanded", "false")
+    expect(trigger).toHaveFocus()
+  })
+
+  it("keeps focus on an outside target when it dismisses the popover", async () => {
+    const user = userEvent.setup()
+    zeroRender(
+      <>
+        <button type="button">Outside action</button>
+        <WelcomeScreenSuggestionsRow
+          suggestions={groups}
+          onItemClick={() => {}}
+        />
+      </>
+    )
+
+    const trigger = screen.getByRole("button", { name: /analyze/i })
+    await user.click(trigger)
+    await screen.findByRole("dialog", { name: /analyze/i })
+
+    const outsideTarget = screen.getByRole("button", {
+      name: /outside action/i,
+    })
+    await user.click(outsideTarget)
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
+    expect(trigger).toHaveAttribute("aria-expanded", "false")
+    expect(outsideTarget).toHaveFocus()
   })
 })

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
@@ -1,16 +1,11 @@
-import { useState } from "react"
+import { useRef, useState } from "react"
 
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { F0Icon } from "@/components/F0Icon"
 import { ArrowUp } from "@/icons/app"
 import { focusRing } from "@/lib/utils"
 import { cn } from "@/lib/utils"
-import {
-  Popover,
-  PopoverAnchor,
-  PopoverContent,
-  PopoverTrigger,
-} from "@/ui/popover"
+import { Popover, PopoverAnchor, PopoverContent } from "@/ui/popover"
 
 import type {
   WelcomeScreenSuggestion,
@@ -65,6 +60,7 @@ export const WelcomeScreenSuggestionsRow = ({
   side = "top",
 }: WelcomeScreenSuggestionsRowProps) => {
   const [activeIdx, setActiveIdx] = useState<number | null>(null)
+  const rowRef = useRef<HTMLDivElement>(null)
   const activeGroup = activeIdx !== null ? suggestions[activeIdx] : null
 
   if (suggestions.length === 0) return null
@@ -80,20 +76,24 @@ export const WelcomeScreenSuggestionsRow = ({
       }}
     >
       <PopoverAnchor asChild>
-        <div className="flex w-full flex-wrap items-center gap-2">
+        <div ref={rowRef} className="flex w-full flex-wrap items-center gap-2">
+          {/* Plain buttons, NOT `PopoverTrigger`s: Radix registers a single
+              trigger per popover (the last one mounted), whose built-in toggle
+              fires after the button's own onClick and overwrites the group
+              selection — so switching to the last group closed the popover
+              instead. The buttons fully own the toggle/switch semantics. */}
           {suggestions.map((group, index) => (
-            <PopoverTrigger asChild key={`${group.label}-${index}`}>
-              <ButtonInternal
-                variant="outline"
-                label={group.label}
-                icon={group.icon}
-                pressed={activeIdx === index}
-                onClick={() => {
-                  setActiveIdx((current) => (current === index ? null : index))
-                  onItemHover?.(null)
-                }}
-              />
-            </PopoverTrigger>
+            <ButtonInternal
+              key={`${group.label}-${index}`}
+              variant="outline"
+              label={group.label}
+              icon={group.icon}
+              pressed={activeIdx === index}
+              onClick={() => {
+                setActiveIdx((current) => (current === index ? null : index))
+                onItemHover?.(null)
+              }}
+            />
           ))}
         </div>
       </PopoverAnchor>
@@ -103,6 +103,15 @@ export const WelcomeScreenSuggestionsRow = ({
           align="start"
           sideOffset={8}
           onOpenAutoFocus={(e) => e.preventDefault()}
+          onPointerDownOutside={(event) => {
+            // Group-button clicks own the open/switch/close semantics; letting
+            // the popover also dismiss on the same pointerdown would race the
+            // click and close it before the switch lands.
+            const target = event.target as Node | null
+            if (target && rowRef.current?.contains(target)) {
+              event.preventDefault()
+            }
+          }}
           className={cn(
             "flex flex-col gap-1 rounded-md border border-solid border-f1-border-secondary bg-f1-background p-2",
             "w-[var(--radix-popover-trigger-width)]"

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react"
+import { useId, useRef, useState } from "react"
 
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { F0Icon } from "@/components/F0Icon"
@@ -61,6 +61,10 @@ export const WelcomeScreenSuggestionsRow = ({
 }: WelcomeScreenSuggestionsRowProps) => {
   const [activeIdx, setActiveIdx] = useState<number | null>(null)
   const rowRef = useRef<HTMLDivElement>(null)
+  const lastTriggerRef = useRef<HTMLElement | null>(null)
+  const shouldRestoreFocusRef = useRef(false)
+  const popoverContentId = useId()
+  const popoverHeadingId = useId()
   const activeGroup = activeIdx !== null ? suggestions[activeIdx] : null
 
   if (suggestions.length === 0) return null
@@ -89,7 +93,12 @@ export const WelcomeScreenSuggestionsRow = ({
               label={group.label}
               icon={group.icon}
               pressed={activeIdx === index}
-              onClick={() => {
+              aria-haspopup="dialog"
+              aria-expanded={activeIdx === index}
+              aria-controls={activeIdx === index ? popoverContentId : undefined}
+              onClick={(event) => {
+                lastTriggerRef.current = event.currentTarget
+                shouldRestoreFocusRef.current = false
                 setActiveIdx((current) => (current === index ? null : index))
                 onItemHover?.(null)
               }}
@@ -102,7 +111,19 @@ export const WelcomeScreenSuggestionsRow = ({
           side={side}
           align="start"
           sideOffset={8}
+          id={popoverContentId}
+          aria-labelledby={popoverHeadingId}
           onOpenAutoFocus={(e) => e.preventDefault()}
+          onCloseAutoFocus={(event) => {
+            event.preventDefault()
+            if (shouldRestoreFocusRef.current) {
+              lastTriggerRef.current?.focus()
+            }
+            shouldRestoreFocusRef.current = false
+          }}
+          onEscapeKeyDown={() => {
+            shouldRestoreFocusRef.current = true
+          }}
           onPointerDownOutside={(event) => {
             // Group-button clicks own the open/switch/close semantics; letting
             // the popover also dismiss on the same pointerdown would race the
@@ -110,6 +131,8 @@ export const WelcomeScreenSuggestionsRow = ({
             const target = event.target as Node | null
             if (target && rowRef.current?.contains(target)) {
               event.preventDefault()
+            } else {
+              shouldRestoreFocusRef.current = false
             }
           }}
           className={cn(
@@ -117,7 +140,10 @@ export const WelcomeScreenSuggestionsRow = ({
             "w-[var(--radix-popover-trigger-width)]"
           )}
         >
-          <div className="flex items-center gap-1.5 p-2 pb-1 text-sm font-medium text-f1-foreground-secondary">
+          <div
+            id={popoverHeadingId}
+            className="flex items-center gap-1.5 p-2 pb-1 text-sm font-medium text-f1-foreground-secondary"
+          >
             <F0Icon icon={activeGroup.icon} size="sm" />
             <span>{activeGroup.label}</span>
           </div>
@@ -126,8 +152,10 @@ export const WelcomeScreenSuggestionsRow = ({
               <button
                 key={index}
                 type="button"
-                onClick={() => {
+                onClick={(event) => {
                   onItemClick(item, activeGroup)
+                  shouldRestoreFocusRef.current =
+                    document.activeElement === event.currentTarget
                   setActiveIdx(null)
                   onItemHover?.(null)
                 }}

--- a/packages/react/src/kits/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
+++ b/packages/react/src/kits/ai/F0AiChatTextArea/components/WelcomeScreenSuggestionsRow.tsx
@@ -144,7 +144,7 @@ export const WelcomeScreenSuggestionsRow = ({
             id={popoverHeadingId}
             className="flex items-center gap-1.5 p-2 pb-1 text-sm font-medium text-f1-foreground-secondary"
           >
-            <F0Icon icon={activeGroup.icon} size="sm" />
+            <F0Icon aria-hidden icon={activeGroup.icon} size="sm" />
             <span>{activeGroup.label}</span>
           </div>
           <div className="flex flex-col">


### PR DESCRIPTION
## Bug

On any AI chat welcome screen, with a suggestion-group popover open, clicking the **last** group tag closes the popover instead of switching to that group. Clicking the open group's own tag also re-opened it instead of closing for every tag except the last.

Reproduce before this fix: open the One chat welcome → click "Analyze" → click "Create" (the third and last tag) → the panel closes instead of showing Create's items.

## Root cause

`WelcomeScreenSuggestionsRow` renders one shared `Popover`, but wrapped each group button in its own `PopoverTrigger`. Radix registers a single trigger per popover—the last one mounted—so its internal dismissal and toggle behavior raced the row's `activeIdx` state.

## Fix

- Use plain group buttons inside the existing `PopoverAnchor`; the row now owns open, switch, and close behavior consistently for every group.
- Ignore pointer-down-outside dismissal for clicks inside the group row, preventing it from racing a group-button click.
- Preserve the popup semantics Radix previously supplied with `aria-haspopup`, `aria-expanded`, `aria-controls`, and an accessible dialog label.
- Restore focus after selection or Escape while preserving focus when the host or an outside click deliberately moves it elsewhere.

## Storybook

`WithWelcomeSuggestions` now has an executable interaction that opens **Analyze**, switches to the third **Create** group, verifies Create's items are visible, and verifies Analyze's items are gone.

Before
https://github.com/user-attachments/assets/9f9444f5-6e8a-4ad1-814f-fa470e762bee

After

https://github.com/user-attachments/assets/07c467af-c357-4829-939a-6e87ebd5329f



## Tests

- 13 focused `WelcomeScreenSuggestionsRow` tests pass, covering switching to and from the last group, same-tag close, ARIA state, selection focus, host-directed focus, Escape, and outside-click dismissal.
- Formatting, TypeScript, focused lint, cycle-dependency checks, and independent code/accessibility/Storybook/test-coverage reviews pass.
- The Storybook interaction was verified locally and finishes with the third Create group open.
