### PR TITLE
fix(OneDataCollection): emit filter-change for object-valued filters

### DIFF
--- a/packages/react/src/lib/providers/events/normalize.test.ts
+++ b/packages/react/src/lib/providers/events/normalize.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest"
+
+import { normalizeEventValue } from "./normalize"
+
+describe("normalizeEventValue", () => {
+  it("passes scalars through unchanged", () => {
+    expect(normalizeEventValue("onboarding")).toBe("onboarding")
+    expect(normalizeEventValue(42)).toBe(42)
+    expect(normalizeEventValue(true)).toBe(true)
+  })
+
+  it("keeps falsy scalars instead of skipping them", () => {
+    expect(normalizeEventValue(0)).toBe(0)
+    expect(normalizeEventValue("")).toBe("")
+    expect(normalizeEventValue(false)).toBe(false)
+  })
+
+  it("returns undefined for null and undefined", () => {
+    expect(normalizeEventValue(null)).toBeUndefined()
+    expect(normalizeEventValue(undefined)).toBeUndefined()
+  })
+
+  it("converts a Date to an ISO string", () => {
+    expect(normalizeEventValue(new Date("2025-01-15T00:00:00.000Z"))).toBe(
+      "2025-01-15T00:00:00.000Z"
+    )
+  })
+
+  it("passes scalar arrays through", () => {
+    expect(normalizeEventValue(["documents", "timeoff"])).toEqual([
+      "documents",
+      "timeoff",
+    ])
+  })
+
+  it("normalizes a date-range object (Dates become ISO strings)", () => {
+    expect(
+      normalizeEventValue({
+        from: new Date("2025-01-01T00:00:00.000Z"),
+        to: new Date("2025-02-01T00:00:00.000Z"),
+      })
+    ).toEqual({
+      from: "2025-01-01T00:00:00.000Z",
+      to: "2025-02-01T00:00:00.000Z",
+    })
+  })
+
+  it("normalizes a nested number-range object", () => {
+    expect(
+      normalizeEventValue({
+        mode: "range",
+        from: { value: 1, closed: true },
+        to: { value: 5, closed: false },
+      })
+    ).toEqual({
+      mode: "range",
+      from: { value: 1, closed: true },
+      to: { value: 5, closed: false },
+    })
+  })
+
+  it("drops undefined entries from objects", () => {
+    expect(
+      normalizeEventValue({
+        from: new Date("2025-01-01T00:00:00.000Z"),
+        to: undefined,
+      })
+    ).toEqual({
+      from: "2025-01-01T00:00:00.000Z",
+    })
+  })
+
+  it("returns undefined for non-serializable values", () => {
+    expect(normalizeEventValue(() => undefined)).toBeUndefined()
+    expect(normalizeEventValue(Symbol("x"))).toBeUndefined()
+  })
+})

--- a/packages/react/src/lib/providers/events/normalize.ts
+++ b/packages/react/src/lib/providers/events/normalize.ts
@@ -1,0 +1,52 @@
+import { EventValue } from "./types"
+
+/**
+ * Normalizes an arbitrary filter/preset value into a JSON-serializable
+ * {@link EventValue} for analytics events.
+ *
+ * - scalars (`string` / `number` / `boolean`) pass through unchanged
+ * - `Date` becomes an ISO string
+ * - arrays and plain objects are normalized recursively (nested `Date`s become
+ *   ISO strings; `undefined` entries are dropped from objects)
+ * - `null` / `undefined` and non-serializable values (`function`, `symbol`,
+ *   `bigint`) return `undefined`, signalling the caller that there is nothing
+ *   meaningful to emit
+ *
+ * Before this existed, the emitter dropped any non-scalar value outright, so
+ * date-range and number-range filters never produced a `filter-change` event.
+ */
+export const normalizeEventValue = (value: unknown): EventValue | undefined => {
+  if (value === null || value === undefined) return undefined
+
+  if (
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return value
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString()
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((item) => normalizeEventValue(item) ?? null)
+  }
+
+  if (typeof value === "object") {
+    const result: Record<string, EventValue> = {}
+
+    for (const [key, item] of Object.entries(value)) {
+      const normalized = normalizeEventValue(item)
+
+      if (normalized !== undefined) {
+        result[key] = normalized
+      }
+    }
+
+    return result
+  }
+
+  return undefined
+}

--- a/packages/react/src/lib/providers/events/types.ts
+++ b/packages/react/src/lib/providers/events/types.ts
@@ -1,11 +1,22 @@
 export type EventScalar = string | number | boolean | undefined | null
 
+/**
+ * A JSON-serializable event value. Scalars and arrays are emitted as-is; object
+ * values (for example a date-range or number-range filter) are normalized to a
+ * nested record of scalars via `normalizeEventValue` before being emitted, so
+ * consumers never receive `Date` instances or other non-serializable values.
+ */
+export type EventValue =
+  | EventScalar
+  | EventValue[]
+  | { [key: string]: EventValue }
+
 export type EventName =
   | "datacollection.filter-change"
   | "datacollection.sorting-change"
   | "datacollection.preset-click"
 
-export type EventParams = Record<string, EventScalar | Array<EventScalar>>
+export type EventParams = Record<string, EventValue>
 
 export type EventCatcherFunction = (
   eventName: EventName,

--- a/packages/react/src/patterns/OneDataCollection/useEventEmitter.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/useEventEmitter.test.tsx
@@ -1,0 +1,98 @@
+import { act, renderHook } from "@testing-library/react"
+import { ReactNode } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import { F0EventCatcherProvider } from "@/lib/providers/events"
+import {
+  FiltersDefinition,
+  FiltersState,
+} from "@/patterns/OneFilterPicker/types"
+
+import { useEventEmitter } from "./useEventEmitter"
+
+type Filters = FiltersState<FiltersDefinition>
+
+const asFilters = (value: Record<string, unknown>) =>
+  value as unknown as Filters
+
+const setup = (defaultFilters?: Record<string, unknown>) => {
+  const onEvent = vi.fn()
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <F0EventCatcherProvider onEvent={onEvent}>
+      {children}
+    </F0EventCatcherProvider>
+  )
+  const { result } = renderHook(
+    () =>
+      useEventEmitter({
+        defaultFilters: defaultFilters && asFilters(defaultFilters),
+      }),
+    { wrapper }
+  )
+
+  return { onEvent, result }
+}
+
+describe("useEventEmitter", () => {
+  describe("emitFilterChange", () => {
+    it("emits a scalar-array filter as-is", () => {
+      const { onEvent, result } = setup({})
+
+      act(() =>
+        result.current.emitFilterChange(asFilters({ category: ["documents"] }))
+      )
+
+      expect(onEvent).toHaveBeenCalledWith("datacollection.filter-change", {
+        name: "category",
+        value: ["documents"],
+      })
+    })
+
+    it("emits a date-range filter as normalized ISO strings (previously dropped)", () => {
+      const { onEvent, result } = setup({})
+
+      act(() =>
+        result.current.emitFilterChange(
+          asFilters({
+            createdAt: {
+              from: new Date("2025-01-01T00:00:00.000Z"),
+              to: new Date("2025-02-01T00:00:00.000Z"),
+            },
+          })
+        )
+      )
+
+      expect(onEvent).toHaveBeenCalledWith("datacollection.filter-change", {
+        name: "createdAt",
+        value: {
+          from: "2025-01-01T00:00:00.000Z",
+          to: "2025-02-01T00:00:00.000Z",
+        },
+      })
+    })
+
+    it("does not emit when nothing changed from the default filters", () => {
+      const filters = { category: ["documents"] }
+      const { onEvent, result } = setup(filters)
+
+      act(() => result.current.emitFilterChange(asFilters(filters)))
+
+      expect(onEvent).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("emitPresetClick", () => {
+    it("emits the changed preset filter", () => {
+      const { onEvent, result } = setup({})
+
+      act(() =>
+        result.current.emitPresetClick(asFilters({ category: ["timeoff"] }))
+      )
+
+      expect(onEvent).toHaveBeenCalledWith("datacollection.preset-click", {
+        name: "category",
+        value: ["timeoff"],
+      })
+    })
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/useEventEmitter.ts
+++ b/packages/react/src/patterns/OneDataCollection/useEventEmitter.ts
@@ -9,22 +9,14 @@ import {
   FiltersDefinition,
   FiltersState,
 } from "@/patterns/OneFilterPicker/types"
-import { EventScalar, useF0EventCatcher } from "../../lib/providers/events"
+import { useF0EventCatcher } from "../../lib/providers/events"
+import { normalizeEventValue } from "../../lib/providers/events/normalize"
 
 type UseEventEmitterParams<Sortings extends SortingsDefinition> = {
   defaultFilters?: FiltersState<FiltersDefinition>
   defaultSorting?: SortingsState<Sortings>
   /** Current visualization index, included in filter/preset change events when per-visualization filters are active */
   currentVisualization?: number
-}
-
-const isScalar = (value: unknown): value is EventScalar => {
-  return (
-    typeof value === "string" ||
-    typeof value === "number" ||
-    typeof value === "boolean" ||
-    Array.isArray(value)
-  )
 }
 
 export const useEventEmitter = <Sortings extends SortingsDefinition>({
@@ -53,13 +45,15 @@ export const useEventEmitter = <Sortings extends SortingsDefinition>({
 
       const [field, value] = changedFilter
 
-      if (!isScalar(value)) return
+      const normalizedValue = normalizeEventValue(value)
+
+      if (normalizedValue === undefined) return
 
       latestFilters.current = filters
 
       onEvent("datacollection.filter-change", {
         name: field,
-        value: value,
+        value: normalizedValue,
         ...(currentVisualization !== undefined && {
           visualization: currentVisualization,
         }),
@@ -100,13 +94,15 @@ export const useEventEmitter = <Sortings extends SortingsDefinition>({
 
       const [field, value] = changedFilter
 
-      if (!isScalar(value)) return
+      const normalizedValue = normalizeEventValue(value)
+
+      if (normalizedValue === undefined) return
 
       latestFilters.current = filters
 
       onEvent("datacollection.preset-click", {
         name: field,
-        value: value,
+        value: normalizedValue,
         ...(currentVisualization !== undefined && {
           visualization: currentVisualization,
         }),


### PR DESCRIPTION
## What

The OneDataCollection event emitter dropped any **non-scalar** filter value. `isScalar` in `useEventEmitter` only allowed `string | number | boolean | array`, so **date-range** and **number-range** filters never produced a `datacollection.filter-change` (or `preset-click`) event — the emitter `return`ed before calling `onEvent`.

Worse, because it returned *before* updating the `latestFilters` snapshot, a single object-valued filter could **permanently shadow** every later filter change: it stayed "the first changed entry" on each apply and kept getting dropped.

## Why

Consumers using `F0EventCatcherProvider` to track filtering (e.g. Factorial's inbox, [FCT-37393](https://factorialmakers.atlassian.net/browse/FCT-37393)) get no event when users apply a date or number filter.

## Change

- New internal `normalizeEventValue(value)` turns any serializable value into a JSON-safe `EventValue`:
  - scalars pass through unchanged (including falsy `0` / `""` / `false`)
  - `Date` → ISO string
  - arrays and plain objects normalized recursively (nested `Date`s → ISO strings, `undefined` entries dropped)
  - only genuinely non-serializable values (`function`, `symbol`, `bigint`, `null`/`undefined`) are skipped
- `emitFilterChange` / `emitPresetClick` now emit the normalized value instead of dropping it, and update the snapshot, so no filter can shadow later ones.
- `EventParams` widened to `Record<string, EventValue>`. **Additive** — scalars and scalar-arrays are unchanged; the new `EventValue` type just also permits nested serializable objects. `normalizeEventValue` is kept internal to the events module.

## API surface

Adds the exported type `EventValue` and widens `EventParams`. Non-breaking for existing consumers (a wider value type on read).

## Tests

- `normalize.test.ts` — 9 cases (scalars, falsy scalars, null/undefined, Date→ISO, scalar arrays, date-range object, nested number-range object, dropped undefined entries, non-serializable).
- `useEventEmitter.test.tsx` — 4 cases via `renderHook` + `F0EventCatcherProvider`: scalar-array emitted as-is, date-range emitted as normalized ISO strings (the previously-dropped case), no-op when unchanged, preset-click.

`vitest` 13/13, `oxlint` clean, `oxfmt --check` clean.

## Downstream

Once released, Factorial bumps `@factorialco/f0-react` and the inbox `createdAt` filter starts emitting `Click Inbox Filters` — no consumer code change needed (companion PR factorialco/factorial#105504 already generalized the handler).


[FCT-37393]: https://factorialmakers.atlassian.net/browse/FCT-37393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ