### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "4.29.0",
-  "packages/react-native": "0.57.0",
+  "packages/react-native": "0.58.0",
   "packages/core": "1.54.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.58.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.57.0...f0-react-native-v0.58.0) (2026-07-10)
+
+
+### Features
+
+* **react-native:** support Expo SDK 56 (React Native 0.85) ([#4584](https://github.com/factorialco/f0/issues/4584)) ([c8312c9](https://github.com/factorialco/f0/commit/c8312c955f59dcb162c9dfbcabe6a5e60ee782a4))
+
 ## [0.57.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.56.0...f0-react-native-v0.57.0) (2026-07-06)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.57.0",
+  "version": "0.58.0",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.58.0</summary>

## [0.58.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.57.0...f0-react-native-v0.58.0) (2026-07-10)


### Features

* **react-native:** support Expo SDK 56 (React Native 0.85) ([#4584](https://github.com/factorialco/f0/issues/4584)) ([c8312c9](https://github.com/factorialco/f0/commit/c8312c955f59dcb162c9dfbcabe6a5e60ee782a4))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).