### PR TITLE
feat(F0AnalyticsDashboard): add valueFormatter to metric items

### DIFF
--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/MetricItem.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/MetricItem.test.tsx
@@ -1,0 +1,52 @@
+import { waitFor } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import type { DashboardMetricItem } from "../types"
+
+import { MetricItem } from "../components/MetricItem/MetricItem"
+
+const metricItem = (
+  overrides: Partial<DashboardMetricItem> = {}
+): DashboardMetricItem => ({
+  id: "avg-salary",
+  type: "metric",
+  title: "Average salary",
+  fetchData: () => Promise.resolve({ value: 46272.72 }),
+  ...overrides,
+})
+
+describe("MetricItem", () => {
+  it("formats with the built-in preset when no valueFormatter is given", async () => {
+    render(
+      <MetricItem
+        item={metricItem({ format: { type: "currency", currency: "EUR" } })}
+        filters={{}}
+      />
+    )
+
+    await waitFor(() => expect(screen.getByText("€46,273")).toBeInTheDocument())
+  })
+
+  it("prefers valueFormatter over format presets", async () => {
+    render(
+      <MetricItem
+        item={metricItem({
+          format: { type: "currency", currency: "EUR" },
+          valueFormatter: (value) =>
+            new Intl.NumberFormat("ca", {
+              style: "currency",
+              currency: "EUR",
+              maximumFractionDigits: 0,
+            }).format(value),
+        })}
+        filters={{}}
+      />
+    )
+
+    await waitFor(() =>
+      expect(screen.getByText("46.273 €")).toBeInTheDocument()
+    )
+  })
+})

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
@@ -115,7 +115,9 @@ export function MetricItem<Filters extends FiltersDefinition>({
         <div className="flex h-full min-h-0 items-end overflow-auto px-4 pb-4">
           <div className="flex items-baseline gap-3">
             <span className="whitespace-nowrap text-4xl font-semibold leading-none tracking-tight text-f1-foreground">
-              {formatValue(data.value, item.format, item.decimals)}
+              {item.valueFormatter
+                ? item.valueFormatter(data.value)
+                : formatValue(data.value, item.format, item.decimals)}
             </span>
             {trend && trend.direction !== "flat" && (
               <div className="flex shrink-0 items-center">

--- a/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
@@ -1,11 +1,4 @@
 import type {
-  FiltersDefinition,
-  FiltersState,
-  PresetsDefinition,
-} from "@/patterns/OneFilterPicker/types"
-import type { NavigationFiltersDefinition } from "@/patterns/OneDataCollection/navigationFilters/types"
-
-import type {
   ChartColorToken,
   F0DataChartBarSeries,
   F0DataChartFunnelSeries,
@@ -14,6 +7,12 @@ import type {
   F0DataChartRadarIndicator,
   F0DataChartRadarSeries,
 } from "@/kits/F0DataChart"
+import type { NavigationFiltersDefinition } from "@/patterns/OneDataCollection/navigationFilters/types"
+import type {
+  FiltersDefinition,
+  FiltersState,
+  PresetsDefinition,
+} from "@/patterns/OneFilterPicker/types"
 
 // ---------------------------------------------------------------------------
 // Chart config — the "visual" half of a chart item (no data)
@@ -269,6 +268,13 @@ export interface DashboardMetricItem<
   format?: MetricFormat
   /** Number of decimal places. @default 0 */
   decimals?: number
+  /**
+   * Custom value formatter — takes precedence over `format`/`decimals`.
+   * The built-in presets format with the browser locale; this lets the
+   * consumer control locale and currency, mirroring the chart configs'
+   * `valueFormatter`.
+   */
+  valueFormatter?: (value: number) => string
   /** Async data fetcher — receives dashboard filters */
   fetchData: (filters: FiltersState<Filters>) => Promise<DashboardMetricData>
 }


### PR DESCRIPTION
## What

Adds an optional `valueFormatter?: (value: number) => string` to `DashboardMetricItem`, taking precedence over the `format`/`decimals` presets — the same escape hatch every chart config already has.

## Why

`MetricItem`'s built-in presets format with the **browser** locale (`Intl.NumberFormat(undefined, …)`). For a user whose app locale differs from their browser locale, KPI tiles render `€7,935,000` (en grouping, symbol-first) while the surrounding charts — whose `valueFormatter` the consumer builds with the app locale — render `7.935.000 €`. The consumer has no way to control the metric's locale or number style.

With this, Factorial's semantic dashboards (factorialco/factorial#105744) can pass a locale- and currency-aware formatter for metric KPIs, consistent with charts and collection cells.

Presets remain the default path — no behavior change for existing consumers.

## Test plan

- New `MetricItem.test.tsx`: preset renders as before; `valueFormatter` wins over an explicit currency preset (asserts Catalan `46.273 €` vs preset `€46,273`).
- `pnpm vitest run …/MetricItem.test.tsx` green; tsc, oxfmt, oxlint clean (lefthook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)