### PR TITLE
fix(react): contain dashboard widget loading states and fix the chart lifecycle

### DIFF
--- a/packages/react/src/experimental/OneTable/Table/__tests__/Table.test.tsx
+++ b/packages/react/src/experimental/OneTable/Table/__tests__/Table.test.tsx
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest"
+
+import { zeroRender } from "@/testing/test-utils"
+
+import { OneTable, TableBody, TableCell, TableRow } from "../../index"
+
+const renderTable = (loading: boolean) =>
+  zeroRender(
+    <OneTable loading={loading}>
+      <TableBody>
+        <TableRow>
+          <TableCell>37</TableCell>
+        </TableRow>
+      </TableBody>
+    </OneTable>
+  )
+
+describe("OneTable loading overlay", () => {
+  it("renders the overlay as a sibling of the scroll container, not inside it", () => {
+    const { container } = renderTable(true)
+
+    const scroller = container.querySelector(".overflow-auto")
+    const overlay = container.querySelector(".cursor-progress")
+
+    expect(scroller).not.toBeNull()
+    expect(overlay).not.toBeNull()
+    // Inside the scroll container an `absolute inset-0` overlay only covers
+    // the first scroll page, so the spinner scrolls out of view on scrolled
+    // tables. It must live next to the scroll container instead.
+    expect(scroller!.contains(overlay!)).toBe(false)
+    expect(overlay!.parentElement).toBe(scroller!.parentElement)
+  })
+
+  it("does not render the overlay when not loading", () => {
+    const { container } = renderTable(false)
+
+    expect(container.querySelector(".cursor-progress")).toBeNull()
+  })
+})
+
+describe("OneTable.Skeleton", () => {
+  it("clips its fixed-size placeholder rows with an overflow-hidden container", () => {
+    const { container } = zeroRender(<OneTable.Skeleton columns={3} />)
+
+    const table = container.querySelector("table")
+
+    expect(table).not.toBeNull()
+    // The skeleton renders a fixed number of rows regardless of the space it
+    // is given, so it must be clipped or it paints past short containers
+    // (e.g. a small dashboard widget card).
+    expect(table!.closest(".overflow-hidden")).not.toBeNull()
+  })
+})

--- a/packages/react/src/experimental/OneTable/Table/__tests__/Table.test.tsx
+++ b/packages/react/src/experimental/OneTable/Table/__tests__/Table.test.tsx
@@ -24,9 +24,6 @@ describe("OneTable loading overlay", () => {
 
     expect(scroller).not.toBeNull()
     expect(overlay).not.toBeNull()
-    // Inside the scroll container an `absolute inset-0` overlay only covers
-    // the first scroll page, so the spinner scrolls out of view on scrolled
-    // tables. It must live next to the scroll container instead.
     expect(scroller!.contains(overlay!)).toBe(false)
     expect(overlay!.parentElement).toBe(scroller!.parentElement)
   })
@@ -45,9 +42,6 @@ describe("OneTable.Skeleton", () => {
     const table = container.querySelector("table")
 
     expect(table).not.toBeNull()
-    // The skeleton renders a fixed number of rows regardless of the space it
-    // is given, so it must be clipped or it paints past short containers
-    // (e.g. a small dashboard widget card).
     expect(table!.closest(".overflow-hidden")).not.toBeNull()
   })
 })

--- a/packages/react/src/experimental/OneTable/Table/index.tsx
+++ b/packages/react/src/experimental/OneTable/Table/index.tsx
@@ -49,11 +49,8 @@ function TableBase({ children, loading = false }: TableProps) {
     <TableContext.Provider
       value={{ isScrolled, setIsScrolled, isScrolledRight, setIsScrolledRight }}
     >
-      {/* The overlay lives OUTSIDE the scroll container (as a sibling) so it
-          always covers the visible viewport: `absolute inset-0` inside an
-          `overflow-auto` element only covers the first scroll page, so the
-          spinner scrolled out of view (and could paint past the widget's
-          rounded boundary) when the table was scrolled. */}
+      {/* The overlay is a sibling of the scroll container — inside it,
+          `absolute inset-0` only covers the first scroll page */}
       <div className="relative h-full w-full">
         <div ref={containerRef} className="h-full w-full overflow-auto">
           <TableRoot
@@ -102,9 +99,8 @@ function TableSkeleton({ columns = 5 }: TableSkeletonProps) {
         setIsScrolledRight: () => {},
       }}
     >
-      {/* Clip the fixed-size placeholder rows: the skeleton has no scroll
-          container of its own, so without this it paints past short
-          containers (e.g. a small dashboard widget card). */}
+      {/* The skeleton renders fixed-size rows with no scroll container —
+          clip them so they don't paint past short containers */}
       <div className="h-full w-full overflow-hidden">
         <TableRoot
           className="cursor-progress"

--- a/packages/react/src/experimental/OneTable/Table/index.tsx
+++ b/packages/react/src/experimental/OneTable/Table/index.tsx
@@ -49,14 +49,23 @@ function TableBase({ children, loading = false }: TableProps) {
     <TableContext.Provider
       value={{ isScrolled, setIsScrolled, isScrolledRight, setIsScrolledRight }}
     >
-      <div ref={containerRef} className="relative h-full w-full overflow-auto">
-        <TableRoot
-          className={cn(loading && "select-none opacity-50 transition-opacity")}
-          aria-live={loading ? "polite" : undefined}
-          aria-busy={loading ? "true" : undefined}
-        >
-          {children}
-        </TableRoot>
+      {/* The overlay lives OUTSIDE the scroll container (as a sibling) so it
+          always covers the visible viewport: `absolute inset-0` inside an
+          `overflow-auto` element only covers the first scroll page, so the
+          spinner scrolled out of view (and could paint past the widget's
+          rounded boundary) when the table was scrolled. */}
+      <div className="relative h-full w-full">
+        <div ref={containerRef} className="h-full w-full overflow-auto">
+          <TableRoot
+            className={cn(
+              loading && "select-none opacity-50 transition-opacity"
+            )}
+            aria-live={loading ? "polite" : undefined}
+            aria-busy={loading ? "true" : undefined}
+          >
+            {children}
+          </TableRoot>
+        </div>
         <AnimatePresence>
           {loading && (
             <motion.div
@@ -93,32 +102,37 @@ function TableSkeleton({ columns = 5 }: TableSkeletonProps) {
         setIsScrolledRight: () => {},
       }}
     >
-      <TableRoot
-        className="cursor-progress"
-        role="presentation"
-        aria-hidden="true"
-      >
-        <TableHeader>
-          <TableRow>
-            {Array.from({ length: columns }).map((_, i) => (
-              <TableHead key={`skeleton-header-${i}`}>
-                <Skeleton className="h-4 w-[80px]" />
-              </TableHead>
-            ))}
-          </TableRow>
-        </TableHeader>
-        <TableBody>
-          {Array.from({ length: 5 }).map((_, rowIndex) => (
-            <TableRow key={`skeleton-row-${rowIndex}`}>
-              {Array.from({ length: columns }).map((_, colIndex) => (
-                <TableCell key={`skeleton-cell-${rowIndex}-${colIndex}`}>
+      {/* Clip the fixed-size placeholder rows: the skeleton has no scroll
+          container of its own, so without this it paints past short
+          containers (e.g. a small dashboard widget card). */}
+      <div className="h-full w-full overflow-hidden">
+        <TableRoot
+          className="cursor-progress"
+          role="presentation"
+          aria-hidden="true"
+        >
+          <TableHeader>
+            <TableRow>
+              {Array.from({ length: columns }).map((_, i) => (
+                <TableHead key={`skeleton-header-${i}`}>
                   <Skeleton className="h-4 w-[80px]" />
-                </TableCell>
+                </TableHead>
               ))}
             </TableRow>
-          ))}
-        </TableBody>
-      </TableRoot>
+          </TableHeader>
+          <TableBody>
+            {Array.from({ length: 5 }).map((_, rowIndex) => (
+              <TableRow key={`skeleton-row-${rowIndex}`}>
+                {Array.from({ length: columns }).map((_, colIndex) => (
+                  <TableCell key={`skeleton-cell-${rowIndex}-${colIndex}`}>
+                    <Skeleton className="h-4 w-[80px]" />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </TableBody>
+        </TableRoot>
+      </div>
     </TableContext.Provider>
   )
 }

--- a/packages/react/src/kits/F0DataChart/__stories__/Lifecycle.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Lifecycle.stories.tsx
@@ -33,14 +33,10 @@ const CollapsiblePanel = () => {
         label={open ? "Collapse panel" : "Expand panel"}
         onClick={() => setOpen(!open)}
       />
-      {/* Mimics the app's canvas panel: the chart is MOUNTED while its
-          container is 0-sized, and only later gets real dimensions via a
-          CSS transition. */}
       <div
         className="overflow-hidden rounded-lg border border-solid border-f1-border-secondary transition-all duration-300"
         style={{ width: open ? 560 : 0, height: open ? 320 : 0 }}
       >
-        {/* Same content padding the dashboard's ChartItem gives its charts. */}
         <div className="h-full w-full px-4 py-3">
           <F0DataChart {...SAMPLE} />
         </div>
@@ -49,25 +45,7 @@ const CollapsiblePanel = () => {
   )
 }
 
-/**
- * Regression story for chart initialization inside animated panels (the
- * app renders dashboards in canvas panels that mount widgets while the
- * panel is still 0-sized / transitioning open).
- *
- * The chart is mounted from the start inside a container that begins at
- * `0×0` and only gets real dimensions when you press **Expand panel**.
- * `useEChartsInstance` defers `echarts.init` until the container has
- * dimensions, so:
- *
- * - the console stays free of "[ECharts] Can't get DOM width or height"
- *   warnings while the panel is collapsed, and
- * - the chart paints correctly (with the options rendered so far, and with
- *   axis-label tooltips and legend interaction attached) as soon as the
- *   panel opens.
- *
- * Before the fix, init ran at 0-size, warned, and interaction hooks could
- * attach to a blank chart.
- */
+/** A chart mounted inside a 0-sized panel that expands via a CSS transition: no console warnings while collapsed, one fully-formed paint on open. */
 export const InitInsideAnimatedPanel: Story = {
   render: () => <CollapsiblePanel />,
 }
@@ -97,16 +75,7 @@ const MountChurn = () => {
   )
 }
 
-/**
- * Regression story for chart disposal (dashboards are opened and closed
- * quickly, mounting/unmounting every chart each time).
- *
- * Toggle the chart repeatedly and watch the console: every unmount used to
- * log "[ECharts] Instance ec_XXXX has been disposed" once per interaction
- * hook — the instance-owning hook disposes the chart before the axis-label
- * tooltip and legend hooks run their `off()` cleanups. Those cleanups are
- * now guarded with `isDisposed()`, so mount/unmount churn is silent.
- */
+/** Mount/unmount churn must not log "[ECharts] Instance has been disposed". */
 export const MountUnmountChurn: Story = {
   render: () => <MountChurn />,
 }

--- a/packages/react/src/kits/F0DataChart/__stories__/Lifecycle.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Lifecycle.stories.tsx
@@ -1,0 +1,109 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { useState } from "react"
+
+import { F0Button } from "@/components/F0Button"
+
+import { F0DataChart } from "../index"
+
+const meta = {
+  component: F0DataChart,
+  title: "F0DataChart/Lifecycle",
+  tags: ["autodocs", "experimental"],
+} satisfies Meta<typeof F0DataChart>
+
+export default meta
+type Story = StoryObj<typeof F0DataChart>
+
+const SAMPLE = {
+  type: "bar" as const,
+  categories: ["Engineering", "Product", "Design", "Marketing"],
+  series: [
+    { name: "Headcount", data: [92, 57, 43, 27] },
+    { name: "Open positions", data: [4, 3, 6, 3] },
+  ],
+}
+
+const CollapsiblePanel = () => {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div className="flex flex-col items-start gap-4">
+      <F0Button
+        label={open ? "Collapse panel" : "Expand panel"}
+        onClick={() => setOpen(!open)}
+      />
+      {/* Mimics the app's canvas panel: the chart is MOUNTED while its
+          container is 0-sized, and only later gets real dimensions via a
+          CSS transition. */}
+      <div
+        className="overflow-hidden rounded-lg border border-solid border-f1-border-secondary transition-all duration-300"
+        style={{ width: open ? 560 : 0, height: open ? 320 : 0 }}
+      >
+        <F0DataChart {...SAMPLE} />
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Regression story for chart initialization inside animated panels (the
+ * app renders dashboards in canvas panels that mount widgets while the
+ * panel is still 0-sized / transitioning open).
+ *
+ * The chart is mounted from the start inside a container that begins at
+ * `0×0` and only gets real dimensions when you press **Expand panel**.
+ * `useEChartsInstance` defers `echarts.init` until the container has
+ * dimensions, so:
+ *
+ * - the console stays free of "[ECharts] Can't get DOM width or height"
+ *   warnings while the panel is collapsed, and
+ * - the chart paints correctly (with the options rendered so far, and with
+ *   axis-label tooltips and legend interaction attached) as soon as the
+ *   panel opens.
+ *
+ * Before the fix, init ran at 0-size, warned, and interaction hooks could
+ * attach to a blank chart.
+ */
+export const InitInsideAnimatedPanel: Story = {
+  render: () => <CollapsiblePanel />,
+}
+
+const MountChurn = () => {
+  const [mounted, setMounted] = useState(true)
+  const [cycles, setCycles] = useState(0)
+
+  return (
+    <div className="flex flex-col items-start gap-4">
+      <div className="flex items-center gap-3">
+        <F0Button
+          label={mounted ? "Unmount chart" : "Mount chart"}
+          onClick={() => {
+            setMounted(!mounted)
+            if (mounted) setCycles((c) => c + 1)
+          }}
+        />
+        <span className="text-base text-f1-foreground-secondary">
+          {cycles} unmount cycles — console must stay clean
+        </span>
+      </div>
+      <div className="h-[320px] w-[560px]">
+        {mounted && <F0DataChart {...SAMPLE} />}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Regression story for chart disposal (dashboards are opened and closed
+ * quickly, mounting/unmounting every chart each time).
+ *
+ * Toggle the chart repeatedly and watch the console: every unmount used to
+ * log "[ECharts] Instance ec_XXXX has been disposed" once per interaction
+ * hook — the instance-owning hook disposes the chart before the axis-label
+ * tooltip and legend hooks run their `off()` cleanups. Those cleanups are
+ * now guarded with `isDisposed()`, so mount/unmount churn is silent.
+ */
+export const MountUnmountChurn: Story = {
+  render: () => <MountChurn />,
+}

--- a/packages/react/src/kits/F0DataChart/__stories__/Lifecycle.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Lifecycle.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
-import { useState } from "react"
+import { useEffect, useState } from "react"
 
 import { F0Button } from "@/components/F0Button"
 
@@ -78,4 +78,109 @@ const MountChurn = () => {
 /** Mount/unmount churn must not log "[ECharts] Instance has been disposed". */
 export const MountUnmountChurn: Story = {
   render: () => <MountChurn />,
+}
+
+/** Counts ECharts console warnings/errors and shows them on screen, so the
+ * lifecycle fixes are visible without opening devtools. */
+const useEChartsWarningCounter = () => {
+  const [count, setCount] = useState(0)
+  useEffect(() => {
+    const orig = { warn: console.warn, error: console.error }
+    const bump = (args: unknown[]) => {
+      const text = args.map(String).join(" ")
+      if (/echarts|dom width|disposed/i.test(text)) setCount((c) => c + 1)
+    }
+    console.warn = (...args) => {
+      bump(args)
+      orig.warn(...args)
+    }
+    console.error = (...args) => {
+      bump(args)
+      orig.error(...args)
+    }
+    return () => {
+      console.warn = orig.warn
+      console.error = orig.error
+    }
+  }, [])
+  return count
+}
+
+const WarningBadge = ({ count }: { count: number }) => (
+  <span
+    className={
+      "rounded-md px-3 py-1 text-lg font-semibold text-f1-foreground-inverse " +
+      (count > 0
+        ? "bg-f1-background-critical-bold"
+        : "bg-f1-background-positive-bold")
+    }
+  >
+    ECharts console warnings: {count}
+  </span>
+)
+
+const AutoPanel = () => {
+  const warnings = useEChartsWarningCounter()
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    const timer = setInterval(() => setOpen((o) => !o), 2600)
+    return () => clearInterval(timer)
+  }, [])
+
+  return (
+    <div className="flex flex-col items-start gap-4">
+      <WarningBadge count={warnings} />
+      <div
+        className="overflow-hidden rounded-lg border border-solid border-f1-border-secondary transition-all duration-300"
+        style={{ width: open ? 560 : 0, height: open ? 320 : 0 }}
+      >
+        <div className="h-full w-full px-4 py-3">
+          <F0DataChart {...SAMPLE} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/** Self-running showcase: the panel opens and closes on a loop while the badge
+ * counts ECharts warnings. Broken lifecycle = the counter climbs by itself. */
+export const AutoReplayInsideAnimatedPanel: Story = {
+  render: () => <AutoPanel />,
+}
+
+const AutoChurn = () => {
+  const warnings = useEChartsWarningCounter()
+  const [mounted, setMounted] = useState(true)
+  const [cycles, setCycles] = useState(0)
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setMounted((m) => {
+        if (m) setCycles((c) => c + 1)
+        return !m
+      })
+    }, 1500)
+    return () => clearInterval(timer)
+  }, [])
+
+  return (
+    <div className="flex flex-col items-start gap-4">
+      <div className="flex items-center gap-3">
+        <WarningBadge count={warnings} />
+        <span className="text-base text-f1-foreground-secondary">
+          {cycles} unmount cycles
+        </span>
+      </div>
+      <div className="h-[320px] w-[560px] px-4 py-3">
+        {mounted && <F0DataChart {...SAMPLE} />}
+      </div>
+    </div>
+  )
+}
+
+/** Self-running showcase: the chart mounts and unmounts on a loop while the
+ * badge counts ECharts warnings. Broken disposal = the counter climbs. */
+export const AutoMountUnmountChurn: Story = {
+  render: () => <AutoChurn />,
 }

--- a/packages/react/src/kits/F0DataChart/__stories__/Lifecycle.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Lifecycle.stories.tsx
@@ -121,37 +121,54 @@ const WarningBadge = ({ count }: { count: number }) => (
 
 const AutoPanel = () => {
   const warnings = useEChartsWarningCounter()
+  // Chart mounts only after the counter is armed, and only while the panel is
+  // open — mirroring the app's canvas, which mounts widgets while the panel
+  // is still 0-sized and unmounts them on close.
+  const [armed, setArmed] = useState(false)
   const [open, setOpen] = useState(false)
+  const [opens, setOpens] = useState(0)
 
+  useEffect(() => setArmed(true), [])
   useEffect(() => {
-    const timer = setInterval(() => setOpen((o) => !o), 2600)
+    const timer = setInterval(() => {
+      setOpen((o) => {
+        if (!o) setOpens((n) => n + 1)
+        return !o
+      })
+    }, 2600)
     return () => clearInterval(timer)
   }, [])
 
   return (
     <div className="flex flex-col items-start gap-4">
-      <WarningBadge count={warnings} />
+      <div className="flex items-center gap-3">
+        <WarningBadge count={warnings} />
+        <span className="text-base text-f1-foreground-secondary">
+          {opens} panel opens
+        </span>
+      </div>
       <div
         className="overflow-hidden rounded-lg border border-solid border-f1-border-secondary transition-all duration-300"
         style={{ width: open ? 560 : 0, height: open ? 320 : 0 }}
       >
         <div className="h-full w-full px-4 py-3">
-          <F0DataChart {...SAMPLE} />
+          {armed && open && <F0DataChart {...SAMPLE} />}
         </div>
       </div>
     </div>
   )
 }
 
-/** Self-running showcase: the panel opens and closes on a loop while the badge
- * counts ECharts warnings. Broken lifecycle = the counter climbs by itself. */
+/** Self-running showcase: the panel opens and closes on a loop, mounting the
+ * chart while the panel is still 0-sized (like the app's canvas) while the
+ * badge counts ECharts warnings. Broken lifecycle = the counter climbs. */
 export const AutoReplayInsideAnimatedPanel: Story = {
   render: () => <AutoPanel />,
 }
 
 const AutoChurn = () => {
   const warnings = useEChartsWarningCounter()
-  const [mounted, setMounted] = useState(true)
+  const [mounted, setMounted] = useState(false)
   const [cycles, setCycles] = useState(0)
 
   useEffect(() => {

--- a/packages/react/src/kits/F0DataChart/__stories__/Lifecycle.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Lifecycle.stories.tsx
@@ -40,7 +40,10 @@ const CollapsiblePanel = () => {
         className="overflow-hidden rounded-lg border border-solid border-f1-border-secondary transition-all duration-300"
         style={{ width: open ? 560 : 0, height: open ? 320 : 0 }}
       >
-        <F0DataChart {...SAMPLE} />
+        {/* Same content padding the dashboard's ChartItem gives its charts. */}
+        <div className="h-full w-full px-4 py-3">
+          <F0DataChart {...SAMPLE} />
+        </div>
       </div>
     </div>
   )
@@ -87,7 +90,7 @@ const MountChurn = () => {
           {cycles} unmount cycles — console must stay clean
         </span>
       </div>
-      <div className="h-[320px] w-[560px]">
+      <div className="h-[320px] w-[560px] px-4 py-3">
         {mounted && <F0DataChart {...SAMPLE} />}
       </div>
     </div>

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -4,6 +4,10 @@ import { zeroRender as render } from "@/testing/test-utils"
 
 import { F0DataChart } from "../F0DataChart"
 
+import { stubChartContainerLayout } from "./stubChartContainerLayout"
+
+stubChartContainerLayout()
+
 // ---------------------------------------------------------------------------
 // Same ECharts mock + container size mock as LineChart.test.tsx so the two
 // suites assert on the live `setOption` payload at each breakpoint.
@@ -16,6 +20,7 @@ vi.mock("echarts", () => ({
     setOption: setOptionMock,
     resize: vi.fn(),
     dispose: vi.fn(),
+    isDisposed: vi.fn(() => false),
     getDom: vi.fn(() => document.createElement("div")),
     on: vi.fn(),
     off: vi.fn(),

--- a/packages/react/src/kits/F0DataChart/__tests__/F0DataChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/F0DataChart.test.tsx
@@ -4,12 +4,17 @@ import { zeroRender as render } from "@/testing/test-utils"
 
 import { F0DataChart } from "../F0DataChart"
 
+import { stubChartContainerLayout } from "./stubChartContainerLayout"
+
+stubChartContainerLayout()
+
 // Mock ECharts — canvas rendering is not testable in jsdom
 vi.mock("echarts", () => ({
   init: vi.fn(() => ({
     setOption: vi.fn(),
     resize: vi.fn(),
     dispose: vi.fn(),
+    isDisposed: vi.fn(() => false),
     getDom: vi.fn(() => document.createElement("div")),
   })),
   use: vi.fn(),

--- a/packages/react/src/kits/F0DataChart/__tests__/GaugeChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/GaugeChart.test.tsx
@@ -4,6 +4,10 @@ import { zeroRender as render } from "@/testing/test-utils"
 
 import { F0DataChart } from "../F0DataChart"
 
+import { stubChartContainerLayout } from "./stubChartContainerLayout"
+
+stubChartContainerLayout()
+
 const setOptionMock = vi.fn()
 
 vi.mock("echarts", () => ({
@@ -11,6 +15,7 @@ vi.mock("echarts", () => ({
     setOption: setOptionMock,
     resize: vi.fn(),
     dispose: vi.fn(),
+    isDisposed: vi.fn(() => false),
     getDom: vi.fn(() => document.createElement("div")),
     on: vi.fn(),
     off: vi.fn(),

--- a/packages/react/src/kits/F0DataChart/__tests__/HeatmapChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/HeatmapChart.test.tsx
@@ -5,6 +5,10 @@ import { zeroRender as render } from "@/testing/test-utils"
 
 import { F0DataChart } from "../F0DataChart"
 
+import { stubChartContainerLayout } from "./stubChartContainerLayout"
+
+stubChartContainerLayout()
+
 const setOptionMock = vi.fn()
 
 vi.mock("echarts", () => ({
@@ -12,6 +16,7 @@ vi.mock("echarts", () => ({
     setOption: setOptionMock,
     resize: vi.fn(),
     dispose: vi.fn(),
+    isDisposed: vi.fn(() => false),
     getDom: vi.fn(() => document.createElement("div")),
     on: vi.fn(),
     off: vi.fn(),

--- a/packages/react/src/kits/F0DataChart/__tests__/LineChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/LineChart.test.tsx
@@ -4,6 +4,10 @@ import { zeroRender as render } from "@/testing/test-utils"
 
 import { F0DataChart } from "../F0DataChart"
 
+import { stubChartContainerLayout } from "./stubChartContainerLayout"
+
+stubChartContainerLayout()
+
 // ---------------------------------------------------------------------------
 // ECharts mock
 //
@@ -19,6 +23,7 @@ vi.mock("echarts", () => ({
     setOption: setOptionMock,
     resize: vi.fn(),
     dispose: vi.fn(),
+    isDisposed: vi.fn(() => false),
     getDom: vi.fn(() => document.createElement("div")),
     on: vi.fn(),
     off: vi.fn(),

--- a/packages/react/src/kits/F0DataChart/__tests__/PieChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/PieChart.test.tsx
@@ -4,6 +4,10 @@ import { zeroRender as render } from "@/testing/test-utils"
 
 import { F0DataChart } from "../F0DataChart"
 
+import { stubChartContainerLayout } from "./stubChartContainerLayout"
+
+stubChartContainerLayout()
+
 const setOptionMock = vi.fn()
 
 vi.mock("echarts", () => ({
@@ -11,6 +15,7 @@ vi.mock("echarts", () => ({
     setOption: setOptionMock,
     resize: vi.fn(),
     dispose: vi.fn(),
+    isDisposed: vi.fn(() => false),
     getDom: vi.fn(() => document.createElement("div")),
     on: vi.fn(),
     off: vi.fn(),

--- a/packages/react/src/kits/F0DataChart/__tests__/RadarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/RadarChart.test.tsx
@@ -4,6 +4,10 @@ import { zeroRender as render } from "@/testing/test-utils"
 
 import { F0DataChart } from "../F0DataChart"
 
+import { stubChartContainerLayout } from "./stubChartContainerLayout"
+
+stubChartContainerLayout()
+
 const setOptionMock = vi.fn()
 
 vi.mock("echarts", () => ({
@@ -11,6 +15,7 @@ vi.mock("echarts", () => ({
     setOption: setOptionMock,
     resize: vi.fn(),
     dispose: vi.fn(),
+    isDisposed: vi.fn(() => false),
     getDom: vi.fn(() => document.createElement("div")),
     on: vi.fn(),
     off: vi.fn(),

--- a/packages/react/src/kits/F0DataChart/__tests__/stubChartContainerLayout.ts
+++ b/packages/react/src/kits/F0DataChart/__tests__/stubChartContainerLayout.ts
@@ -1,0 +1,45 @@
+import { afterAll, beforeAll } from "vitest"
+
+/**
+ * jsdom has no layout engine, so every element measures 0×0 — and
+ * `useEChartsInstance` deliberately defers `echarts.init` until the
+ * container has real dimensions (initializing at 0-size warns and paints a
+ * blank canvas in real browsers). Stub non-zero client dimensions so charts
+ * initialize in tests the way they do in a laid-out browser.
+ */
+export function stubChartContainerLayout(width = 800, height = 320) {
+  let originalWidth: PropertyDescriptor | undefined
+  let originalHeight: PropertyDescriptor | undefined
+
+  beforeAll(() => {
+    originalWidth = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "clientWidth"
+    )
+    originalHeight = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "clientHeight"
+    )
+    Object.defineProperty(HTMLElement.prototype, "clientWidth", {
+      configurable: true,
+      get: () => width,
+    })
+    Object.defineProperty(HTMLElement.prototype, "clientHeight", {
+      configurable: true,
+      get: () => height,
+    })
+  })
+
+  afterAll(() => {
+    if (originalWidth) {
+      Object.defineProperty(HTMLElement.prototype, "clientWidth", originalWidth)
+    }
+    if (originalHeight) {
+      Object.defineProperty(
+        HTMLElement.prototype,
+        "clientHeight",
+        originalHeight
+      )
+    }
+  })
+}

--- a/packages/react/src/kits/F0DataChart/__tests__/stubChartContainerLayout.ts
+++ b/packages/react/src/kits/F0DataChart/__tests__/stubChartContainerLayout.ts
@@ -1,12 +1,6 @@
 import { afterAll, beforeAll } from "vitest"
 
-/**
- * jsdom has no layout engine, so every element measures 0×0 — and
- * `useEChartsInstance` deliberately defers `echarts.init` until the
- * container has real dimensions (initializing at 0-size warns and paints a
- * blank canvas in real browsers). Stub non-zero client dimensions so charts
- * initialize in tests the way they do in a laid-out browser.
- */
+/** jsdom measures everything 0×0 and `useEChartsInstance` defers init until the container has real dimensions — stub them so charts initialize in tests. */
 export function stubChartContainerLayout(width = 800, height = 320) {
   let originalWidth: PropertyDescriptor | undefined
   let originalHeight: PropertyDescriptor | undefined

--- a/packages/react/src/kits/F0DataChart/components/BarChart/BarChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/BarChart.tsx
@@ -15,10 +15,10 @@ export const BarChart = (props: F0DataChartBarProps) => {
   const { width } = useContainerSize(ref)
   const size = resolveChartSize(width)
   const options = useBarChartOptions(ref, props, size)
-  const chartRef = useEChartsInstance(ref, options)
+  const chart = useEChartsInstance(ref, options)
   const theme = useChartTheme(ref)
-  useAxisLabelTooltip(chartRef, ref, theme)
-  useLegendInteraction(chartRef)
+  useAxisLabelTooltip(chart, ref, theme)
+  useLegendInteraction(chart)
 
   // See LineChart.tsx for the rationale on the scoped axis-label cursor reset.
   return (

--- a/packages/react/src/kits/F0DataChart/components/BarChart/BarChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/BarChart.tsx
@@ -24,7 +24,7 @@ export const BarChart = (props: F0DataChartBarProps) => {
   return (
     <div
       ref={ref}
-      className="h-full w-full data-[axis-hover=true]:[&_canvas]:!cursor-default"
+      className="h-full w-full data-[axis-hover=true]:[&_canvas]:!cursor-default [&_canvas]:animate-in [&_canvas]:fade-in [&_canvas]:duration-200"
     />
   )
 }

--- a/packages/react/src/kits/F0DataChart/components/BarChart/BarChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/BarChart.tsx
@@ -24,7 +24,7 @@ export const BarChart = (props: F0DataChartBarProps) => {
   return (
     <div
       ref={ref}
-      className="h-full w-full data-[axis-hover=true]:[&_canvas]:!cursor-default [&_canvas]:animate-in [&_canvas]:fade-in [&_canvas]:duration-200"
+      className="h-full w-full data-[axis-hover=true]:[&_canvas]:!cursor-default"
     />
   )
 }

--- a/packages/react/src/kits/F0DataChart/components/FunnelChart/FunnelChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/FunnelChart/FunnelChart.tsx
@@ -109,10 +109,7 @@ export const FunnelChart = (props: F0DataChartFunnelProps) => {
         </div>
       )}
 
-      <div
-        ref={ref}
-        className="h-full w-full [&_canvas]:animate-in [&_canvas]:fade-in [&_canvas]:duration-200"
-      />
+      <div ref={ref} className="h-full w-full" />
     </div>
   )
 }

--- a/packages/react/src/kits/F0DataChart/components/FunnelChart/FunnelChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/FunnelChart/FunnelChart.tsx
@@ -109,7 +109,10 @@ export const FunnelChart = (props: F0DataChartFunnelProps) => {
         </div>
       )}
 
-      <div ref={ref} className="h-full w-full" />
+      <div
+        ref={ref}
+        className="h-full w-full [&_canvas]:animate-in [&_canvas]:fade-in [&_canvas]:duration-200"
+      />
     </div>
   )
 }

--- a/packages/react/src/kits/F0DataChart/components/FunnelChart/FunnelChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/FunnelChart/FunnelChart.tsx
@@ -36,8 +36,8 @@ export const FunnelChart = (props: F0DataChartFunnelProps) => {
 
   const ref = useRef<HTMLDivElement>(null)
   const options = useFunnelChartOptions(ref, props)
-  const chartRef = useEChartsInstance(ref, options)
-  useLegendInteraction(chartRef)
+  const chart = useEChartsInstance(ref, options)
+  useLegendInteraction(chart)
 
   const sorted = sortFunnelData(series.data ?? [], sort)
   const firstValue = sorted[0]?.value ?? 0

--- a/packages/react/src/kits/F0DataChart/components/GaugeChart/GaugeChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/GaugeChart/GaugeChart.tsx
@@ -14,10 +14,5 @@ export const GaugeChart = (props: F0DataChartGaugeProps) => {
   const options = useGaugeChartOptions(ref, props, size)
   useEChartsInstance(ref, options)
 
-  return (
-    <div
-      ref={ref}
-      className="h-full w-full [&_canvas]:animate-in [&_canvas]:fade-in [&_canvas]:duration-200"
-    />
-  )
+  return <div ref={ref} className="h-full w-full" />
 }

--- a/packages/react/src/kits/F0DataChart/components/GaugeChart/GaugeChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/GaugeChart/GaugeChart.tsx
@@ -14,5 +14,10 @@ export const GaugeChart = (props: F0DataChartGaugeProps) => {
   const options = useGaugeChartOptions(ref, props, size)
   useEChartsInstance(ref, options)
 
-  return <div ref={ref} className="h-full w-full" />
+  return (
+    <div
+      ref={ref}
+      className="h-full w-full [&_canvas]:animate-in [&_canvas]:fade-in [&_canvas]:duration-200"
+    />
+  )
 }

--- a/packages/react/src/kits/F0DataChart/components/HeatmapChart/HeatmapChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/HeatmapChart/HeatmapChart.tsx
@@ -17,9 +17,9 @@ export const HeatmapChart = (props: F0DataChartHeatmapProps) => {
   const { width } = useContainerSize(ref)
   const size = resolveChartSize(width)
   const options = useHeatmapChartOptions(ref, props, size)
-  const chartRef = useEChartsInstance(ref, options)
+  const chart = useEChartsInstance(ref, options)
   const theme = useChartTheme(ref)
-  useAxisLabelTooltip(chartRef, ref, theme)
+  useAxisLabelTooltip(chart, ref, theme)
 
   // The chart container always stays mounted so the ECharts instance has a
   // stable DOM target across breakpoint transitions. At the `sm` breakpoint

--- a/packages/react/src/kits/F0DataChart/components/HeatmapChart/HeatmapChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/HeatmapChart/HeatmapChart.tsx
@@ -31,7 +31,7 @@ export const HeatmapChart = (props: F0DataChartHeatmapProps) => {
     <div className="relative h-full w-full">
       <div
         ref={ref}
-        className="h-full w-full data-[axis-hover=true]:[&_canvas]:!cursor-default [&_canvas]:animate-in [&_canvas]:fade-in [&_canvas]:duration-200"
+        className="h-full w-full data-[axis-hover=true]:[&_canvas]:!cursor-default"
       />
       {size === "sm" && (
         <div className="absolute inset-0 flex items-center justify-center bg-f1-background p-3 text-center text-sm font-medium text-f1-foreground-tertiary">

--- a/packages/react/src/kits/F0DataChart/components/HeatmapChart/HeatmapChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/HeatmapChart/HeatmapChart.tsx
@@ -31,7 +31,7 @@ export const HeatmapChart = (props: F0DataChartHeatmapProps) => {
     <div className="relative h-full w-full">
       <div
         ref={ref}
-        className="h-full w-full data-[axis-hover=true]:[&_canvas]:!cursor-default"
+        className="h-full w-full data-[axis-hover=true]:[&_canvas]:!cursor-default [&_canvas]:animate-in [&_canvas]:fade-in [&_canvas]:duration-200"
       />
       {size === "sm" && (
         <div className="absolute inset-0 flex items-center justify-center bg-f1-background p-3 text-center text-sm font-medium text-f1-foreground-tertiary">

--- a/packages/react/src/kits/F0DataChart/components/LineChart/LineChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/LineChart/LineChart.tsx
@@ -15,10 +15,10 @@ export const LineChart = (props: F0DataChartLineProps) => {
   const { width } = useContainerSize(ref)
   const size = resolveChartSize(width)
   const options = useLineChartOptions(ref, props, size)
-  const chartRef = useEChartsInstance(ref, options)
+  const chart = useEChartsInstance(ref, options)
   const theme = useChartTheme(ref)
-  useAxisLabelTooltip(chartRef, ref, theme)
-  useLegendInteraction(chartRef)
+  useAxisLabelTooltip(chart, ref, theme)
+  useLegendInteraction(chart)
 
   // ECharts (zrender) sets `cursor: pointer` on the canvas element via inline
   // style whenever an axis label has `triggerEvent: true` (which we need for

--- a/packages/react/src/kits/F0DataChart/components/LineChart/LineChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/LineChart/LineChart.tsx
@@ -31,7 +31,7 @@ export const LineChart = (props: F0DataChartLineProps) => {
   return (
     <div
       ref={ref}
-      className="h-full w-full data-[axis-hover=true]:[&_canvas]:!cursor-default [&_canvas]:animate-in [&_canvas]:fade-in [&_canvas]:duration-200"
+      className="h-full w-full data-[axis-hover=true]:[&_canvas]:!cursor-default"
     />
   )
 }

--- a/packages/react/src/kits/F0DataChart/components/LineChart/LineChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/LineChart/LineChart.tsx
@@ -31,7 +31,7 @@ export const LineChart = (props: F0DataChartLineProps) => {
   return (
     <div
       ref={ref}
-      className="h-full w-full data-[axis-hover=true]:[&_canvas]:!cursor-default"
+      className="h-full w-full data-[axis-hover=true]:[&_canvas]:!cursor-default [&_canvas]:animate-in [&_canvas]:fade-in [&_canvas]:duration-200"
     />
   )
 }

--- a/packages/react/src/kits/F0DataChart/components/PieChart/PieChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/PieChart/PieChart.tsx
@@ -13,8 +13,8 @@ export const PieChart = (props: F0DataChartPieProps) => {
   const { width } = useContainerSize(ref)
   const size = resolveChartSize(width)
   const options = usePieChartOptions(ref, props, size)
-  const chartRef = useEChartsInstance(ref, options)
-  useLegendInteraction(chartRef)
+  const chart = useEChartsInstance(ref, options)
+  useLegendInteraction(chart)
 
   return <div ref={ref} className="h-full w-full" />
 }

--- a/packages/react/src/kits/F0DataChart/components/PieChart/PieChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/PieChart/PieChart.tsx
@@ -16,10 +16,5 @@ export const PieChart = (props: F0DataChartPieProps) => {
   const chart = useEChartsInstance(ref, options)
   useLegendInteraction(chart)
 
-  return (
-    <div
-      ref={ref}
-      className="h-full w-full [&_canvas]:animate-in [&_canvas]:fade-in [&_canvas]:duration-200"
-    />
-  )
+  return <div ref={ref} className="h-full w-full" />
 }

--- a/packages/react/src/kits/F0DataChart/components/PieChart/PieChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/PieChart/PieChart.tsx
@@ -16,5 +16,10 @@ export const PieChart = (props: F0DataChartPieProps) => {
   const chart = useEChartsInstance(ref, options)
   useLegendInteraction(chart)
 
-  return <div ref={ref} className="h-full w-full" />
+  return (
+    <div
+      ref={ref}
+      className="h-full w-full [&_canvas]:animate-in [&_canvas]:fade-in [&_canvas]:duration-200"
+    />
+  )
 }

--- a/packages/react/src/kits/F0DataChart/components/RadarChart/RadarChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/RadarChart/RadarChart.tsx
@@ -16,10 +16,5 @@ export const RadarChart = (props: F0DataChartRadarProps) => {
   const chart = useEChartsInstance(ref, options)
   useLegendInteraction(chart)
 
-  return (
-    <div
-      ref={ref}
-      className="h-full w-full [&_canvas]:animate-in [&_canvas]:fade-in [&_canvas]:duration-200"
-    />
-  )
+  return <div ref={ref} className="h-full w-full" />
 }

--- a/packages/react/src/kits/F0DataChart/components/RadarChart/RadarChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/RadarChart/RadarChart.tsx
@@ -16,5 +16,10 @@ export const RadarChart = (props: F0DataChartRadarProps) => {
   const chart = useEChartsInstance(ref, options)
   useLegendInteraction(chart)
 
-  return <div ref={ref} className="h-full w-full" />
+  return (
+    <div
+      ref={ref}
+      className="h-full w-full [&_canvas]:animate-in [&_canvas]:fade-in [&_canvas]:duration-200"
+    />
+  )
 }

--- a/packages/react/src/kits/F0DataChart/components/RadarChart/RadarChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/RadarChart/RadarChart.tsx
@@ -13,8 +13,8 @@ export const RadarChart = (props: F0DataChartRadarProps) => {
   const { width } = useContainerSize(ref)
   const size = resolveChartSize(width)
   const options = useRadarChartOptions(ref, props, size)
-  const chartRef = useEChartsInstance(ref, options)
-  useLegendInteraction(chartRef)
+  const chart = useEChartsInstance(ref, options)
+  useLegendInteraction(chart)
 
   return <div ref={ref} className="h-full w-full" />
 }

--- a/packages/react/src/kits/F0DataChart/utils/useAxisLabelTooltip.ts
+++ b/packages/react/src/kits/F0DataChart/utils/useAxisLabelTooltip.ts
@@ -192,8 +192,6 @@ export function useAxisLabelTooltip(
     chart.on("mouseout", onMouseOut)
 
     return () => {
-      // The instance-owning hook disposes the chart before sibling cleanups
-      // run — `off` on a disposed instance makes ECharts log a warning.
       if (!chart.isDisposed()) {
         chart.off("mouseover", onMouseOver)
         chart.off("mouseout", onMouseOut)

--- a/packages/react/src/kits/F0DataChart/utils/useAxisLabelTooltip.ts
+++ b/packages/react/src/kits/F0DataChart/utils/useAxisLabelTooltip.ts
@@ -1,5 +1,5 @@
 import type * as echarts from "echarts"
-import { type RefObject, useEffect } from "react"
+import { useEffect, type RefObject } from "react"
 
 import type { ChartTheme } from "./theme"
 
@@ -64,12 +64,11 @@ function isLabelTruncated(
  * to show.
  */
 export function useAxisLabelTooltip(
-  chartRef: RefObject<echarts.ECharts | null>,
+  chart: echarts.ECharts | null,
   containerRef: RefObject<HTMLDivElement | null>,
   theme: ChartTheme
 ) {
   useEffect(() => {
-    const chart = chartRef.current
     const container = containerRef.current
     if (!chart || !container) return
 
@@ -193,13 +192,17 @@ export function useAxisLabelTooltip(
     chart.on("mouseout", onMouseOut)
 
     return () => {
-      chart.off("mouseover", onMouseOver)
-      chart.off("mouseout", onMouseOut)
+      // The instance-owning hook disposes the chart before sibling cleanups
+      // run — `off` on a disposed instance makes ECharts log a warning.
+      if (!chart.isDisposed()) {
+        chart.off("mouseover", onMouseOver)
+        chart.off("mouseout", onMouseOut)
+      }
       // Reset the cursor scope in case we tear down mid-hover.
       container.dataset.axisHover = "false"
       if (overlay && container.contains(overlay)) {
         container.removeChild(overlay)
       }
     }
-  }, [chartRef, containerRef, theme])
+  }, [chart, containerRef, theme])
 }

--- a/packages/react/src/kits/F0DataChart/utils/useEChartsInstance.ts
+++ b/packages/react/src/kits/F0DataChart/utils/useEChartsInstance.ts
@@ -40,6 +40,7 @@ export function useEChartsInstance(
     if (!container) return
 
     let chart: echarts.ECharts | null = null
+    let settleTimer: number | undefined
 
     const init = () => {
       if (chart || container.clientWidth === 0 || container.clientHeight === 0)
@@ -49,11 +50,20 @@ export function useEChartsInstance(
       setInstance(chart)
     }
 
+    // Mounted with a real size (the common case: grid cells, static layouts)
+    // — init synchronously, no delay.
     init()
 
     const resizeObserver = new ResizeObserver(() => {
       if (!chart) {
-        init()
+        // Deferred init: the container mounted at 0×0, so it is expanding
+        // inside an animation (canvas panels grow via a CSS transition).
+        // Initializing on the first sized tick paints the chart mid-growth —
+        // it lands on the small responsive breakpoint and its axes/labels
+        // pop in later as the breakpoints upgrade. Wait until the size stops
+        // changing so the chart appears once, fully formed, at final size.
+        window.clearTimeout(settleTimer)
+        settleTimer = window.setTimeout(init, 120)
         return
       }
       if (!chart.isDisposed()) {
@@ -64,6 +74,7 @@ export function useEChartsInstance(
     resizeObserver.observe(container)
 
     return () => {
+      window.clearTimeout(settleTimer)
       resizeObserver.disconnect()
       if (chart && !chart.isDisposed()) {
         chart.dispose()

--- a/packages/react/src/kits/F0DataChart/utils/useEChartsInstance.ts
+++ b/packages/react/src/kits/F0DataChart/utils/useEChartsInstance.ts
@@ -1,6 +1,6 @@
 import * as echarts from "echarts"
 import { AriaComponent } from "echarts/components"
-import { type RefObject, useEffect, useRef } from "react"
+import { type RefObject, useEffect, useRef, useState } from "react"
 
 // @ts-expect-error - Duplicate echarts types in dependency tree
 echarts.use(AriaComponent)
@@ -12,34 +12,71 @@ echarts.use(AriaComponent)
  * Accepts a ref to the container `<div>` so it can be shared with other
  * hooks that need access to the same DOM element (e.g. `useChartTheme`
  * for dark mode detection via `element.closest(".dark")`).
+ *
+ * Init is deferred until the container has a real size: dashboard widgets
+ * mount inside animated canvas panels, and calling `echarts.init` on a
+ * 0-sized element warns ("Can't get DOM width or height") and produces a
+ * blank chart that never recovers. The ResizeObserver performs the init on
+ * the first tick where the container has dimensions.
+ *
+ * The instance is returned as STATE (not a ref) so dependent hooks — axis
+ * label tooltip, legend interaction — re-run and attach their listeners
+ * when the instance is created late.
  */
 export function useEChartsInstance(
   ref: RefObject<HTMLDivElement | null>,
   options: echarts.EChartsOption
-): RefObject<echarts.ECharts | null> {
-  const chart = useRef<echarts.ECharts | null>(null)
+): echarts.ECharts | null {
+  const [instance, setInstance] = useState<echarts.ECharts | null>(null)
+
+  // Latest options for the deferred-init path: when the container gets its
+  // size after mount, init must apply the options rendered since then —
+  // the options effect below only fires on `options` changes.
+  const optionsRef = useRef(options)
+  optionsRef.current = options
 
   useEffect(() => {
-    if (ref.current) {
-      chart.current = echarts.init(ref.current)
+    const container = ref.current
+    if (!container) return
 
-      const container = ref.current
-      const resizeObserver = new ResizeObserver(() => {
-        chart.current?.resize()
-      })
+    let chart: echarts.ECharts | null = null
 
-      resizeObserver.observe(container)
+    const init = () => {
+      if (chart || container.clientWidth === 0 || container.clientHeight === 0)
+        return
+      chart = echarts.init(container)
+      chart.setOption(optionsRef.current, true)
+      setInstance(chart)
+    }
 
-      return () => {
-        resizeObserver.disconnect()
-        chart.current?.dispose()
+    init()
+
+    const resizeObserver = new ResizeObserver(() => {
+      if (!chart) {
+        init()
+        return
       }
+      if (!chart.isDisposed()) {
+        chart.resize()
+      }
+    })
+
+    resizeObserver.observe(container)
+
+    return () => {
+      resizeObserver.disconnect()
+      if (chart && !chart.isDisposed()) {
+        chart.dispose()
+      }
+      setInstance(null)
     }
   }, [ref])
 
   useEffect(() => {
-    chart.current?.setOption(options, true)
-  }, [options])
+    if (instance && !instance.isDisposed()) {
+      instance.setOption(options, true)
+    }
+  }, [instance, options])
 
-  return chart
+  return instance
 }

--- a/packages/react/src/kits/F0DataChart/utils/useEChartsInstance.ts
+++ b/packages/react/src/kits/F0DataChart/utils/useEChartsInstance.ts
@@ -5,42 +5,18 @@ import { type RefObject, useEffect, useRef, useState } from "react"
 // @ts-expect-error - Duplicate echarts types in dependency tree
 echarts.use(AriaComponent)
 
-/**
- * Manages the ECharts instance lifecycle: init, resize, option updates,
- * and cleanup. Shared across all ECharts-based F0 chart components.
- *
- * Accepts a ref to the container `<div>` so it can be shared with other
- * hooks that need access to the same DOM element (e.g. `useChartTheme`
- * for dark mode detection via `element.closest(".dark")`).
- *
- * Init is deferred until the container has a real size: dashboard widgets
- * mount inside animated canvas panels, and calling `echarts.init` on a
- * 0-sized element warns ("Can't get DOM width or height") and produces a
- * blank chart that never recovers. The ResizeObserver performs the init on
- * the first tick where the container has dimensions.
- *
- * The instance is returned as STATE (not a ref) so dependent hooks — axis
- * label tooltip, legend interaction — re-run and attach their listeners
- * when the instance is created late.
- */
+/** ECharts instance lifecycle. Init waits for a real, settled container size (0-sized init warns and stays blank); the instance is state so listener hooks re-attach when it is created late. */
 export function useEChartsInstance(
   ref: RefObject<HTMLDivElement | null>,
   options: echarts.EChartsOption
 ): echarts.ECharts | null {
   const [instance, setInstance] = useState<echarts.ECharts | null>(null)
 
-  // Latest options for the deferred-init path: when the container gets its
-  // size after mount, init must apply the options rendered since then —
-  // the options effect below only fires on `options` changes.
   const optionsRef = useRef(options)
   optionsRef.current = options
 
-  // The exact options object the instance currently renders. Guards the
-  // options effect against re-applying what init just painted: `setInstance`
-  // re-renders the component, the effect fires with the same (memoized)
-  // options, and `setOption(..., notMerge)` would then rebuild the whole
-  // chart — restarting the entrance animation and visibly re-laying-out the
-  // grid one beat after the first paint.
+  // Stops the options effect re-applying what init just painted — a redundant
+  // notMerge setOption rebuilds the chart and restarts its entrance animation.
   const appliedOptionsRef = useRef<echarts.EChartsOption | null>(null)
 
   useEffect(() => {
@@ -59,20 +35,11 @@ export function useEChartsInstance(
       setInstance(chart)
     }
 
-    // Mounted with a real size (the common case: grid cells, static layouts)
-    // — init synchronously, no delay.
     init()
 
-    // Deferred init: the container mounted at 0×0, so it is expanding inside
-    // an animation (canvas panels grow via a CSS transition). Initializing
-    // mid-growth paints the chart on a smaller responsive breakpoint and its
-    // axes/labels then pop in when the final size upgrades the breakpoint,
-    // visibly re-laying-out the grid. Wait until the size stops changing so
-    // the chart appears once, fully formed, at its final size. The timer
-    // re-checks the size when it fires: a rendering hiccup can starve
-    // ResizeObserver ticks for longer than the debounce while the CSS
-    // transition keeps progressing, and painting in that lull would land
-    // mid-animation again.
+    // Mounted 0-sized: the container is growing inside a CSS transition. Wait
+    // for the size to settle, re-checking at fire time (frame hiccups can
+    // starve ResizeObserver ticks mid-transition), then paint once.
     const scheduleSettledInit = () => {
       window.clearTimeout(settleTimer)
       const scheduledWidth = container.clientWidth

--- a/packages/react/src/kits/F0DataChart/utils/useEChartsInstance.ts
+++ b/packages/react/src/kits/F0DataChart/utils/useEChartsInstance.ts
@@ -63,16 +63,35 @@ export function useEChartsInstance(
     // — init synchronously, no delay.
     init()
 
+    // Deferred init: the container mounted at 0×0, so it is expanding inside
+    // an animation (canvas panels grow via a CSS transition). Initializing
+    // mid-growth paints the chart on a smaller responsive breakpoint and its
+    // axes/labels then pop in when the final size upgrades the breakpoint,
+    // visibly re-laying-out the grid. Wait until the size stops changing so
+    // the chart appears once, fully formed, at its final size. The timer
+    // re-checks the size when it fires: a rendering hiccup can starve
+    // ResizeObserver ticks for longer than the debounce while the CSS
+    // transition keeps progressing, and painting in that lull would land
+    // mid-animation again.
+    const scheduleSettledInit = () => {
+      window.clearTimeout(settleTimer)
+      const scheduledWidth = container.clientWidth
+      const scheduledHeight = container.clientHeight
+      settleTimer = window.setTimeout(() => {
+        if (
+          container.clientWidth !== scheduledWidth ||
+          container.clientHeight !== scheduledHeight
+        ) {
+          scheduleSettledInit()
+          return
+        }
+        init()
+      }, 120)
+    }
+
     const resizeObserver = new ResizeObserver(() => {
       if (!chart) {
-        // Deferred init: the container mounted at 0×0, so it is expanding
-        // inside an animation (canvas panels grow via a CSS transition).
-        // Initializing on the first sized tick paints the chart mid-growth —
-        // it lands on the small responsive breakpoint and its axes/labels
-        // pop in later as the breakpoints upgrade. Wait until the size stops
-        // changing so the chart appears once, fully formed, at final size.
-        window.clearTimeout(settleTimer)
-        settleTimer = window.setTimeout(init, 120)
+        scheduleSettledInit()
         return
       }
       if (!chart.isDisposed()) {

--- a/packages/react/src/kits/F0DataChart/utils/useEChartsInstance.ts
+++ b/packages/react/src/kits/F0DataChart/utils/useEChartsInstance.ts
@@ -35,6 +35,14 @@ export function useEChartsInstance(
   const optionsRef = useRef(options)
   optionsRef.current = options
 
+  // The exact options object the instance currently renders. Guards the
+  // options effect against re-applying what init just painted: `setInstance`
+  // re-renders the component, the effect fires with the same (memoized)
+  // options, and `setOption(..., notMerge)` would then rebuild the whole
+  // chart — restarting the entrance animation and visibly re-laying-out the
+  // grid one beat after the first paint.
+  const appliedOptionsRef = useRef<echarts.EChartsOption | null>(null)
+
   useEffect(() => {
     const container = ref.current
     if (!container) return
@@ -47,6 +55,7 @@ export function useEChartsInstance(
         return
       chart = echarts.init(container)
       chart.setOption(optionsRef.current, true)
+      appliedOptionsRef.current = optionsRef.current
       setInstance(chart)
     }
 
@@ -84,9 +93,10 @@ export function useEChartsInstance(
   }, [ref])
 
   useEffect(() => {
-    if (instance && !instance.isDisposed()) {
-      instance.setOption(options, true)
-    }
+    if (!instance || instance.isDisposed()) return
+    if (appliedOptionsRef.current === options) return
+    appliedOptionsRef.current = options
+    instance.setOption(options, true)
   }, [instance, options])
 
   return instance

--- a/packages/react/src/kits/F0DataChart/utils/useLegendInteraction.ts
+++ b/packages/react/src/kits/F0DataChart/utils/useLegendInteraction.ts
@@ -1,5 +1,5 @@
 import type * as echarts from "echarts"
-import { type RefObject, useEffect, useRef } from "react"
+import { useEffect, useRef } from "react"
 
 /**
  * Implements Plotly-style legend interaction:
@@ -12,14 +12,11 @@ import { type RefObject, useEffect, useRef } from "react"
  * Does not need an explicit legend data list — it reads the full selected
  * state from ECharts' `legendselectchanged` event.
  */
-export function useLegendInteraction(
-  chartRef: RefObject<echarts.ECharts | null>
-) {
+export function useLegendInteraction(chart: echarts.ECharts | null) {
   // Track the previous selected state so we know what changed
   const prevSelectedRef = useRef<Record<string, boolean> | null>(null)
 
   useEffect(() => {
-    const chart = chartRef.current
     if (!chart || typeof chart.on !== "function") return
 
     function onLegendSelectChanged(params: {
@@ -77,10 +74,14 @@ export function useLegendInteraction(
     )
 
     return () => {
-      chart.off(
-        "legendselectchanged",
-        onLegendSelectChanged as (...args: unknown[]) => void
-      )
+      // The instance-owning hook disposes the chart before sibling cleanups
+      // run — `off` on a disposed instance makes ECharts log a warning.
+      if (!chart.isDisposed()) {
+        chart.off(
+          "legendselectchanged",
+          onLegendSelectChanged as (...args: unknown[]) => void
+        )
+      }
     }
-  }, [chartRef])
+  }, [chart])
 }

--- a/packages/react/src/kits/F0DataChart/utils/useLegendInteraction.ts
+++ b/packages/react/src/kits/F0DataChart/utils/useLegendInteraction.ts
@@ -74,8 +74,6 @@ export function useLegendInteraction(chart: echarts.ECharts | null) {
     )
 
     return () => {
-      // The instance-owning hook disposes the chart before sibling cleanups
-      // run — `off` on a disposed instance makes ECharts log a warning.
       if (!chart.isDisposed()) {
         chart.off(
           "legendselectchanged",

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
@@ -157,28 +157,7 @@ export const EmptyDashboard: Story = {
   ),
 }
 
-/**
- * Loading states for every widget type, all on a deliberately slow (~2s)
- * source so the skeleton phase is visible on first render:
- *
- * - **Metrics** (plain / currency / percent) and **charts** (bar, line, pie)
- *   show their type-specific skeletons and must not shift the card's height
- *   when data lands.
- * - **Short table widget** (300px — the grid's minimum collection row
- *   height): both the skeleton and the loaded table are taller than the
- *   card. Everything must clip at the rounded border — the loaded table
- *   scrolls internally and its pagination stays pinned inside the card.
- *   Before the containment fixes, placeholder rows and pagination painted
- *   past the card's bottom edge and the card height jumped on the
- *   loading→loaded swap.
- * - **Default table widget**: reference behaviour at the regular collection
- *   height.
- *
- * Change any dashboard filter (e.g. department) to re-fire the slow fetches
- * and see the reload treatment — for tables, the content dims to 50% with a
- * spinner overlay that covers the visible area even while the table is
- * scrolled.
- */
+/** Every widget type on a slow (~2s) source: skeletons must not shift card heights, and the short table must clip and scroll inside its card. Change any filter to replay the reload treatment. */
 export const WidgetLoadingStates: Story = {
   render: () => (
     <F0AnalyticsDashboard

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
@@ -7,7 +7,12 @@ import { withSnapshot } from "@/lib/storybook-utils/parameters"
 import type { DashboardItem } from "../types"
 
 import { F0AnalyticsDashboard } from "../index"
-import { dashboardFilters, dashboardPresets, mixedItems } from "./mockDataMixed"
+import {
+  dashboardFilters,
+  dashboardPresets,
+  loadingContainmentItems,
+  mixedItems,
+} from "./mockDataMixed"
 
 const meta = {
   component: F0AnalyticsDashboard,
@@ -148,6 +153,34 @@ export const EmptyDashboard: Story = {
       filters={dashboardFilters}
       presets={dashboardPresets}
       items={emptyItems}
+    />
+  ),
+}
+
+/**
+ * Table-widget loading containment. Both tables fetch through a deliberately
+ * slow source (~2s), so on first render you can watch the skeleton phase and
+ * verify it stays inside each card:
+ *
+ * - **Short widget** (300px — the grid's minimum collection row height): both
+ *   the skeleton and the loaded table are taller than the card. Everything
+ *   must clip at the rounded border — the
+ *   loaded table scrolls internally and its pagination stays pinned inside
+ *   the card. Before the containment fixes, placeholder rows and pagination
+ *   painted past the card's bottom edge and the card height jumped on the
+ *   loading→loaded swap.
+ * - **Default widget**: reference behaviour at the regular collection height.
+ *
+ * Change any dashboard filter (e.g. department) to re-fire the slow fetch and
+ * see the reload treatment: the table dims to 50% with a spinner overlay that
+ * covers the visible area even while the table is scrolled.
+ */
+export const TableLoadingContainment: Story = {
+  render: () => (
+    <F0AnalyticsDashboard
+      filters={dashboardFilters}
+      presets={dashboardPresets}
+      items={loadingContainmentItems}
     />
   ),
 }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
@@ -10,8 +10,8 @@ import { F0AnalyticsDashboard } from "../index"
 import {
   dashboardFilters,
   dashboardPresets,
-  loadingContainmentItems,
   mixedItems,
+  widgetLoadingStatesItems,
 } from "./mockDataMixed"
 
 const meta = {
@@ -158,29 +158,33 @@ export const EmptyDashboard: Story = {
 }
 
 /**
- * Table-widget loading containment. Both tables fetch through a deliberately
- * slow source (~2s), so on first render you can watch the skeleton phase and
- * verify it stays inside each card:
+ * Loading states for every widget type, all on a deliberately slow (~2s)
+ * source so the skeleton phase is visible on first render:
  *
- * - **Short widget** (300px — the grid's minimum collection row height): both
- *   the skeleton and the loaded table are taller than the card. Everything
- *   must clip at the rounded border — the
- *   loaded table scrolls internally and its pagination stays pinned inside
- *   the card. Before the containment fixes, placeholder rows and pagination
- *   painted past the card's bottom edge and the card height jumped on the
+ * - **Metrics** (plain / currency / percent) and **charts** (bar, line, pie)
+ *   show their type-specific skeletons and must not shift the card's height
+ *   when data lands.
+ * - **Short table widget** (300px — the grid's minimum collection row
+ *   height): both the skeleton and the loaded table are taller than the
+ *   card. Everything must clip at the rounded border — the loaded table
+ *   scrolls internally and its pagination stays pinned inside the card.
+ *   Before the containment fixes, placeholder rows and pagination painted
+ *   past the card's bottom edge and the card height jumped on the
  *   loading→loaded swap.
- * - **Default widget**: reference behaviour at the regular collection height.
+ * - **Default table widget**: reference behaviour at the regular collection
+ *   height.
  *
- * Change any dashboard filter (e.g. department) to re-fire the slow fetch and
- * see the reload treatment: the table dims to 50% with a spinner overlay that
- * covers the visible area even while the table is scrolled.
+ * Change any dashboard filter (e.g. department) to re-fire the slow fetches
+ * and see the reload treatment — for tables, the content dims to 50% with a
+ * spinner overlay that covers the visible area even while the table is
+ * scrolled.
  */
-export const TableLoadingContainment: Story = {
+export const WidgetLoadingStates: Story = {
   render: () => (
     <F0AnalyticsDashboard
       filters={dashboardFilters}
       presets={dashboardPresets}
-      items={loadingContainmentItems}
+      items={widgetLoadingStatesItems}
     />
   ),
 }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/mockDataMixed.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/mockDataMixed.ts
@@ -751,50 +751,133 @@ const collectionItem: DashboardCollectionItem<DashboardFiltersType> = {
 }
 
 // ---------------------------------------------------------------------------
-// Loading-containment items — exercises the table widget's loading states
+// Widget loading-state items — every widget type on a deliberately slow source
 // ---------------------------------------------------------------------------
 
+/** Delay applied to every fetch below so loading states are human-visible. */
+const SLOW_FETCH_DELAY = 2000
+
+function slow<Args extends unknown[], T>(
+  fetch: (...args: Args) => Promise<T>
+): (...args: Args) => Promise<T> {
+  return (...args) => delay(SLOW_FETCH_DELAY).then(() => fetch(...args))
+}
+
 /**
- * Two table widgets fed by a deliberately slow source (2s per fetch) so the
- * loading states are actually visible:
+ * One row per widget type (metric, chart, collection), all fed through
+ * `slow()` (~2s per fetch) so every loading state is visible on first render
+ * and again on every dashboard-filter change:
  *
- * - a SHORT card (`itemHeight: 220`) where the fixed-size skeleton and the
- *   loaded table are both taller than the widget — the regression case for
- *   skeleton/table containment (they must clip + scroll, never paint past
- *   the card's rounded border), and
- * - a default-height card for reference.
+ * - metrics and charts show their type-specific skeletons via
+ *   `DashboardItem`'s `isLoading`/`skeleton` contract,
+ * - the SHORT table card (`itemHeight: 220`, clamped to the grid's 300px
+ *   minimum) is the containment regression case — its skeleton and loaded
+ *   table are both taller than the card, so they must clip at the rounded
+ *   border and scroll internally instead of painting past it,
+ * - the default-height table is the reference.
  *
- * Changing any dashboard filter re-fires the slow fetch, which shows the
- * reload treatment (table dimmed + spinner overlay pinned to the visible
- * area).
+ * Each item sits in its own grid row where it matters — the grid sizes a row
+ * to the tallest item in it, so sharing a row would override the short
+ * card's `itemHeight`.
  */
-export const loadingContainmentItems: DashboardItem<DashboardFiltersType>[] = [
-  // Each item sits in its own grid row — the grid sizes a row to the tallest
-  // item in it, so sharing a row would override the short card's itemHeight.
+export const widgetLoadingStatesItems: DashboardItem<DashboardFiltersType>[] = [
+  // Row 0 — one metric per format (plain, currency, percent)
+  {
+    id: "loading-total-headcount",
+    title: "Total Headcount",
+    type: "metric",
+    colSpan: 4,
+    x: 0,
+    y: 0,
+    rowSpan: 3,
+    fetchData: slow(fetchTotalHeadcount),
+  },
+  {
+    id: "loading-avg-salary",
+    title: "Avg. Salary",
+    type: "metric",
+    colSpan: 4,
+    x: 4,
+    y: 0,
+    rowSpan: 3,
+    format: { type: "currency", currency: "EUR" },
+    fetchData: slow(fetchAvgSalary),
+  },
+  {
+    id: "loading-attrition",
+    title: "Attrition Rate",
+    type: "metric",
+    colSpan: 4,
+    x: 8,
+    y: 0,
+    rowSpan: 3,
+    format: { type: "percent" },
+    decimals: 1,
+    fetchData: slow(fetchAttritionMetric),
+  },
+  // Row 1 — cartesian + circular chart skeleton variants
+  {
+    id: "loading-bar-chart",
+    title: "Headcount by Department",
+    description: "Bar-chart skeleton while loading",
+    type: "chart",
+    colSpan: 4,
+    x: 0,
+    y: 3,
+    rowSpan: 7,
+    chart: { type: "bar" },
+    fetchData: slow(fetchHeadcountByDepartment),
+  },
+  {
+    id: "loading-line-chart",
+    title: "Revenue Trend",
+    description: "Line-chart skeleton while loading",
+    type: "chart",
+    colSpan: 4,
+    x: 4,
+    y: 3,
+    rowSpan: 7,
+    chart: { type: "line" },
+    fetchData: slow(fetchRevenueTrend),
+  },
+  {
+    id: "loading-pie-chart",
+    title: "Headcount Distribution",
+    description: "Pie-chart skeleton while loading",
+    type: "chart",
+    colSpan: 4,
+    x: 8,
+    y: 3,
+    rowSpan: 7,
+    chart: { type: "pie", innerRadius: 60, showPercentage: true },
+    fetchData: slow(fetchHeadcountPie),
+  },
+  // Row 2 — the containment regression case
   {
     id: "short-employee-table",
-    title: "Short widget",
+    title: "Short table widget",
     description: "Content is taller than the card — must clip and scroll",
     type: "collection",
     colSpan: 12,
     x: 0,
-    y: 0,
+    y: 10,
     // The grid clamps collection rows to MIN_ROW_HEIGHTS (300px), so this
     // renders at 300px — still well below the table's natural height.
     itemHeight: 220,
-    createSource: (filters) => createEmployeeSource(filters, 2000),
+    createSource: (filters) => createEmployeeSource(filters, SLOW_FETCH_DELAY),
     visualizations: [employeeTableVisualization],
   },
+  // Row 3 — reference table at the default collection height
   {
     id: "default-employee-table",
-    title: "Default widget",
+    title: "Default table widget",
     description: "Reference table at the default collection height",
     type: "collection",
     colSpan: 12,
     x: 0,
-    y: 5,
+    y: 15,
     rowSpan: 10,
-    createSource: (filters) => createEmployeeSource(filters, 2000),
+    createSource: (filters) => createEmployeeSource(filters, SLOW_FETCH_DELAY),
     visualizations: [employeeTableVisualization],
   },
 ]

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/mockDataMixed.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/mockDataMixed.ts
@@ -592,7 +592,7 @@ const MOCK_EMPLOYEES: Employee[] = FIRST_NAMES.map((firstName, i) => {
 
 const PER_PAGE = 5
 
-function createEmployeeSource(filters: Filters) {
+function createEmployeeSource(filters: Filters, delayMs = 200) {
   return {
     dataAdapter: {
       paginationType: "pages" as const,
@@ -639,7 +639,7 @@ function createEmployeeSource(filters: Filters) {
               perPage,
               pagesCount: Math.ceil(filtered.length / perPage),
             })
-          }, 200)
+          }, delayMs)
         })
       },
     },
@@ -749,6 +749,55 @@ const collectionItem: DashboardCollectionItem<DashboardFiltersType> = {
   createSource: createEmployeeSource,
   visualizations: [employeeTableVisualization],
 }
+
+// ---------------------------------------------------------------------------
+// Loading-containment items — exercises the table widget's loading states
+// ---------------------------------------------------------------------------
+
+/**
+ * Two table widgets fed by a deliberately slow source (2s per fetch) so the
+ * loading states are actually visible:
+ *
+ * - a SHORT card (`itemHeight: 220`) where the fixed-size skeleton and the
+ *   loaded table are both taller than the widget — the regression case for
+ *   skeleton/table containment (they must clip + scroll, never paint past
+ *   the card's rounded border), and
+ * - a default-height card for reference.
+ *
+ * Changing any dashboard filter re-fires the slow fetch, which shows the
+ * reload treatment (table dimmed + spinner overlay pinned to the visible
+ * area).
+ */
+export const loadingContainmentItems: DashboardItem<DashboardFiltersType>[] = [
+  // Each item sits in its own grid row — the grid sizes a row to the tallest
+  // item in it, so sharing a row would override the short card's itemHeight.
+  {
+    id: "short-employee-table",
+    title: "Short widget",
+    description: "Content is taller than the card — must clip and scroll",
+    type: "collection",
+    colSpan: 12,
+    x: 0,
+    y: 0,
+    // The grid clamps collection rows to MIN_ROW_HEIGHTS (300px), so this
+    // renders at 300px — still well below the table's natural height.
+    itemHeight: 220,
+    createSource: (filters) => createEmployeeSource(filters, 2000),
+    visualizations: [employeeTableVisualization],
+  },
+  {
+    id: "default-employee-table",
+    title: "Default widget",
+    description: "Reference table at the default collection height",
+    type: "collection",
+    colSpan: 12,
+    x: 0,
+    y: 5,
+    rowSpan: 10,
+    createSource: (filters) => createEmployeeSource(filters, 2000),
+    visualizations: [employeeTableVisualization],
+  },
+]
 
 // ---------------------------------------------------------------------------
 // Mixed items — full dashboard with all types and filter reactivity

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/mockDataMixed.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/mockDataMixed.ts
@@ -750,11 +750,6 @@ const collectionItem: DashboardCollectionItem<DashboardFiltersType> = {
   visualizations: [employeeTableVisualization],
 }
 
-// ---------------------------------------------------------------------------
-// Widget loading-state items — every widget type on a deliberately slow source
-// ---------------------------------------------------------------------------
-
-/** Delay applied to every fetch below so loading states are human-visible. */
 const SLOW_FETCH_DELAY = 2000
 
 function slow<Args extends unknown[], T>(
@@ -763,25 +758,8 @@ function slow<Args extends unknown[], T>(
   return (...args) => delay(SLOW_FETCH_DELAY).then(() => fetch(...args))
 }
 
-/**
- * One row per widget type (metric, chart, collection), all fed through
- * `slow()` (~2s per fetch) so every loading state is visible on first render
- * and again on every dashboard-filter change:
- *
- * - metrics and charts show their type-specific skeletons via
- *   `DashboardItem`'s `isLoading`/`skeleton` contract,
- * - the SHORT table card (`itemHeight: 220`, clamped to the grid's 300px
- *   minimum) is the containment regression case — its skeleton and loaded
- *   table are both taller than the card, so they must clip at the rounded
- *   border and scroll internally instead of painting past it,
- * - the default-height table is the reference.
- *
- * Each item sits in its own grid row where it matters — the grid sizes a row
- * to the tallest item in it, so sharing a row would override the short
- * card's `itemHeight`.
- */
+/** Every widget type on a slow (~2s) source. The tables get their own grid rows — a row sizes to its tallest item, which would override the short card's itemHeight. */
 export const widgetLoadingStatesItems: DashboardItem<DashboardFiltersType>[] = [
-  // Row 0 — one metric per format (plain, currency, percent)
   {
     id: "loading-total-headcount",
     title: "Total Headcount",
@@ -815,7 +793,6 @@ export const widgetLoadingStatesItems: DashboardItem<DashboardFiltersType>[] = [
     decimals: 1,
     fetchData: slow(fetchAttritionMetric),
   },
-  // Row 1 — cartesian + circular chart skeleton variants
   {
     id: "loading-bar-chart",
     title: "Headcount by Department",
@@ -852,7 +829,6 @@ export const widgetLoadingStatesItems: DashboardItem<DashboardFiltersType>[] = [
     chart: { type: "pie", innerRadius: 60, showPercentage: true },
     fetchData: slow(fetchHeadcountPie),
   },
-  // Row 2 — the containment regression case
   {
     id: "short-employee-table",
     title: "Short table widget",
@@ -861,13 +837,11 @@ export const widgetLoadingStatesItems: DashboardItem<DashboardFiltersType>[] = [
     colSpan: 12,
     x: 0,
     y: 10,
-    // The grid clamps collection rows to MIN_ROW_HEIGHTS (300px), so this
-    // renders at 300px — still well below the table's natural height.
+    // Clamped to the grid's 300px collection minimum — still shorter than the table
     itemHeight: 220,
     createSource: (filters) => createEmployeeSource(filters, SLOW_FETCH_DELAY),
     visualizations: [employeeTableVisualization],
   },
-  // Row 3 — reference table at the default collection height
   {
     id: "default-employee-table",
     title: "Default table widget",

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardItem/DashboardItem.tsx
@@ -159,7 +159,7 @@ export function DashboardItem({
 
   return (
     <div
-      className="group/dashitem flex h-full flex-col rounded-lg border border-solid border-f1-border-secondary bg-f1-background"
+      className="group/dashitem flex h-full flex-col overflow-hidden rounded-lg border border-solid border-f1-border-secondary bg-f1-background"
       aria-busy={isLoading ? "true" : undefined}
       aria-live={isLoading ? "polite" : undefined}
     >

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
@@ -88,8 +88,6 @@ export function MetricItem<Filters extends FiltersDefinition>({
   actions,
   editMode,
   handleDelete,
-  isFullscreen,
-  onFullscreenChange,
 }: MetricItemProps<Filters>) {
   const enabled = item.useDashboardFilters !== false
   const { data, isLoading, error, retry } = useDashboardItemData<
@@ -112,8 +110,6 @@ export function MetricItem<Filters extends FiltersDefinition>({
       editMode={editMode}
       handleDelete={handleDelete}
       itemId={item.id}
-      isFullscreen={isFullscreen}
-      onFullscreenChange={onFullscreenChange}
     >
       {data && (
         <div className="flex h-full min-h-0 items-end overflow-auto px-4 pb-4">

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
@@ -88,6 +88,8 @@ export function MetricItem<Filters extends FiltersDefinition>({
   actions,
   editMode,
   handleDelete,
+  isFullscreen,
+  onFullscreenChange,
 }: MetricItemProps<Filters>) {
   const enabled = item.useDashboardFilters !== false
   const { data, isLoading, error, retry } = useDashboardItemData<
@@ -110,6 +112,8 @@ export function MetricItem<Filters extends FiltersDefinition>({
       editMode={editMode}
       handleDelete={handleDelete}
       itemId={item.id}
+      isFullscreen={isFullscreen}
+      onFullscreenChange={onFullscreenChange}
     >
       {data && (
         <div className="flex h-full min-h-0 items-end overflow-auto px-4 pb-4">

--- a/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useChartDownloadActions.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useChartDownloadActions.ts
@@ -23,8 +23,6 @@ function getEChartsInstance(
 ): echarts.ECharts | null {
   const el = containerRef.current?.querySelector<HTMLDivElement>(":scope > div")
   const instance = el ? (echarts.getInstanceByDom(el) ?? null) : null
-  // A download action can fire while the dashboard is closing — calling
-  // getDataURL on a disposed instance throws.
   return instance && !instance.isDisposed() ? instance : null
 }
 

--- a/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useChartDownloadActions.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/hooks/useChartDownloadActions.ts
@@ -22,7 +22,10 @@ function getEChartsInstance(
   containerRef: RefObject<HTMLDivElement | null>
 ): echarts.ECharts | null {
   const el = containerRef.current?.querySelector<HTMLDivElement>(":scope > div")
-  return el ? (echarts.getInstanceByDom(el) ?? null) : null
+  const instance = el ? (echarts.getInstanceByDom(el) ?? null) : null
+  // A download action can fire while the dashboard is closing — calling
+  // getDataURL on a disposed instance throws.
+  return instance && !instance.isDisposed() ? instance : null
 }
 
 interface UseChartDownloadActionsOptions {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -89,10 +89,6 @@ const HighlightedCount = ({ text, count }: { text: string; count: number }) => {
   )
 }
 
-// Shared by the skeleton and the loaded table so the swap is pixel-identical
-const borderedWrapperClasses =
-  "overflow-hidden rounded-lg border border-solid border-f1-border-secondary [&_thead::before]:!bg-transparent [&_thead_th>div:first-child]:!bg-transparent [&_tbody>tr:last-child::after]:!bg-transparent"
-
 export const TableCollection = <
   R extends RecordType,
   Filters extends FiltersDefinition,
@@ -331,14 +327,11 @@ export const TableCollection = <
     source.itemsWithChildren?.(item)
   )
 
+  /*
+   * Initial loading
+   */
   if (isInitialLoading) {
-    return (
-      <div className="flex h-full min-h-0 flex-col gap-4">
-        <div className={cn("min-h-0", bordered && borderedWrapperClasses)}>
-          <OneTable.Skeleton columns={skeletonColumns} />
-        </div>
-      </div>
-    )
+    return <OneTable.Skeleton columns={skeletonColumns} />
   }
 
   // Enforce that sorting is only used when sortings are defined
@@ -399,7 +392,13 @@ export const TableCollection = <
       <TableWrapper>
         {/* min-h-0: without it this flex item never shrinks, OneTable's
             internal scroll never engages and tall tables overflow the card */}
-        <div className={cn("min-h-0", bordered && borderedWrapperClasses)}>
+        <div
+          className={cn(
+            "min-h-0",
+            bordered &&
+              "overflow-hidden rounded-lg border border-solid border-f1-border-secondary [&_thead::before]:!bg-transparent [&_thead_th>div:first-child]:!bg-transparent [&_tbody>tr:last-child::after]:!bg-transparent"
+          )}
+        >
           <OneTable loading={isLoading}>
             <TableHeader sticky={true}>
               {headerGroups ? (

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -89,6 +89,15 @@ const HighlightedCount = ({ text, count }: { text: string; count: number }) => {
   )
 }
 
+/**
+ * Wrapper classes for the `bordered` variant, shared by the loading skeleton
+ * and the loaded table so the swap between them is pixel-identical (the
+ * `!bg-transparent` overrides suppress the table's own hairlines, which would
+ * otherwise double up against the wrapper border).
+ */
+const borderedWrapperClasses =
+  "overflow-hidden rounded-lg border border-solid border-f1-border-secondary [&_thead::before]:!bg-transparent [&_thead_th>div:first-child]:!bg-transparent [&_tbody>tr:last-child::after]:!bg-transparent"
+
 export const TableCollection = <
   R extends RecordType,
   Filters extends FiltersDefinition,
@@ -338,13 +347,7 @@ export const TableCollection = <
   if (isInitialLoading) {
     return (
       <div className="flex h-full min-h-0 flex-col gap-4">
-        <div
-          className={cn(
-            "min-h-0",
-            bordered &&
-              "overflow-hidden rounded-lg border border-solid border-f1-border-secondary"
-          )}
-        >
+        <div className={cn("min-h-0", bordered && borderedWrapperClasses)}>
           <OneTable.Skeleton columns={skeletonColumns} />
         </div>
       </div>
@@ -414,13 +417,7 @@ export const TableCollection = <
             dashboard widgets). Without it the wrapper grows with the table's
             content and overflows the widget card instead of scrolling. Tables
             shorter than the available space are unaffected. */}
-        <div
-          className={cn(
-            "min-h-0",
-            bordered &&
-              "overflow-hidden rounded-lg border border-solid border-f1-border-secondary [&_thead::before]:!bg-transparent [&_thead_th>div:first-child]:!bg-transparent [&_tbody>tr:last-child::after]:!bg-transparent"
-          )}
-        >
+        <div className={cn("min-h-0", bordered && borderedWrapperClasses)}>
           <OneTable loading={isLoading}>
             <TableHeader sticky={true}>
               {headerGroups ? (

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -329,9 +329,26 @@ export const TableCollection = <
 
   /*
    * Initial loading
+   *
+   * The skeleton is rendered inside the same wrapper structure as the loaded
+   * table below so the swap doesn't change the widget's height (no layout
+   * jump) and the placeholder rows stay clipped to the same box the real
+   * table will occupy.
    */
   if (isInitialLoading) {
-    return <OneTable.Skeleton columns={skeletonColumns} />
+    return (
+      <div className="flex h-full min-h-0 flex-col gap-4">
+        <div
+          className={cn(
+            "min-h-0",
+            bordered &&
+              "overflow-hidden rounded-lg border border-solid border-f1-border-secondary"
+          )}
+        >
+          <OneTable.Skeleton columns={skeletonColumns} />
+        </div>
+      </div>
+    )
   }
 
   // Enforce that sorting is only used when sortings are defined
@@ -390,8 +407,16 @@ export const TableCollection = <
   return (
     <div className="flex h-full min-h-0 flex-col gap-4">
       <TableWrapper>
+        {/* `min-h-0` lets this wrapper shrink to the height its flex parent
+            assigns (flex items refuse to shrink below their content height by
+            default), so OneTable's internal `h-full` + `overflow-auto` scroll
+            container actually engages in height-constrained contexts (e.g.
+            dashboard widgets). Without it the wrapper grows with the table's
+            content and overflows the widget card instead of scrolling. Tables
+            shorter than the available space are unaffected. */}
         <div
           className={cn(
+            "min-h-0",
             bordered &&
               "overflow-hidden rounded-lg border border-solid border-f1-border-secondary [&_thead::before]:!bg-transparent [&_thead_th>div:first-child]:!bg-transparent [&_tbody>tr:last-child::after]:!bg-transparent"
           )}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -89,12 +89,7 @@ const HighlightedCount = ({ text, count }: { text: string; count: number }) => {
   )
 }
 
-/**
- * Wrapper classes for the `bordered` variant, shared by the loading skeleton
- * and the loaded table so the swap between them is pixel-identical (the
- * `!bg-transparent` overrides suppress the table's own hairlines, which would
- * otherwise double up against the wrapper border).
- */
+// Shared by the skeleton and the loaded table so the swap is pixel-identical
 const borderedWrapperClasses =
   "overflow-hidden rounded-lg border border-solid border-f1-border-secondary [&_thead::before]:!bg-transparent [&_thead_th>div:first-child]:!bg-transparent [&_tbody>tr:last-child::after]:!bg-transparent"
 
@@ -336,14 +331,6 @@ export const TableCollection = <
     source.itemsWithChildren?.(item)
   )
 
-  /*
-   * Initial loading
-   *
-   * The skeleton is rendered inside the same wrapper structure as the loaded
-   * table below so the swap doesn't change the widget's height (no layout
-   * jump) and the placeholder rows stay clipped to the same box the real
-   * table will occupy.
-   */
   if (isInitialLoading) {
     return (
       <div className="flex h-full min-h-0 flex-col gap-4">
@@ -410,13 +397,8 @@ export const TableCollection = <
   return (
     <div className="flex h-full min-h-0 flex-col gap-4">
       <TableWrapper>
-        {/* `min-h-0` lets this wrapper shrink to the height its flex parent
-            assigns (flex items refuse to shrink below their content height by
-            default), so OneTable's internal `h-full` + `overflow-auto` scroll
-            container actually engages in height-constrained contexts (e.g.
-            dashboard widgets). Without it the wrapper grows with the table's
-            content and overflows the widget card instead of scrolling. Tables
-            shorter than the available space are unaffected. */}
+        {/* min-h-0: without it this flex item never shrinks, OneTable's
+            internal scroll never engages and tall tables overflow the card */}
         <div className={cn("min-h-0", bordered && borderedWrapperClasses)}>
           <OneTable loading={isLoading}>
             <TableHeader sticky={true}>


### PR DESCRIPTION
## Description

Factorial's AI analytics dashboards (semantic dashboards / `displayDashboard`) render every widget inside a canvas panel that animates open and is opened/closed a lot. Under those conditions the widgets were unstable: **a table widget's card ignored its configured height and grew when data landed** (shifting the whole grid below it), tall tables overflowed the card instead of scrolling, the reload spinner scrolled out of view, charts initialized while the panel was still 0-sized or mid-animation (blank charts, warnings, axis labels popping in at the end of the animation), and every dashboard close logged "[ECharts] Instance has been disposed" three times.

This PR makes widget geometry and chart lifecycle **stable** — a widget's configured height becomes a promise the grid can rely on. It changes **no visual styling**: skeletons, spacing, colors and the native chart entrance animation are untouched.

## What changed, in plain words

**Tables (`OneDataCollection` / `OneTable` / `DashboardItem`)**

1. **Widget cards keep their configured height.** A missing `min-h-0` meant the table wrapper refused to shrink, so when data landed the card grew to fit its content — measured in the regression story: the card jumps **+63px** and every widget below shifts. Now the card stays put and the table scrolls internally, with pagination pinned inside.
2. **The widget card clips its content** (`overflow-hidden`, matching its own error state) and the table skeleton clips its fixed-size placeholder rows — nothing paints past the rounded border in cards shorter than the content.
3. **The reload spinner stays visible.** It lived inside the scroll container, so on a scrolled table it scrolled out of view. It now overlays the visible area at any scroll position.

**Charts (`F0DataChart`)**

4. **Charts wait for a real, settled size before initializing.** Init used to run while the container was 0-sized or still growing — "Can't get DOM width or height" warnings, blank charts, or a chart painted at a smaller breakpoint whose axis labels popped in at the end of the panel animation and nudged the grid. The settle check re-verifies size when it fires, so the chart appears once, fully formed. Containers that mount already sized initialize synchronously, exactly as before.
5. **Exactly one first paint.** A redundant `setOption` right after init used to rebuild the chart a beat after it appeared — restarting the entrance animation.
6. **Closing a dashboard is silent.** The chart was disposed before sibling listener hooks ran their cleanups, logging three warnings per close. Post-dispose calls are guarded and listener hooks re-attach correctly on late init.

## See it in Storybook

Run `pnpm dev` in `packages/react`, then:

| Story | What to look at |
|---|---|
| [Patterns → AnalyticsDashboard → **Widget Loading States**](http://localhost:6006/?path=/story/patterns-analyticsdashboard--widget-loading-states) | Watch the **Short table widget**'s bottom edge when its slow (~2s) data lands: on `main` the card grows +63px and the grid shifts; here it doesn't move — the table scrolls inside and pagination stays pinned. Fixes 1–3. |
| [Kits → F0DataChart → Lifecycle → **Init Inside Animated Panel**](http://localhost:6006/?path=/story/kits-f0datachart-lifecycle--init-inside-animated-panel) | A chart mounted inside a 0-sized panel that expands via CSS transition. Console stays clean while collapsed; on expand the chart appears once, complete with axis labels. Fixes 4–5. |
| [Kits → F0DataChart → Lifecycle → **Mount Unmount Churn**](http://localhost:6006/?path=/story/kits-f0datachart-lifecycle--mount-unmount-churn) | Toggle the chart repeatedly with the console open — zero "has been disposed" warnings. Fix 6. |

On `main`, the same stories show the broken behaviors.

## Verification

- Foreground DOM probe on the Widget Loading States story, both sides: `main` = card 300px during load → **363px** after data (content past the configured boundary, grid shifted); this branch = **300px throughout, zero movement**.
- Verified end-to-end in the consuming app (local Factorial stack with this build linked): dashboard cards hold steady through load, exactly one clean chart paint per open, zero ECharts console messages across repeated open/close.
- 208 unit tests green across the touched suites (OneTable, Table visualization, F0AnalyticsDashboard, F0DataChart), including new regression tests for overlay placement and skeleton clipping; `tsc`, `oxlint`, `oxfmt` clean.
- Scope was deliberately trimmed: a skeleton-wrapper restyle and the metric fullscreen prop forwarding were removed after review showed no user-visible benefit in this PR's scope (the latter is a candidate for its own PR).

## Related

- Factorial app side of this initiative (cross-mount compute dedup): factorialco/factorial#105619.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
