### PR TITLE
feat(OneDataCollection): support tooltip on single primary action

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/actions/actions.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/actions/actions.mdx
@@ -59,6 +59,11 @@ const dataSource = useDataCollectionSource({
     loading: true,
     // The disabled state of the action
     disabled: false,
+    // Optional tooltip shown around the button. Receives the disabled and
+    // loading states and returns the tooltip text, or undefined to hide it.
+    // Useful to explain why the action is disabled.
+    tooltip: ({ disabled }) =>
+      disabled ? "Explain why the action is disabled" : undefined,
   }),
 })
 ```
@@ -88,9 +93,9 @@ const dataSource = useDataCollectionSource({
 })
 ```
 
-> ⚠️ The disabled or loading state of the action is not supported in the
-> F0ButtonDropdown component yet so this only works when the actions is a single
-> action.
+> ⚠️ The disabled or loading state and the tooltip of the action are not
+> supported in the F0ButtonDropdown component yet so they only work when the
+> actions is a single action.
 
 - **Secondary actions**: Are an array of actions and by defualt are displayed a
   dropdown. But you can define the number of actions to display as a secondary

--- a/packages/react/src/patterns/OneDataCollection/__stories__/actions/collection-actions.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/actions/collection-actions.stories.tsx
@@ -199,6 +199,27 @@ export const BasicActionsExample: Story = {
   },
 }
 
+// Disabled primary action with a tooltip explaining why it is disabled.
+export const DisabledPrimaryActionWithTooltipExample: Story = {
+  render: () => {
+    const dataSource = useDataCollectionSource({
+      dataAdapter: {
+        fetchData: () => Promise.resolve({ records: mockUsers }),
+      },
+      primaryActions: () => ({
+        label: "Process payroll results",
+        icon: Ai,
+        onClick: () => console.log("Processing payroll results"),
+        disabled: true,
+        tooltip: ({ disabled }) =>
+          disabled ? "The results are not available yet" : undefined,
+      }),
+    })
+
+    return <BaseStory dataSource={dataSource} />
+  },
+}
+
 // Upsell button next to the full toolbar: search, settings, and a primary action.
 export const UpsellActionExample: Story = {
   render: () => {

--- a/packages/react/src/patterns/OneDataCollection/actions.tsx
+++ b/packages/react/src/patterns/OneDataCollection/actions.tsx
@@ -7,6 +7,10 @@ export type PrimaryActionItemDefinition = Pick<
   loading?: boolean
   onClick?: () => void | Promise<void>
   disabled?: boolean
+  tooltip?: (params: {
+    disabled: boolean
+    loading: boolean
+  }) => string | undefined
 }
 
 /**

--- a/packages/react/src/patterns/OneDataCollection/components/CollectionActions/CollectionActions.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/CollectionActions/CollectionActions.tsx
@@ -83,15 +83,31 @@ export const CollectionActions = ({
           }}
         />
       ) : primaryActionsButtons.length === 1 ? (
-        <F0Button
-          size="md"
-          onClick={primaryActionsButtons[0].onClick}
-          icon={primaryActionsButtons[0].icon}
-          variant="default"
-          label={primaryActionsButtons[0].label}
-          loading={primaryActionsButtons[0].loading}
-          disabled={primaryActionsButtons[0].disabled}
-        />
+        (() => {
+          const action = primaryActionsButtons[0]
+          const tooltipText = action.tooltip?.({
+            disabled: !!action.disabled,
+            loading: !!action.loading,
+          })
+
+          const button = (
+            <F0Button
+              size="md"
+              onClick={action.onClick}
+              icon={action.icon}
+              variant="default"
+              label={action.label}
+              loading={action.loading}
+              disabled={action.disabled}
+            />
+          )
+
+          return tooltipText ? (
+            <Tooltip description={tooltipText}>{button}</Tooltip>
+          ) : (
+            button
+          )
+        })()
       ) : (
         primaryActionsButtons.length > 1 && (
           <F0ButtonDropdown

--- a/packages/react/src/patterns/OneDataCollection/components/CollectionActions/__tests__/CollectionActions.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/CollectionActions/__tests__/CollectionActions.test.tsx
@@ -287,6 +287,77 @@ describe("CollectionActions", () => {
     })
   })
 
+  describe("primary action tooltip", () => {
+    it("wraps a single primary action with Tooltip when tooltip returns a string", () => {
+      const actions: PrimaryActionItemDefinition[] = [
+        {
+          label: "Process payroll results",
+          icon: mockIcon,
+          onClick: vi.fn(),
+          disabled: true,
+          tooltip: ({ disabled }) =>
+            disabled ? "Results are not available yet" : undefined,
+        },
+      ]
+
+      render(<CollectionActions primaryActions={actions} />)
+
+      const tooltip = screen.getByTestId("tooltip")
+      expect(tooltip).toBeInTheDocument()
+      expect(tooltip).toHaveAttribute(
+        "data-description",
+        "Results are not available yet"
+      )
+      expect(screen.getByText("Process payroll results")).toBeInTheDocument()
+    })
+
+    it("renders a single primary action without Tooltip when tooltip returns undefined", () => {
+      const actions: PrimaryActionItemDefinition[] = [
+        {
+          label: "Process payroll results",
+          icon: mockIcon,
+          onClick: vi.fn(),
+          disabled: false,
+          tooltip: ({ disabled }) =>
+            disabled ? "Results are not available yet" : undefined,
+        },
+      ]
+
+      render(<CollectionActions primaryActions={actions} />)
+
+      expect(screen.queryByTestId("tooltip")).not.toBeInTheDocument()
+      expect(screen.getByText("Process payroll results")).toBeInTheDocument()
+    })
+
+    it("renders a single primary action without Tooltip when tooltip is not provided", () => {
+      const actions: PrimaryActionItemDefinition[] = [
+        { label: "New expense", icon: mockIcon, onClick: vi.fn() },
+      ]
+
+      render(<CollectionActions primaryActions={actions} />)
+
+      expect(screen.queryByTestId("tooltip")).not.toBeInTheDocument()
+      expect(screen.getByText("New expense")).toBeInTheDocument()
+    })
+
+    it("receives the loading state in the tooltip params", () => {
+      const tooltip = vi.fn(() => undefined)
+      const actions: PrimaryActionItemDefinition[] = [
+        {
+          label: "New expense",
+          icon: mockIcon,
+          onClick: vi.fn(),
+          loading: true,
+          tooltip,
+        },
+      ]
+
+      render(<CollectionActions primaryActions={actions} />)
+
+      expect(tooltip).toHaveBeenCalledWith({ disabled: false, loading: true })
+    })
+  })
+
   describe("secondary actions tooltip", () => {
     it("wraps secondary action with Tooltip when tooltip returns a string", () => {
       render(


### PR DESCRIPTION
## Description

Collection primary actions support `disabled`, but there was no way to explain *why* an action is disabled — `SecondaryActionItem` has a `tooltip` callback, while `PrimaryActionItemDefinition` didn't. This adds the same `tooltip?: ({ disabled, loading }) => string | undefined` to primary actions, rendered when the collection has a single primary action (same single-action caveat as `disabled`/`loading`, which `F0ButtonDropdown` doesn't support). First consumer: Factorial's compensations guided flow, where the Calculation-phase "Process payroll results" CTA is disabled until the bookkeeper uploads results and the design shows an explanatory tooltip.

## Implementation details

- feat: add `tooltip` to `PrimaryActionItemDefinition`, mirroring the `SecondaryActionItem` signature
- feat: resolve the tooltip in `CollectionActions` and wrap the single primary `F0Button` in `Tooltip`, following the existing secondary-actions pattern
- test: primary-action tooltip cases (shown when callback returns text, hidden when `undefined` or absent, receives `loading` in params)
- docs: document `tooltip` in the actions MDX and extend the single-action caveat
- docs: add `DisabledPrimaryActionWithTooltipExample` story