### PR TITLE
feat(value-display): support tooltip on status cell

### DIFF
--- a/packages/react/src/ui/value-display/types/status/__stories__/status.stories.tsx
+++ b/packages/react/src/ui/value-display/types/status/__stories__/status.stories.tsx
@@ -37,3 +37,21 @@ export const StatusType: Story = {
     },
   },
 }
+
+export const WithTooltip: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Status",
+      render: () => ({
+        type: "status",
+        value: {
+          status: "warning",
+          label: "Needs follow-up",
+          tooltip:
+            "The call ended before all screening information was collected.",
+        },
+      }),
+    },
+  },
+}

--- a/packages/react/src/ui/value-display/types/status/__stories__/status.stories.tsx
+++ b/packages/react/src/ui/value-display/types/status/__stories__/status.stories.tsx
@@ -39,6 +39,9 @@ export const StatusType: Story = {
 }
 
 export const WithTooltip: Story = {
+  parameters: {
+    layout: "centered",
+  },
   args: {
     item: mockItem,
     property: {

--- a/packages/react/src/ui/value-display/types/status/status.test.tsx
+++ b/packages/react/src/ui/value-display/types/status/status.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
+import { describe, expect, it } from "vitest"
+
+import { Placeholder } from "@/icons/app"
+
+import { StatusCell, StatusCellValue } from "./status"
+
+describe("StatusCell", () => {
+  it("should render the status tag with label", () => {
+    const args: StatusCellValue = {
+      status: "positive",
+      label: "Contacted",
+    }
+
+    render(StatusCell(args))
+
+    expect(screen.getByText("Contacted")).toBeInTheDocument()
+  })
+
+  it("should render the icon inside the tag when provided", () => {
+    const args: StatusCellValue = {
+      status: "info",
+      label: "Live call",
+      icon: Placeholder,
+    }
+
+    render(StatusCell(args))
+
+    expect(screen.getByText("Live call")).toBeInTheDocument()
+    const svg = document.querySelector("svg")
+    expect(svg).toBeInTheDocument()
+  })
+
+  it("should show tooltip on hover when tooltip is provided", async () => {
+    const args: StatusCellValue = {
+      status: "warning",
+      label: "Needs follow-up",
+      tooltip: "The call ended before all information was collected",
+    }
+
+    render(StatusCell(args))
+
+    await userEvent.hover(screen.getByText("Needs follow-up"))
+
+    await waitFor(() => {
+      expect(screen.getByRole("tooltip")).toBeInTheDocument()
+    })
+  })
+
+  it("should expose the tooltip text to screen readers", () => {
+    const args: StatusCellValue = {
+      status: "warning",
+      label: "Needs follow-up",
+      tooltip: "The call ended before all information was collected",
+    }
+
+    render(StatusCell(args))
+
+    const srText = screen.getByText(
+      "The call ended before all information was collected"
+    )
+    expect(srText).toHaveClass("sr-only")
+  })
+
+  it("should not show tooltip when tooltip is not provided", () => {
+    const args: StatusCellValue = {
+      status: "positive",
+      label: "Contacted",
+    }
+
+    render(StatusCell(args))
+
+    expect(screen.queryByRole("tooltip")).not.toBeInTheDocument()
+  })
+})

--- a/packages/react/src/ui/value-display/types/status/status.tsx
+++ b/packages/react/src/ui/value-display/types/status/status.tsx
@@ -4,16 +4,27 @@
  */
 import { IconType } from "@/components/F0Icon"
 import { F0TagStatus, StatusVariant } from "@/components/tags/F0TagStatus"
+import { TooltipWrapper } from "@/lib/tooltip-wrapper"
 
 interface StatusValue {
   status: StatusVariant
   label: string
   icon?: IconType
+  tooltip?: string
 }
 export type StatusCellValue = StatusValue
 
 export const StatusCell = (args: StatusCellValue) => (
   <div data-cell-type="status">
-    <F0TagStatus variant={args.status} text={args.label} icon={args.icon} />
+    <TooltipWrapper tooltip={args.tooltip}>
+      <div className="w-fit max-w-full">
+        <F0TagStatus
+          variant={args.status}
+          text={args.label}
+          icon={args.icon}
+          additionalAccessibleText={args.tooltip}
+        />
+      </div>
+    </TooltipWrapper>
   </div>
 )


### PR DESCRIPTION
## Description

Adds an optional `tooltip` field to the `status` value-display cell (`StatusCellValue`), so consumers can explain a status on hover.

Follows the existing `IconCell` pattern: the cell wraps its content in `TooltipWrapper`, and the tooltip text is also passed as `additionalAccessibleText` to `F0TagStatus` for screen readers. `F0TagStatus` itself is untouched; both fields are optional, so existing usages are unaffected.

<img width="1149" height="361" alt="Screenshot 2026-07-13 at 15 16 20" src="https://github.com/user-attachments/assets/d62fe672-94af-4906-b9d0-a0ad1c53de8c" />

