### PR TITLE
feat(OneDataCollection): custom labels for built-in visualizations

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/Settings/components/__tests__/useVisualizationMeta.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/Settings/components/__tests__/useVisualizationMeta.test.tsx
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest"
+
+import { IconType } from "@/components/F0Icon"
+import { zeroRenderHook as renderHook } from "@/testing/test-utils"
+
+import { useVisualizationMeta } from "../useVisualizationMeta"
+
+// A stand-in IconType value; the resolver only compares identity.
+const CustomIcon = (() => null) as unknown as IconType
+
+// The resolver only reads `type`, `label` and (for custom) `icon` at runtime, so
+// we cast minimal fixtures to the visualization union to avoid rebuilding the full
+// options shape of each view.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const viz = (v: Record<string, unknown>): any => v
+
+const renderResolver = () =>
+  renderHook(() => useVisualizationMeta()).result.current
+
+describe("useVisualizationMeta", () => {
+  it("uses the localized built-in label when no override is provided", () => {
+    const resolve = renderResolver()
+
+    expect(resolve(viz({ type: "table", options: {} })).label).toBe("Table")
+    expect(resolve(viz({ type: "graph", options: {} })).label).toBe("Graph")
+  })
+
+  it("uses the per-instance label override for built-in visualizations", () => {
+    const resolve = renderResolver()
+
+    expect(
+      resolve(viz({ type: "table", label: "Teams", options: {} })).label
+    ).toBe("Teams")
+    expect(
+      resolve(viz({ type: "graph", label: "Org chart", options: {} })).label
+    ).toBe("Org chart")
+  })
+
+  it("keeps the built-in icon even when the label is overridden", () => {
+    const resolve = renderResolver()
+
+    const withoutOverride = resolve(viz({ type: "graph", options: {} }))
+    const withOverride = resolve(
+      viz({ type: "graph", label: "Org chart", options: {} })
+    )
+
+    expect(withOverride.icon).toBe(withoutOverride.icon)
+  })
+
+  it("honors the label and icon of a custom visualization", () => {
+    const resolve = renderResolver()
+
+    const meta = resolve(
+      viz({
+        type: "custom",
+        label: "My view",
+        icon: CustomIcon,
+        component: () => null,
+      })
+    )
+
+    expect(meta.label).toBe("My view")
+    expect(meta.icon).toBe(CustomIcon)
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/Settings/components/useVisualizationMeta.ts
+++ b/packages/react/src/patterns/OneDataCollection/Settings/components/useVisualizationMeta.ts
@@ -43,7 +43,9 @@ export const useVisualizationMeta = () => {
 
     return {
       icon: collectionVisualizations[visualization.type].icon,
-      label: i18n.collections.visualizations[visualization.type],
+      label:
+        visualization.label ??
+        i18n.collections.visualizations[visualization.type],
     }
   }
 }

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations.mdx
@@ -2,6 +2,7 @@ import { Canvas, Meta, Controls, Unstyled } from "@storybook/addon-docs/blocks"
 import { DoDonts } from "@/lib/storybook-utils/do-donts"
 import { FeatureGrid } from "~/docs/components/FeatureGrid"
 import { Kanban, List, Pencil, Table } from "@/icons/app"
+import * as GraphStories from "./visualizations/graph.stories"
 
 <Meta title="Data collection/Visualizations" />
 
@@ -56,3 +57,39 @@ etc.) and the visualization, of the data at item level (visualization) and
     ]}
   />
 </Unstyled>
+
+## Switching between visualizations
+
+When you pass more than one visualization, Data Collection renders a view
+switcher (a segmented control) in the header. Each chip shows the
+visualization's icon and label.
+
+## Renaming the switcher chips
+
+By default each built-in visualization uses its localized name — "Table",
+"Graph", "List", etc. To rename a chip for a specific collection, pass an
+optional `label` on the visualization. Different collections can label the same
+type differently — e.g. the `graph` view as "Org chart" for employees, or the
+`table` view as "Teams" for teams.
+
+```tsx
+<OneDataCollection
+  source={dataSource}
+  visualizations={[
+    // Renames the chip to "Org chart"; the built-in graph icon is kept.
+    { type: "graph", label: "Org chart", options: {} },
+    // Omit `label` to keep the default localized name ("Table").
+    { type: "table", options: {} },
+  ]}
+/>
+```
+
+- `label` is optional; when omitted the localized built-in label is used, so
+  existing collections keep showing "Table" and "Graph".
+- Only the text is customizable — the icon still comes from the visualization
+  type. For a fully custom icon and label, use a `type: "custom"` visualization.
+
+In the example below the two chips read "Org chart" and "Directory" instead of
+the defaults "Graph" and "Table":
+
+<Canvas of={GraphStories.CustomViewLabels} />

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/graph.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/graph.stories.tsx
@@ -674,9 +674,15 @@ const DetailField = ({ label, value }: { label: string; value: string }) => (
 const OrgChartExample = ({
   defaultExpandDepth,
   focusOnEntry,
+  graphLabel,
+  tableLabel,
 }: {
   defaultExpandDepth: number
   focusOnEntry?: string
+  /** Custom label for the graph chip; falls back to the localized "Graph". */
+  graphLabel?: string
+  /** Custom label for the table chip; falls back to the localized "Table". */
+  tableLabel?: string
 }) => {
   const [selected, setSelected] = useState<EmployeeNode | null>(null)
   const [revealId, setRevealId] = useState<string | undefined>(undefined)
@@ -690,6 +696,7 @@ const OrgChartExample = ({
         visualizations={[
           {
             ...graphVisualization,
+            label: graphLabel,
             options: {
               ...graphVisualization.options,
               defaultExpandDepth,
@@ -697,7 +704,7 @@ const OrgChartExample = ({
               focusOnEntry,
             },
           },
-          tableVisualization,
+          { ...tableVisualization, label: tableLabel },
         ]}
       />
       <F0Dialog
@@ -767,4 +774,20 @@ export const PreExpanded: Story = {
  */
 export const FocusOnRoot: Story = {
   render: () => <OrgChartExample defaultExpandDepth={2} focusOnEntry="ceo-a" />,
+}
+
+/**
+ * The view-switcher chips are renamed per instance with the optional `label` on
+ * each built-in visualization — here "Org chart" instead of the default "Graph"
+ * and "Directory" instead of "Table". Omit `label` to keep the localized
+ * built-in name. Icons are unchanged; only the text is overridden.
+ */
+export const CustomViewLabels: Story = {
+  render: () => (
+    <OrgChartExample
+      defaultExpandDepth={1}
+      graphLabel="Org chart"
+      tableLabel="Directory"
+    />
+  ),
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/types.ts
@@ -50,6 +50,21 @@ export type VisualizationFilterOverrides<
 }
 
 /**
+ * Optional per-visualization label override for built-in visualization types.
+ * When omitted, the localized built-in label from
+ * `i18n.collections.visualizations[type]` (e.g. "Table", "Graph") is used.
+ *
+ * Lets consumers rename the view switcher chip per instance, e.g. show "Org chart"
+ * instead of "Graph" for employees, or "Teams" instead of "Table". The icon still
+ * comes from the built-in registry for the visualization type.
+ */
+export type VisualizationLabelOverrides = {
+  /** Custom label shown in the view switcher chip and Settings selector.
+   *  Defaults to the localized built-in label for this visualization type. */
+  label?: string
+}
+
+/**
  * Represents a visualization configuration for displaying collection data.
  * Supports different visualization types (card, table, or custom) with their respective options.
  *
@@ -71,19 +86,22 @@ export type Visualization<
       type: "card"
       /** Configuration options for card visualization */
       options: CardVisualizationOptions<R, Filters, Sortings>
-    } & VisualizationFilterOverrides<Filters, Sortings>)
+    } & VisualizationFilterOverrides<Filters, Sortings> &
+      VisualizationLabelOverrides)
   | ({
       /** Kanban-based visualization type */
       type: "kanban"
       /** Configuration options for kanban visualization */
       options: KanbanVisualizationOptions<R, Filters, Sortings>
-    } & VisualizationFilterOverrides<Filters, Sortings>)
+    } & VisualizationFilterOverrides<Filters, Sortings> &
+      VisualizationLabelOverrides)
   | ({
       /** Table-based visualization type */
       type: "table"
       /** Configuration options for table visualization */
       options: TableVisualizationOptions<R, Filters, Sortings, Summaries>
-    } & VisualizationFilterOverrides<Filters, Sortings>)
+    } & VisualizationFilterOverrides<Filters, Sortings> &
+      VisualizationLabelOverrides)
   | ({
       /** Editable table-based visualization type */
       type: "editableTable"
@@ -94,19 +112,22 @@ export type Visualization<
         Sortings,
         Summaries
       >
-    } & VisualizationFilterOverrides<Filters, Sortings>)
+    } & VisualizationFilterOverrides<Filters, Sortings> &
+      VisualizationLabelOverrides)
   | ({
       /** List-based visualization type */
       type: "list"
       /** Configuration options for list visualization */
       options: ListVisualizationOptions<R, Filters, Sortings>
-    } & VisualizationFilterOverrides<Filters, Sortings>)
+    } & VisualizationFilterOverrides<Filters, Sortings> &
+      VisualizationLabelOverrides)
   | ({
       /** Graph/org-chart-based visualization type */
       type: "graph"
       /** Configuration options for graph visualization */
       options: GraphVisualizationOptions<R, Filters, Sortings>
-    } & VisualizationFilterOverrides<Filters, Sortings>)
+    } & VisualizationFilterOverrides<Filters, Sortings> &
+      VisualizationLabelOverrides)
   | ({
       /** Human-readable label for the visualization */
       label: string


### PR DESCRIPTION
## Description

Built-in visualization types in OneDataCollection (`table`, `graph`, `list`, `card`, `kanban`, `editableTable`) always derived their view-switcher chip label from the localized i18n key, so the only way to rename them was to override the translation globally. This adds an optional per-instance `label` prop so consumers can rename a single view — e.g. show "Org chart" instead of "Graph" for employees, or "Teams" instead of "Table" — while everything still defaults to the current localized labels when `label` is omitted. Icons are unchanged and continue to come from the built-in registry.

## Implementation details

- feat: add optional `label` to built-in visualization types via a new `VisualizationLabelOverrides` type intersected into each built-in member of the `Visualization` union (the `custom` type keeps its existing required `label`/`icon`)
- feat: resolve the chip/settings label as `visualization.label ?? i18n.collections.visualizations[type]` in `useVisualizationMeta`, keeping the built-in icon
- test: cover the i18n fallback, the per-instance override, icon stability under override, and the custom-visualization path in `useVisualizationMeta`
- docs: add a "Renaming the switcher chips" section to the Visualizations docs and a `CustomViewLabels` story (graph → "Org chart", table → "Directory")

## How to use

```tsx
visualizations={[
  { type: "table", label: "Teams", options: {...} },     // instead of "Table"
  { type: "graph", label: "Org chart", options: {...} }, // instead of "Graph"
]}
```

### Before
<img width="927" height="209" alt="Screenshot 2026-07-13 at 18 33 48" src="https://github.com/user-attachments/assets/b613b607-e6b3-407d-bccf-7426a25cfedd" />

### After
<img width="890" height="155" alt="Screenshot 2026-07-13 at 18 37 51" src="https://github.com/user-attachments/assets/c402bc19-8292-41fc-a203-a50a6ca0aaf0" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)