### PR TITLE
fix(F0Graph): reliable focus via imperative focusNode/clearSelection

### DIFF
--- a/packages/react/src/patterns/F0Graph/F0Graph.tsx
+++ b/packages/react/src/patterns/F0Graph/F0Graph.tsx
@@ -1,5 +1,5 @@
 import { ReactFlowProvider } from "@xyflow/react"
-import { type ReactNode } from "react"
+import { forwardRef, type ForwardedRef, type ReactNode, type Ref } from "react"
 
 import "./F0Graph.css"
 import { F0GraphView } from "./components/F0GraphView"
@@ -110,6 +110,13 @@ export interface F0GraphProps<T = unknown> {
   onPaneClick?: () => void
 
   // ---- Navigation ----
+  /**
+   * Id of a node to fly to (center on) when the value **changes**. Because it
+   * only reacts to a value change, re-selecting the **same** node (e.g.
+   * searching the same employee twice after panning away) will NOT re-fly — for
+   * that "always fly on the action" behavior, call the imperative
+   * `focusNode(id)` on the graph ref instead (see {@link F0GraphHandle}).
+   */
   focusedNode?: string
   highlightedNodes?: Set<string>
   /**
@@ -253,6 +260,30 @@ export interface F0GraphProps<T = unknown> {
   onRenderedNodesChange?: (count: number) => void
 }
 
+// ─── Imperative handle ─────────────────────────────────────────
+/**
+ * Imperative API exposed via a ref on `<F0Graph>`. Use for actions that should
+ * fire every time they're invoked, regardless of whether any prop changed —
+ * the canonical case is a search box that re-centers on a result even when the
+ * user picks the same node twice.
+ */
+export interface F0GraphHandle {
+  /**
+   * Fly to (center on) a node, animating from the current viewport. Always
+   * runs, even if the node is already focused/centered — unlike the
+   * `focusedNode` prop, which only reacts to a value change. Frames the node
+   * with its direct children (capped zoom); safe with node windowing (an
+   * off-screen target is centered via its layout position).
+   */
+  focusNode: (nodeId: string) => void
+  /**
+   * Clear the graph's own node selection (the ring set on click). Use when the
+   * consumer marks a node another way — e.g. `highlightedNodes` for a search /
+   * "Find me" reveal — so the two don't leave two nodes marked at once.
+   */
+  clearSelection: () => void
+}
+
 // ─── Custom Node Type for React Flow ───────────────────────────
 /**
  * Behavior context passed to consumer's `renderNode`. Describes how F0Graph
@@ -296,12 +327,19 @@ export interface F0GraphNodeRenderContext {
 }
 
 // ─── Public component (wraps the view in a ReactFlowProvider) ──────────────
-export function F0Graph<T = unknown>(props: F0GraphProps<T>) {
+function F0GraphInner<T = unknown>(
+  props: F0GraphProps<T>,
+  ref: ForwardedRef<F0GraphHandle>
+) {
   return (
     <ReactFlowProvider>
-      <F0GraphView {...props} />
+      <F0GraphView {...props} handleRef={ref} />
     </ReactFlowProvider>
   )
 }
 
-F0Graph.displayName = "F0Graph"
+export const F0Graph = forwardRef(F0GraphInner) as <T = unknown>(
+  props: F0GraphProps<T> & { ref?: Ref<F0GraphHandle> }
+) => ReturnType<typeof F0GraphInner>
+
+;(F0Graph as { displayName?: string }).displayName = "F0Graph"

--- a/packages/react/src/patterns/F0Graph/__tests__/F0Graph.imperative.test.tsx
+++ b/packages/react/src/patterns/F0Graph/__tests__/F0Graph.imperative.test.tsx
@@ -1,0 +1,126 @@
+import { act } from "@testing-library/react"
+import { createRef } from "react"
+import { beforeAll, describe, expect, it, vi } from "vitest"
+
+import { zeroRender, screen } from "@/testing/test-utils"
+
+import type { GraphNode } from "../types"
+
+import {
+  F0Graph,
+  type F0GraphHandle,
+  type F0GraphNodeRenderContext,
+} from "../F0Graph"
+
+// ─── Helpers ───────────────────────────────────────────────────
+
+function makeNodes(): GraphNode<string>[] {
+  return [
+    { id: "1", parentId: null, data: "CEO", childrenCount: 2 },
+    { id: "2", parentId: "1", data: "CTO", childrenCount: 0 },
+    { id: "3", parentId: "1", data: "CFO", childrenCount: 0 },
+  ]
+}
+
+function renderNodeFn(node: GraphNode<string>, ctx: F0GraphNodeRenderContext) {
+  return (
+    <div
+      ref={ctx.nodeRef}
+      role="treeitem"
+      tabIndex={ctx.tabIndex}
+      data-testid={`node-${node.id}`}
+      data-state={ctx.state}
+      onClick={ctx.onClick}
+    >
+      {node.data}
+    </div>
+  )
+}
+
+function dispatchKey(element: HTMLElement, key: string) {
+  act(() => {
+    element.dispatchEvent(
+      new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true })
+    )
+  })
+}
+
+// React Flow needs ResizeObserver; jsdom doesn't provide it.
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  }
+})
+
+// ─── Imperative handle ─────────────────────────────────────────
+
+describe("F0Graph — imperative handle", () => {
+  it("exposes focusNode and clearSelection on the ref", () => {
+    const ref = createRef<F0GraphHandle>()
+    zeroRender(
+      <div style={{ width: 800, height: 600 }}>
+        <F0Graph ref={ref} nodes={makeNodes()} renderNode={renderNodeFn} />
+      </div>
+    )
+
+    expect(typeof ref.current?.focusNode).toBe("function")
+    expect(typeof ref.current?.clearSelection).toBe("function")
+  })
+
+  it("clearSelection() drops the current click selection", () => {
+    const ref = createRef<F0GraphHandle>()
+    const onSelectedNodesChange = vi.fn()
+    zeroRender(
+      <div style={{ width: 800, height: 600 }}>
+        <F0Graph
+          ref={ref}
+          nodes={makeNodes()}
+          renderNode={renderNodeFn}
+          selectionMode="single"
+          defaultExpandedNodes={new Set(["1"])}
+          onSelectedNodesChange={onSelectedNodesChange}
+        />
+      </div>
+    )
+
+    // Select the first focused node via keyboard.
+    const tree = screen.getByRole("tree", { name: "Graph view" })
+    dispatchKey(tree, "Enter")
+    expect(onSelectedNodesChange.mock.calls.at(-1)?.[0]).toEqual(new Set(["1"]))
+
+    onSelectedNodesChange.mockClear()
+    act(() => ref.current?.clearSelection())
+
+    // Selection is cleared back to an empty set.
+    expect(onSelectedNodesChange).toHaveBeenCalledWith(new Set())
+    expect(screen.getByTestId("node-1")).toHaveAttribute(
+      "data-state",
+      "default"
+    )
+  })
+
+  it("focusNode() can be called repeatedly for the same node without throwing", () => {
+    const ref = createRef<F0GraphHandle>()
+    zeroRender(
+      <div style={{ width: 800, height: 600 }}>
+        <F0Graph
+          ref={ref}
+          nodes={makeNodes()}
+          renderNode={renderNodeFn}
+          defaultExpandedNodes={new Set(["1"])}
+        />
+      </div>
+    )
+
+    // The declarative `focusedNode` prop can't re-fly on an unchanged value;
+    // the imperative call must run every time (here: not throw across repeats).
+    expect(() =>
+      act(() => {
+        ref.current?.focusNode("2")
+        ref.current?.focusNode("2")
+      })
+    ).not.toThrow()
+  })
+})

--- a/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
+++ b/packages/react/src/patterns/F0Graph/components/F0GraphView/F0GraphView.tsx
@@ -8,10 +8,12 @@ import {
   type NodeTypes,
 } from "@xyflow/react"
 import {
+  type ForwardedRef,
   type ReactNode,
   memo,
   useCallback,
   useEffect,
+  useImperativeHandle,
   useMemo,
   useRef,
   useState,
@@ -37,7 +39,11 @@ import {
   F0GraphZoomContext,
   useF0GraphRenderConfigInternal,
 } from "../../contexts"
-import type { F0GraphNodeRenderContext, F0GraphProps } from "../../F0Graph"
+import type {
+  F0GraphHandle,
+  F0GraphNodeRenderContext,
+  F0GraphProps,
+} from "../../F0Graph"
 import { useExpandState } from "../../hooks/useExpandState"
 import { useGraphKeyboard } from "../../hooks/useGraphKeyboard"
 import { useGraphRenderModel } from "../../hooks/useGraphRenderModel"
@@ -125,8 +131,11 @@ const customEdgeTypes: EdgeTypes = {
 }
 
 // ─── View (consumes ReactFlow hooks via the provider in the shell) ─────────
-export function F0GraphView<T = unknown>(props: F0GraphProps<T>) {
+export function F0GraphView<T = unknown>(
+  props: F0GraphProps<T> & { handleRef?: ForwardedRef<F0GraphHandle> }
+) {
   const {
+    handleRef,
     nodes: nodesProp,
     edges: edgesProp,
     rootNodes,
@@ -498,10 +507,21 @@ export function F0GraphView<T = unknown>(props: F0GraphProps<T>) {
     // store, so center on its layout position instead of an id-based fitView
     // (which silently no-ops for a missing node).
     if (enableNodeWindowing && centerOnNode(id, 300)) return
+    // Frame the node together with its (present) direct children and cap the
+    // zoom, so navigation lands with surrounding context instead of zooming a
+    // single node to `maxZoom` (2×) — same framing as the `initialFocusNodeId`
+    // first frame.
+    const childIds = nodeMap.get(id)?.children.map((c) => c.id) ?? []
+    const framed = resolveInitialFitViewNodes(
+      id,
+      childIds,
+      new Set(renderedNodeIds)
+    )
     reactFlow.fitView({
-      nodes: [{ id }],
+      nodes: framed ?? [{ id }],
       duration: 300,
       padding: FIT_VIEW_PADDING_LOOSE,
+      maxZoom: Math.min(INITIAL_FOCUS_MAX_ZOOM, maxZoom),
     })
   }
   useEffect(() => {
@@ -516,6 +536,22 @@ export function F0GraphView<T = unknown>(props: F0GraphProps<T>) {
     )
     return () => clearTimeout(timer)
   }, [focusedNode])
+
+  // Imperative API: `focusNode` fires on every call, independent of prop
+  // values, so a consumer's search can re-center on the same node the user
+  // picks twice (the `focusedNode` prop can't — an unchanged value never
+  // re-runs its effect). `clearSelection` lets the consumer drop the click ring
+  // when it marks a node another way (e.g. a search / "Find me" highlight).
+  const clearSelectionRef = useRef<() => void>(() => {})
+  clearSelectionRef.current = clearSelection
+  useImperativeHandle(
+    handleRef,
+    () => ({
+      focusNode: (nodeId: string) => flyToFocusedRef.current(nodeId),
+      clearSelection: () => clearSelectionRef.current(),
+    }),
+    []
+  )
 
   // ── Split context values (wrappers subscribe to only what they need) ──
   const zoomContextValue = useMemo(

--- a/packages/react/src/patterns/F0Graph/index.tsx
+++ b/packages/react/src/patterns/F0Graph/index.tsx
@@ -5,6 +5,8 @@ export { F0GraphSkeleton } from "./F0GraphSkeleton"
 export type { F0GraphSkeletonProps } from "./F0GraphSkeleton"
 /** Props for configuring F0Graph — data, rendering, zoom, selection, layout, and customization. */
 export type { F0GraphProps } from "./F0Graph"
+/** Imperative handle (via ref) — exposes `focusNode(id)` to fly to a node on demand, even when re-selecting the same node. */
+export type { F0GraphHandle } from "./F0Graph"
 /** Render context passed to the renderNode callback. */
 export type { F0GraphNodeRenderContext } from "./F0Graph"
 

--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -1660,6 +1660,7 @@ const OneDataCollectionComp = <
           onLoadData={onLoadData}
           onLoadError={onLoadError}
           tmpFullWidth={tmpFullWidth}
+          searchSelectionNonce={searchPreview.selectionNonce}
         />
       </div>
       {emptyState ? (

--- a/packages/react/src/patterns/OneDataCollection/components/Search/useSearchPreview.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/components/Search/useSearchPreview.test.ts
@@ -61,6 +61,39 @@ describe("useSearchPreview", () => {
     expect(onSelect).toHaveBeenCalledWith(people[1])
   })
 
+  it("bumps selectionNonce on every pick, including a repeat of the same record", async () => {
+    const preview = buildPreview(vi.fn())
+    const { result, rerender } = renderHook(
+      ({ query }) => useSearchPreview(preview, query),
+      { initialProps: { query: "" as string | undefined } }
+    )
+
+    rerender({ query: "alan" })
+    await waitFor(() => expect(result.current.results).toHaveLength(1))
+
+    expect(result.current.selectionNonce).toBe(0)
+    act(() => result.current.onSelect("2"))
+    expect(result.current.selectionNonce).toBe(1)
+    // Re-picking the same record still advances the nonce, so a consumer can
+    // re-fire (e.g. re-center the graph) even though its derived id is unchanged.
+    act(() => result.current.onSelect("2"))
+    expect(result.current.selectionNonce).toBe(2)
+  })
+
+  it("does not bump selectionNonce when the id matches no loaded record", async () => {
+    const preview = buildPreview(vi.fn())
+    const { result, rerender } = renderHook(
+      ({ query }) => useSearchPreview(preview, query),
+      { initialProps: { query: "" as string | undefined } }
+    )
+
+    rerender({ query: "alan" })
+    await waitFor(() => expect(result.current.results).toHaveLength(1))
+
+    act(() => result.current.onSelect("does-not-exist"))
+    expect(result.current.selectionNonce).toBe(0)
+  })
+
   it("clears results when the query is empty", async () => {
     const preview = buildPreview(vi.fn())
     const { result, rerender } = renderHook(

--- a/packages/react/src/patterns/OneDataCollection/components/Search/useSearchPreview.ts
+++ b/packages/react/src/patterns/OneDataCollection/components/Search/useSearchPreview.ts
@@ -9,6 +9,14 @@ type UseSearchPreviewReturn = {
   results: SearchResultItem[]
   loading: boolean
   onSelect: (id: string) => void
+  /**
+   * Increments on every result selection. Consumers derive their own state
+   * from `onSelect` (e.g. a graph `revealNodeId`), but re-picking the same
+   * result leaves that state unchanged — so this monotonic nonce lets a
+   * visualization re-fire its action on a repeat pick (the graph re-centers on
+   * the same node, like "Find me").
+   */
+  selectionNonce: number
 }
 
 /**
@@ -23,6 +31,7 @@ export function useSearchPreview<R extends RecordType>(
 ): UseSearchPreviewReturn {
   const [results, setResults] = useState<SearchResultItem[]>([])
   const [loading, setLoading] = useState(false)
+  const [selectionNonce, setSelectionNonce] = useState(0)
   const recordsRef = useRef<R[]>([])
   const searchPreviewRef = useRef(searchPreview)
   searchPreviewRef.current = searchPreview
@@ -60,8 +69,14 @@ export function useSearchPreview<R extends RecordType>(
     const record = recordsRef.current.find(
       (candidate) => preview.getId(candidate) === id
     )
-    if (record) preview.onSelect(record)
+    if (record) {
+      preview.onSelect(record)
+      // Bump AFTER forwarding, so the consumer's derived state (e.g. a new
+      // `revealNodeId`) and this nonce land in the same React batch — the graph
+      // sees the (possibly unchanged) id and a fresh nonce together.
+      setSelectionNonce((n) => n + 1)
+    }
   }
 
-  return { results, loading, onSelect }
+  return { results, loading, onSelect, selectionNonce }
 }

--- a/packages/react/src/patterns/OneDataCollection/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/types.ts
@@ -108,4 +108,11 @@ export type CollectionProps<
   tmpFullWidth?: boolean
   /** Indicates the source visualization type */
   fromVisualization?: TableVisualizationType
+  /**
+   * Bumps on every shared-search result selection. Lets a visualization
+   * re-fire its reveal/focus even when the selected record (hence the derived
+   * reveal target) is unchanged — so re-searching the same node re-centers,
+   * like the graph's "Find me". Only the graph view reads it today.
+   */
+  searchSelectionNonce?: number
 } & VisualizationOptions

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/reveal.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/__tests__/reveal.test.ts
@@ -15,6 +15,7 @@ describe("resolveGraphReveal", () => {
       revealId: null,
       consumeInitial: false,
       lastRevealed: undefined,
+      lastNonce: undefined,
     })
   })
 
@@ -42,14 +43,48 @@ describe("resolveGraphReveal", () => {
     expect(d.lastRevealed).toBe("search-2")
   })
 
-  it("does not re-reveal the same search selection", () => {
+  it("does not re-reveal the same search selection on a plain re-render", () => {
+    // Same id, same nonce → nothing changed, so no reveal.
     const d = resolveGraphReveal({
       isInitialLoading: false,
       initialConsumed: true,
       revealNodeId: "search-2",
       lastRevealed: "search-2",
+      revealNonce: 3,
+      lastNonce: 3,
     })
     expect(d.revealId).toBeNull()
     expect(d.lastRevealed).toBe("search-2")
+    expect(d.lastNonce).toBe(3)
+  })
+
+  it("re-reveals the same node when the search nonce bumps (repeat pick)", () => {
+    // Re-picking the same node in the shared search bumps the nonce even though
+    // the id is unchanged — so it re-centers, like "Find me".
+    const d = resolveGraphReveal({
+      isInitialLoading: false,
+      initialConsumed: true,
+      revealNodeId: "search-2",
+      lastRevealed: "search-2",
+      revealNonce: 4,
+      lastNonce: 3,
+    })
+    expect(d.revealId).toBe("search-2")
+    expect(d.lastRevealed).toBe("search-2")
+    expect(d.lastNonce).toBe(4)
+  })
+
+  it("adopts the entry nonce as handled without revealing", () => {
+    const d = resolveGraphReveal({
+      isInitialLoading: false,
+      initialConsumed: false,
+      revealNodeId: "search-1",
+      lastRevealed: undefined,
+      revealNonce: 2,
+      lastNonce: undefined,
+    })
+    expect(d.revealId).toBeNull()
+    expect(d.consumeInitial).toBe(true)
+    expect(d.lastNonce).toBe(2)
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/index.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/index.tsx
@@ -67,6 +67,7 @@ export const GraphCollection = <
   childrenFilters,
   defaultExpandDepth,
   revealNodeId,
+  searchSelectionNonce,
   focusOnEntry,
   loadNodePath,
   getParentId,
@@ -154,7 +155,10 @@ export const GraphCollection = <
   // focus is handled instead by `focusOnEntry`, which the tree-data hook
   // pre-resolves before first paint so F0Graph opens framed on it (no pan).
   // The decision lives in the pure `resolveGraphReveal`.
+  // `searchSelectionNonce` bumps on every shared-search pick, so re-selecting
+  // the SAME node still re-reveals/re-centers (the id alone wouldn't change).
   const lastRevealedRef = useRef<string | undefined>(undefined)
+  const lastNonceRef = useRef<number | undefined>(undefined)
   const initialRevealConsumedRef = useRef(false)
   useEffect(() => {
     if (isInitialLoading) return
@@ -163,11 +167,14 @@ export const GraphCollection = <
       initialConsumed: initialRevealConsumedRef.current,
       revealNodeId,
       lastRevealed: lastRevealedRef.current,
+      revealNonce: searchSelectionNonce,
+      lastNonce: lastNonceRef.current,
     })
     if (decision.consumeInitial) initialRevealConsumedRef.current = true
     lastRevealedRef.current = decision.lastRevealed
+    lastNonceRef.current = decision.lastNonce
     if (decision.revealId) void revealAndFocus(decision.revealId)
-  }, [revealNodeId, revealAndFocus, isInitialLoading])
+  }, [revealNodeId, searchSelectionNonce, revealAndFocus, isInitialLoading])
 
   // Clear the shared header search when ENTERING and LEAVING the graph view, so
   // it never points at a node here (the graph is a tree, not a filtered list).

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/index.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react"
+import { useCallback, useEffect, useRef } from "react"
 
 import {
   GroupingDefinition,
@@ -6,7 +6,12 @@ import {
   SortingsDefinition,
 } from "@/hooks/datasource"
 import { FiltersDefinition } from "@/patterns/OneFilterPicker/types"
-import { F0Graph, F0GraphNode, F0GraphSkeleton } from "@/patterns/F0Graph"
+import {
+  F0Graph,
+  type F0GraphHandle,
+  F0GraphNode,
+  F0GraphSkeleton,
+} from "@/patterns/F0Graph"
 
 import { useDataCollectionSettings } from "../../../Settings/SettingsProvider"
 import { ItemActionsDefinition } from "../../../item-actions"
@@ -123,6 +128,26 @@ export const GraphCollection = <
     { onLoadData, onLoadError }
   )
 
+  // Imperative handle to the graph, for actions the declarative props can't
+  // express: re-centering on a node that is already the focus target (the
+  // `focusedNode` prop only reacts to value changes), and dropping the click
+  // selection when a reveal marks a node via `highlightedNodes` instead.
+  const graphRef = useRef<F0GraphHandle>(null)
+
+  // Reveal + focus a node: load/expand it (declarative `focusedNode` handles
+  // the first fly, with the right async + settle timing), then imperatively
+  // re-center — so re-searching the SAME node after panning still flies — and
+  // clear the click selection so it doesn't stay marked alongside the reveal
+  // highlight.
+  const revealAndFocus = useCallback(
+    async (nodeId: string): Promise<void> => {
+      await revealNode(nodeId)
+      graphRef.current?.clearSelection()
+      graphRef.current?.focusNode(nodeId)
+    },
+    [revealNode]
+  )
+
   // Reveal driver. The graph never auto-focuses on entry via this path: the
   // initial `revealNodeId` is adopted as "already handled", and only LATER
   // changes (a fresh search selection) reveal — with the smooth pan. Entry
@@ -141,8 +166,8 @@ export const GraphCollection = <
     })
     if (decision.consumeInitial) initialRevealConsumedRef.current = true
     lastRevealedRef.current = decision.lastRevealed
-    if (decision.revealId) void revealNode(decision.revealId)
-  }, [revealNodeId, revealNode, isInitialLoading])
+    if (decision.revealId) void revealAndFocus(decision.revealId)
+  }, [revealNodeId, revealAndFocus, isInitialLoading])
 
   // Clear the shared header search when ENTERING and LEAVING the graph view, so
   // it never points at a node here (the graph is a tree, not a filtered list).
@@ -194,6 +219,7 @@ export const GraphCollection = <
         <F0GraphSkeleton showTags={tags !== undefined} />
       ) : (
         <F0Graph<Record>
+          ref={graphRef}
           nodes={nodes}
           expandedNodes={expandedNodes}
           onExpandedNodesChange={setExpandedNodes}
@@ -203,6 +229,16 @@ export const GraphCollection = <
           initialFocusNodeId={focusOnEntry}
           highlightedNodes={highlightedNodes}
           selectionMode="single"
+          // Selecting a node marks it via the internal selection ring; drop the
+          // reveal highlight (search / "Find me") so only one node stays marked.
+          // Fires with the new set — a non-empty set means a real selection (an
+          // empty set is a pane click or our own `clearSelection()` on reveal,
+          // which must NOT wipe the highlight we just set). Centering lives on
+          // the node's own click (below) so a click on the empty canvas never
+          // re-centers.
+          onSelectedNodesChange={(next) => {
+            if (next.size > 0) clearFocus()
+          }}
           showControls={showControls ?? true}
           zoomPreset={zoomPreset}
           minZoom={minZoom}
@@ -220,7 +256,11 @@ export const GraphCollection = <
           onFocusUser={
             // Return the reveal promise so the "Find me" button shows a loading
             // spinner while it loads the path, expands and centers the node.
-            currentUserNodeId ? () => revealNode(currentUserNodeId) : undefined
+            // `revealAndFocus` also re-centers on repeat presses and clears any
+            // click selection so it doesn't stay marked alongside the reveal.
+            currentUserNodeId
+              ? () => revealAndFocus(currentUserNodeId)
+              : undefined
           }
           onPaneClick={clearFocus}
           renderNode={(node, ctx) => {
@@ -239,6 +279,9 @@ export const GraphCollection = <
                 hoverCard
                 onClick={() => {
                   ctx.onClick()
+                  // Center on the node the user actually clicked (never fires on
+                  // an empty-canvas click); re-centers even on a repeat click.
+                  graphRef.current?.focusNode(ctx.nodeId)
                   itemOnClick?.()
                 }}
               />

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/reveal.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/reveal.ts
@@ -7,6 +7,15 @@ interface RevealState {
   revealNodeId?: string
   /** Last `revealNodeId` we adopted/acted on, to detect a *new* search pick. */
   lastRevealed?: string
+  /**
+   * Monotonic counter bumped by the shared search on every result selection.
+   * Lets us re-reveal the SAME `revealNodeId` when the user picks it again
+   * (the id alone can't distinguish a repeat pick from a no-op re-render), so
+   * re-searching a node re-centers just like "Find me".
+   */
+  revealNonce?: number
+  /** Last `revealNonce` we acted on, to detect a repeat pick of the same node. */
+  lastNonce?: number
 }
 
 interface RevealDecision {
@@ -16,6 +25,8 @@ interface RevealDecision {
   consumeInitial: boolean
   /** The value `lastRevealed` should take after this run. */
   lastRevealed: string | undefined
+  /** The value `lastNonce` should take after this run. */
+  lastNonce: number | undefined
 }
 
 /**
@@ -28,32 +39,40 @@ interface RevealDecision {
  *   "already handled" so an initial search value doesn't yank the view. (Entry
  *   focus is handled separately by `focusOnEntry` → `initialFocusNodeId`, which
  *   frames the node on the first paint without a reveal/pan.)
- * - Later renders: reveal `revealNodeId` only when it *changes* (a fresh search
- *   selection). "Find me" reveals via the controls, outside this path.
+ * - Later renders: reveal `revealNodeId` when it *changes* (a fresh search
+ *   selection) OR when `revealNonce` changes with the id unchanged (the user
+ *   re-picked the same node — re-center it, like "Find me"). "Find me" itself
+ *   reveals via the controls, outside this path.
  */
 export function resolveGraphReveal({
   isInitialLoading,
   initialConsumed,
   revealNodeId,
   lastRevealed,
+  revealNonce,
+  lastNonce,
 }: RevealState): RevealDecision {
   if (isInitialLoading) {
-    return { revealId: null, consumeInitial: false, lastRevealed }
+    return { revealId: null, consumeInitial: false, lastRevealed, lastNonce }
   }
   if (!initialConsumed) {
-    // Adopt the current search value as handled; never reveal on entry.
+    // Adopt the current search value + nonce as handled; never reveal on entry.
     return {
       revealId: null,
       consumeInitial: true,
       lastRevealed: revealNodeId,
+      lastNonce: revealNonce,
     }
   }
-  if (revealNodeId && revealNodeId !== lastRevealed) {
+  const idChanged = revealNodeId !== lastRevealed
+  const nonceChanged = revealNonce !== lastNonce
+  if (revealNodeId && (idChanged || nonceChanged)) {
     return {
       revealId: revealNodeId,
       consumeInitial: false,
       lastRevealed: revealNodeId,
+      lastNonce: revealNonce,
     }
   }
-  return { revealId: null, consumeInitial: false, lastRevealed }
+  return { revealId: null, consumeInitial: false, lastRevealed, lastNonce }
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/VisualizationRenderer.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/VisualizationRenderer.tsx
@@ -50,6 +50,7 @@ export const VisualizationRenderer = <
   onLoadData,
   onLoadError,
   tmpFullWidth,
+  searchSelectionNonce,
 }: {
   visualization: Visualization<
     R,
@@ -74,6 +75,8 @@ export const VisualizationRenderer = <
   onLoadError: OnLoadErrorCallback
   clearSelectedItems?: () => void
   tmpFullWidth?: boolean
+  /** Bumped on every shared-search selection; forwarded to the visualization. */
+  searchSelectionNonce?: number
 }): JSX.Element => {
   if (visualization.type === "custom") {
     return visualization.component({
@@ -110,5 +113,6 @@ export const VisualizationRenderer = <
     onLoadData,
     onLoadError,
     tmpFullWidth,
+    searchSelectionNonce,
   })
 }


### PR DESCRIPTION
## Description

Fixes two focus/navigation defects in the F0 Graph / org chart ([FCT-58527](https://factorialmakers.atlassian.net/browse/FCT-58527)): re-searching a node that is already the focus target now re-centers the viewport every time, and clicking a node followed by "Find me"/search no longer leaves two nodes marked at once. Both are solved by giving `F0Graph` an imperative handle so navigation actions run on every invocation rather than only on prop-value changes.

## Screenshots

### Before (multiple selects)
<img width="605" height="575" alt="Screenshot 2026-07-13 at 17 44 08" src="https://github.com/user-attachments/assets/494928c2-e7c6-46d4-8162-30b4eff82cb3" />

### After
<img width="440" height="237" alt="Screenshot 2026-07-13 at 17 54 31" src="https://github.com/user-attachments/assets/e745ddbd-09e0-4625-97f5-75381e02f77d" />


https://github.com/user-attachments/assets/e6f19957-97f7-4d22-8bc1-c81522aae368



## Implementation details

- feat: expose an imperative `F0GraphHandle` (via `ref`) with `focusNode(id)` and `clearSelection()`, exported from `@/patterns/F0Graph`

  <details>
  <summary>Why?</summary>

  Focus was driven only by the `focusedNode` prop, whose effect never re-runs on an unchanged value — so re-selecting the same node (e.g. searching the same employee after panning away) did nothing. An imperative call always fires. The fly-to logic is now held in a stable ref reused by both the declarative effect and the handle.
  </details>

- fix: re-center on repeated search/"Find me" by calling `focusNode` from the org chart's reveal path, alongside the declarative `focusedNode` prop (kept for the first reveal's async load + settle timing)
- fix: keep at most one node marked — reveal clears the click selection (`clearSelection`) and a node click clears the reveal highlight, so the `selectedNodes` and `highlightedNodes` ring channels no longer coexist on different nodes
- test: add `F0Graph.imperative.test.tsx` covering the handle surface and selection clearing

[FCT-58527]: https://factorialmakers.atlassian.net/browse/FCT-58527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ