### PR TITLE
fix(F0SegmentedControl): increase segment text size to label variant

### DIFF
--- a/packages/react/src/experimental/Actions/F0SegmentedControl/F0SegmentedControl.tsx
+++ b/packages/react/src/experimental/Actions/F0SegmentedControl/F0SegmentedControl.tsx
@@ -56,7 +56,7 @@ export const F0SegmentedControl = ({
             "disabled:pointer-events-none disabled:text-f1-foreground-disabled",
             "data-[state=on]:bg-f1-background data-[state=on]:text-f1-foreground data-[state=on]:shadow",
             focusRing(),
-            "h-8 px-3 text-sm",
+            "h-8 px-3 text-base",
             fullWidth && "w-full"
           )}
         >


### PR DESCRIPTION
## Description

Increase the text size of `F0SegmentedControl` segments from the `small` text style (12px) to the `label` text style (14px).

## Screenshots (if applicable)

Visual diff will be produced by Chromatic on this PR for the `F0SegmentedControl` stories. Change is a font-size bump only:

| Text style | Class | Size |
|---|---|---|
| Before: `small` | `text-sm` | 0.75rem / 12px |
| After: `label` | `text-base` | 0.875rem / 14px |

## Implementation details

The segment labels were styled with `text-sm` (0.75rem / 12px), which matches the `small` text variant (`text-sm font-medium text-f1-foreground-secondary`). This bumps the font size to `text-base` (0.875rem / 14px), matching the `label` text variant (`font-medium` on the base 14px size).

Only the font-size token changes (`text-sm` to `text-base`). Weight (`font-medium`) and the component's interaction color states (idle `text-f1-foreground-secondary`, hover/selected `text-f1-foreground`, disabled) are intentionally preserved.

```diff
-            "h-8 px-3 text-sm",
+            "h-8 px-3 text-base",
```

File: `packages/react/src/experimental/Actions/F0SegmentedControl/F0SegmentedControl.tsx`

Verification: `oxlint` clean, `oxfmt` clean, 12/12 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)