### PR TITLE
fix(ci): correct agentic-checks paths filter to packages/react/src

### DIFF
--- a/.github/workflows/agentic-checks.yaml
+++ b/.github/workflows/agentic-checks.yaml
@@ -3,8 +3,8 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - "packages/react/components/**"
-      - "packages/react/patterns/**"
+      - "packages/react/src/components/**"
+      - "packages/react/src/patterns/**"
     types:
       - opened
       - synchronize


### PR DESCRIPTION
## Problem

The `🤖 Agentic Checks` workflow (`.github/workflows/agentic-checks.yaml`) is gated at the `on:` level by a `paths` filter:

```yaml
on:
  pull_request:
    paths:
      - "packages/react/components/**"
      - "packages/react/patterns/**"
```

But components and patterns actually live under **`packages/react/src/`**:

```
packages/react/src/components/**
packages/react/src/patterns/**
```

The `src/` segment is missing, so the glob never matches any changed file. As a result the workflow **never triggers** — the checks (🧐 Code Review, ♿ Accessibility, 📚 Storybook, 🧪 Test Coverage) don't even get queued. Observed on #4606, which touches `packages/react/src/components/avatars/**` and passed all the `draft == false` / same-repo gates yet showed no agentic checks.

## Fix

Add the missing `src/` segment to both path globs.

## Verification

- `packages/react/src/components` and `packages/react/src/patterns` exist; the un-prefixed paths do not.
- After merge, PRs modifying those directories will trigger the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)