### PR TITLE
fix(OneFilterPicker): apply nested grouped filter selections

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
@@ -172,6 +172,33 @@ export const nestedFilters = {
 
 export type NestedFiltersType = typeof nestedFilters
 
+// A user carrying a workplace assignment (office → space → desk). Used by
+// `SubfiltersExampleComponent` so the nested "Office" filter visibly narrows
+// the list when a group or sub-option is selected.
+export type WorkplaceMockUser = MockUser & {
+  officeId: string
+  spaceId: string
+  deskId?: string
+}
+
+// Deterministically assign each user to a space (and a desk within it, when the
+// space has any) so selections map to a predictable, stable subset of rows.
+export const subfilterMockUsers: WorkplaceMockUser[] = generateMockUsers(
+  24
+).map((user, i) => {
+  const space = SPACES[i % SPACES.length]
+  const desksInSpace = DESKS.filter((d) => d.spaceId === space.id)
+  const desk = desksInSpace.length
+    ? desksInSpace[i % desksInSpace.length]
+    : undefined
+  return {
+    ...user,
+    officeId: String(space.officeId),
+    spaceId: String(space.id),
+    deskId: desk ? String(desk.id) : undefined,
+  }
+})
+
 // Example filter definition
 export const filters = {
   search: {
@@ -1598,13 +1625,30 @@ export const SubfiltersExampleComponent = () => {
         const { filters: f, sortings: s, search } = options
         return new Promise<BaseResponse<MockUser>>((resolve) => {
           setTimeout(() => {
-            const filtered = filterUsers(
-              mockUsers,
+            // Reuse the shared helper for search/sort, then narrow by the
+            // nested workplace selections (office/space/desk) it doesn't know
+            // about. `filterUsers` only filters/sorts, so the surviving items
+            // are still the original WorkplaceMockUser objects.
+            const base = filterUsers(
+              subfilterMockUsers,
               f as FiltersState<FiltersType>,
               s,
               undefined,
               search
-            )
+            ) as WorkplaceMockUser[]
+
+            const officeSel = (f.office as string[] | undefined) ?? []
+            const spaceSel = (f.space as string[] | undefined) ?? []
+            const deskSel = (f.desk as string[] | undefined) ?? []
+
+            const filtered = base.filter((u) => {
+              if (officeSel.length && !officeSel.includes(u.officeId))
+                return false
+              if (spaceSel.length && !spaceSel.includes(u.spaceId)) return false
+              if (deskSel.length && (!u.deskId || !deskSel.includes(u.deskId)))
+                return false
+              return true
+            })
             resolve({ records: filtered })
           }, 100)
         })

--- a/packages/react/src/patterns/OneFilterPicker/OneFilterPicker.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/OneFilterPicker.tsx
@@ -227,6 +227,7 @@ const FiltersControls = () => {
     <>
       <FiltersControlsComponent
         filters={shownFilters}
+        allFilters={filters}
         value={value}
         onChange={handleFilterChange}
         onOpenChange={setIsFiltersOpen}

--- a/packages/react/src/patterns/OneFilterPicker/__test__/groupedOptions.test.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/__test__/groupedOptions.test.tsx
@@ -1,0 +1,157 @@
+import userEvent from "@testing-library/user-event"
+import "@testing-library/jest-dom/vitest"
+import { describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render, screen, waitFor } from "@/testing/test-utils"
+
+import type { FiltersDefinition } from "../types"
+
+import { OneFilterPicker } from "../index"
+
+/**
+ * Grouped ("in" filter with nested children) options store their selection under
+ * a sibling filter key (`children.filterKey`). Those sibling filters are marked
+ * `hideSelector: true` so they don't appear as their own entry in the filter
+ * list — they're only ever reached by expanding their parent group.
+ *
+ * Regression coverage: selecting a nested child and applying the filters must
+ * emit the child's value under its sibling key. The bug was that `hideSelector`
+ * filters were stripped from the definition before the value was computed on
+ * apply, so nested selections silently vanished.
+ */
+const groupedDefinition = {
+  office: {
+    type: "in",
+    label: "Office",
+    options: {
+      options: [
+        {
+          value: "101",
+          label: "Barcelona HQ",
+          children: {
+            filterKey: "space",
+            options: [
+              { value: "1", label: "Floor 1" },
+              { value: "2", label: "Floor 2" },
+            ],
+          },
+        },
+        {
+          value: "102",
+          label: "Madrid Office",
+          children: {
+            filterKey: "space",
+            options: [{ value: "4", label: "Floor 1 (Madrid)" }],
+          },
+        },
+      ],
+    },
+  },
+  space: {
+    type: "in",
+    label: "Space",
+    hideSelector: true,
+    options: {
+      options: [
+        { value: "1", label: "Floor 1" },
+        { value: "2", label: "Floor 2" },
+        { value: "4", label: "Floor 1 (Madrid)" },
+      ],
+    },
+  },
+} as const satisfies FiltersDefinition
+
+const openPicker = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.click(screen.getByRole("button", { name: /filters/i }))
+  await waitFor(() =>
+    expect(screen.getByText("Barcelona HQ")).toBeInTheDocument()
+  )
+}
+
+// The expand chevron is a ghost icon-button with no accessible label; it's the
+// only empty-labelled button rendered inside a group row.
+const expandGroup = async (
+  user: ReturnType<typeof userEvent.setup>,
+  index = 0
+) => {
+  const chevrons = screen
+    .getAllByRole("button")
+    .filter((b) => !b.textContent?.trim() && !b.getAttribute("aria-label"))
+  await user.click(chevrons[index])
+}
+
+describe("OneFilterPicker - grouped (nested) options", () => {
+  it("does not render hideSelector sibling filters as their own list entry", async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 })
+
+    render(
+      <OneFilterPicker
+        filters={groupedDefinition}
+        value={{}}
+        onChange={vi.fn()}
+      />
+    )
+
+    await openPicker(user)
+
+    // "Office" is the only selectable filter; the "Space" sibling is hidden.
+    expect(screen.getByText("Office")).toBeInTheDocument()
+    const spaceEntries = screen
+      .queryAllByRole("button")
+      .filter((b) => b.textContent?.trim() === "Space")
+    expect(spaceEntries).toHaveLength(0)
+  })
+
+  it("applies a nested child selection under its sibling filter key", async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 })
+    const onChange = vi.fn()
+
+    render(
+      <OneFilterPicker
+        filters={groupedDefinition}
+        value={{}}
+        onChange={onChange}
+      />
+    )
+
+    await openPicker(user)
+
+    // Expand "Barcelona HQ" and pick its nested "Floor 1" child.
+    await expandGroup(user, 0)
+    await waitFor(() => expect(screen.getByText("Floor 1")).toBeInTheDocument())
+    await user.click(screen.getByText("Floor 1"))
+
+    await user.click(screen.getByRole("button", { name: /apply filters/i }))
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ space: ["1"] })
+    )
+  })
+
+  it("keeps a nested child selection alongside a top-level parent selection", async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 })
+    const onChange = vi.fn()
+
+    render(
+      <OneFilterPicker
+        filters={groupedDefinition}
+        value={{}}
+        onChange={onChange}
+      />
+    )
+
+    await openPicker(user)
+
+    // Select the parent office itself.
+    await user.click(screen.getByRole("checkbox", { name: "Barcelona HQ" }))
+
+    // Then drill into it and select a nested child.
+    await expandGroup(user, 0)
+    await waitFor(() => expect(screen.getByText("Floor 1")).toBeInTheDocument())
+    await user.click(screen.getByText("Floor 1"))
+
+    await user.click(screen.getByRole("button", { name: /apply filters/i }))
+
+    expect(onChange).toHaveBeenCalledWith({ office: ["101"], space: ["1"] })
+  })
+})

--- a/packages/react/src/patterns/OneFilterPicker/components/FiltersControls.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/components/FiltersControls.tsx
@@ -22,7 +22,15 @@ import { FilterContent } from "./FilterContent"
 import { FilterList } from "./FilterList"
 
 interface FiltersControlsProps<Filters extends FiltersDefinition> {
+  /** The filters shown in the selector list (excludes `hideSelector` filters). */
   filters: Filters
+  /**
+   * The complete filter definition, including `hideSelector` filters (e.g. the
+   * sibling keys that hold nested/grouped child selections). Used when computing
+   * the value to apply so nested selections aren't dropped. Falls back to
+   * `filters` when omitted.
+   */
+  allFilters?: Filters
   value: FiltersState<Filters>
   onChange: (value: FiltersState<Filters>) => void
   isOpen?: boolean
@@ -36,6 +44,7 @@ const DEFAULT_FORM_HEIGHT = 388
 
 export function FiltersControls<Filters extends FiltersDefinition>({
   filters,
+  allFilters,
   value,
   onChange,
   isOpen: controlledIsOpen,
@@ -44,6 +53,11 @@ export function FiltersControls<Filters extends FiltersDefinition>({
   mode = "default",
   displayCounter = false,
 }: FiltersControlsProps<Filters>) {
+  // The value to emit must consider every filter — including `hideSelector`
+  // siblings that store nested/grouped selections — otherwise those selections
+  // are dropped when applying. Display concerns (list, counter, tooltip) stay on
+  // the visible `filters` set.
+  const filtersForValue = allFilters ?? filters
   const firstFilterKey = (Object.keys(filters)[0] as keyof Filters) ?? null
   const [selectedFilterKey, setSelectedFilterKey] = useState<
     keyof Filters | null
@@ -110,19 +124,19 @@ export function FiltersControls<Filters extends FiltersDefinition>({
   const handleApplyFilters = () => {
     // Emit only active filters so a cleared set is applied as `{}` (unfiltered),
     // not `{ key: emptyValue }` which could make the data source return nothing.
-    onChange(getActiveFiltersValue(filters, localFiltersValue, i18n))
+    onChange(getActiveFiltersValue(filtersForValue, localFiltersValue, i18n))
     onOpenChange(false)
   }
 
   const handleClearFilters = () => {
-    setLocalFiltersValue(getClearedFiltersValue(filters))
+    setLocalFiltersValue(getClearedFiltersValue(filtersForValue))
   }
 
   const handleGoBack = () => {
     if (selectedFilterKey) {
       setSelectedFilterKey(null)
     } else {
-      onChange(getActiveFiltersValue(filters, localFiltersValue, i18n))
+      onChange(getActiveFiltersValue(filtersForValue, localFiltersValue, i18n))
       onOpenChange(false)
     }
   }

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/__stories__/InFilter.stories.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/__stories__/InFilter.stories.tsx
@@ -398,3 +398,71 @@ export const WithDataSource: Story = {
     onChange: () => {},
   },
 }
+
+// Grouped (nested) options example.
+//
+// A parent option can expose `children`, whose selections are stored under a
+// separate `filterKey` (here `"space"`). Expanding a group reveals its children;
+// toggling a child is reported through `onFilterChange(filterKey, values)` rather
+// than the parent's `onChange`. This is how "in" filters render grouped options
+// like the office → floor hierarchy below.
+const GroupedOptionsExample = () => {
+  // Parent selection (offices) lives in `value`; nested child selections
+  // (spaces) live under their own filter key, mirroring how OneFilterPicker
+  // stores sibling-filter values.
+  const [officeValues, setOfficeValues] = useState<string[]>([])
+  const [allFiltersValue, setAllFiltersValue] = useState<
+    Record<string, unknown>
+  >({ space: [] })
+
+  const groupedOptions: InFilterOptionItem<string>[] = [
+    {
+      value: "101",
+      label: "Barcelona HQ",
+      children: {
+        filterKey: "space",
+        options: [
+          { value: "1", label: "Floor 1" },
+          { value: "2", label: "Floor 2" },
+          { value: "3", label: "Rooftop Terrace" },
+        ],
+      },
+    },
+    {
+      value: "102",
+      label: "Madrid Office",
+      children: {
+        filterKey: "space",
+        options: [
+          { value: "4", label: "Floor 1 (Madrid)" },
+          { value: "5", label: "Floor 2 (Madrid)" },
+        ],
+      },
+    },
+    { value: "103", label: "London (no floors)" },
+  ]
+
+  return (
+    <InFilter<string>
+      schema={{ label: "Office", options: { options: groupedOptions } }}
+      value={officeValues}
+      onChange={setOfficeValues}
+      allFiltersValue={allFiltersValue}
+      onFilterChange={(key, value) =>
+        setAllFiltersValue((prev) => ({ ...prev, [key]: value }))
+      }
+    />
+  )
+}
+
+export const GroupedOptions: Story = {
+  render: () => <GroupedOptionsExample />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Options grouped under expandable parents. Child selections are stored under a separate `filterKey` and reported via `onFilterChange`, so a group's children can drive a sibling filter independently of the parent selection.",
+      },
+    },
+  },
+}


### PR DESCRIPTION
## Description

Fixes [FCT-58171](https://factorialmakers.atlassian.net/browse/FCT-58171) — the "Lugar de trabajo" (Workplace) filter not applying. When a user expanded a workplace group, selected a sub-option, and clicked "Aplicar filtros", the popover closed without updating the list and the filter was never applied. Grouped ("in" filter with nested `children`) options store each child's selection under a `hideSelector` sibling filter key, and those keys were stripped from the filter definition before the applied value was computed — so nested selections were silently dropped on Apply.

**Regression introduced by** #3485 (`feat(F0Select): selection preview panel, nested filters and improved filter UX`, commit `c25e85f20`). That PR added grouped/nested sub-options stored under `hideSelector` sibling filter keys, but never updated the Apply path (`getActiveFiltersValue`, which runs over the visible/stripped filter set) to include those hidden keys — so grouped selections have never applied since the feature landed.

## Implementation details

- fix: compute the applied/cleared value from the complete filter definition (including `hideSelector` siblings) so nested/grouped sub-option selections survive Apply, while keeping the selector list, active counter and tooltip driven by the visible filters only

  <details>
  <summary>Why?</summary>

  `OneFilterPicker` strips `hideSelector` filters from the definition it hands to the controls so they don't render as their own row in the selector list. That same stripped definition was then passed to `getActiveFiltersValue` on Apply, which only iterates the keys it is given — so a nested child stored under a hidden sibling key (e.g. `space`/`desk`) was dropped even though its checkbox showed as selected. The controls now receive both the visible set (`filters`, for display) and the full set (`allFilters`, for value computation). Notably `getClearedFiltersValue` already handled nested keys, which is why *clearing* worked but *applying* didn't.
  </details>

- test: add regression coverage for grouped options — a nested child selection is applied under its sibling key, survives alongside a top-level parent selection, and `hideSelector` siblings never render as their own list entry
- test: make the `Data Collection › Filters › WithSubfilters` story a runnable demo — mock users are assigned a workplace (office → space → desk) and the data adapter filters by the applied values, so selecting a sub-option visibly narrows the list (previously the story applied nothing observable)
- docs: add a `GroupedOptions` story to `InFilter` demonstrating expandable groups with nested children


[FCT-58171]: https://factorialmakers.atlassian.net/browse/FCT-58171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ