### PR TITLE
fix(F0AudioPlayer): use secondary border token on card

### DIFF
--- a/packages/react/src/components/F0AudioPlayer/F0AudioPlayerCard.tsx
+++ b/packages/react/src/components/F0AudioPlayer/F0AudioPlayerCard.tsx
@@ -65,7 +65,7 @@ const F0AudioPlayerCardBase = forwardRef<
       role="group"
       aria-label={ariaLabel ?? title}
       className={cn(
-        "flex flex-col gap-2.5 rounded-2xl border border-solid border-f1-border bg-f1-background p-3",
+        "flex flex-col gap-2.5 rounded-2xl border border-solid border-f1-border-secondary bg-f1-background p-3",
         className
       )}
       {...dataAttributes}


### PR DESCRIPTION
## Description

The audio player card used `border-f1-border` (`--neutral-30`, 0.2 alpha), noticeably stronger than the design spec, which calls for Border-Default-secondary (`hsla(216, 89%, 18%, 0.06)`). Switch to `border-f1-border-secondary` — the token used by other subtle-border surfaces (tooltips, dropdowns, tables) and already used by the card's own PlayPauseButton.

## Implementation details

- `F0AudioPlayerCard.tsx`: `border-f1-border` → `border-f1-border-secondary` on the card wrapper.

Note: `f1-border-secondary` resolves to `--neutral-20` (0.1 alpha), slightly stronger than the Figma value (0.06 = `--neutral-10`). Matching Figma exactly would require realigning the `border.secondary` token in f0-core, which affects all subtle-border surfaces — out of scope here.

## Testing

- `pnpm vitest run src/components/F0AudioPlayer` — 34/34 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)