### PR TITLE
fix(dialog-alike): don't preventDefault inner dialog clicks (unblocks file picker)

### DIFF
--- a/packages/react/src/components/dialog-alike/F0Dialog/__tests__/F0Dialog.file-input-click.test.tsx
+++ b/packages/react/src/components/dialog-alike/F0Dialog/__tests__/F0Dialog.file-input-click.test.tsx
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { F0Dialog } from "../index"
+
+/**
+ * Regression cover for the native file picker not opening inside a dialog-alike
+ * F0Dialog (and therefore inside F0Wizard, which renders via this dialog).
+ *
+ * Root cause: the dialog content `<div>` used to call `e.preventDefault()` on
+ * every bubbling `click`. A hidden `<input type="file">` lives inside the
+ * dialog, and the f0 file field opens the OS picker by calling
+ * `fileInputRef.current.click()`. That programmatic click bubbles up through
+ * the content div; `preventDefault()` on the bubbling event cancels the file
+ * chooser's default action, so no picker appears. `stopPropagation()` alone is
+ * enough to keep inner clicks from being treated as outside-clicks, so the fix
+ * drops `preventDefault()` and keeps `stopPropagation()`.
+ *
+ * We can't observe the OS picker in jsdom, so we assert the property that
+ * governs it: a bubbling click originating on an element inside the dialog must
+ * NOT end up `defaultPrevented`.
+ */
+describe("dialog-alike F0Dialog does not swallow inner click defaults", () => {
+  let overlayRoot: HTMLElement
+
+  beforeEach(() => {
+    overlayRoot = document.createElement("div")
+    overlayRoot.id = "f0-overlay-root"
+    document.body.appendChild(overlayRoot)
+  })
+
+  afterEach(() => {
+    overlayRoot.remove()
+    vi.clearAllMocks()
+  })
+
+  it("leaves a bubbling click from an inner file input un-prevented (modal)", () => {
+    render(
+      <F0Dialog isOpen modal onClose={vi.fn()} title="Wizard-like modal">
+        <input type="file" data-testid="file-input" className="hidden" />
+      </F0Dialog>
+    )
+
+    const input = screen.getByTestId("file-input")
+
+    // Simulate the f0 file field opening the picker: a real bubbling,
+    // cancelable click dispatched on the hidden input.
+    const clickEvent = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    })
+    input.dispatchEvent(clickEvent)
+
+    // If the dialog content preventDefault's this, the browser would suppress
+    // the file chooser. It must stay un-prevented.
+    expect(clickEvent.defaultPrevented).toBe(false)
+  })
+
+  it("leaves a bubbling click un-prevented in non-modal mode too", () => {
+    render(
+      <F0Dialog isOpen onClose={vi.fn()} title="Non-modal">
+        <input type="file" data-testid="file-input" className="hidden" />
+      </F0Dialog>
+    )
+
+    const input = screen.getByTestId("file-input")
+    const clickEvent = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    })
+    input.dispatchEvent(clickEvent)
+
+    expect(clickEvent.defaultPrevented).toBe(false)
+  })
+})

--- a/packages/react/src/components/dialog-alike/common/dialog-primitive/DialogContent.tsx
+++ b/packages/react/src/components/dialog-alike/common/dialog-primitive/DialogContent.tsx
@@ -129,7 +129,13 @@ export const DialogContent = forwardRef<
               className
             )}
             onClick={(e) => {
-              e.preventDefault()
+              // Only stop propagation so clicks inside the dialog box are not
+              // treated as outside-clicks by the overlay handler above. Do NOT
+              // preventDefault: this handler runs for every click that bubbles
+              // up from the dialog's contents, and preventing the default would
+              // cancel default actions of inner controls — most visibly the
+              // native file picker, which opens via a programmatic
+              // `fileInputRef.click()` that bubbles through here.
               e.stopPropagation()
             }}
           >


### PR DESCRIPTION
## Problem

The native f0 file field (`fieldType: 'file'`) does not open the OS file picker when rendered inside **F0Wizard**. Clicking the dropzone does nothing.

## Root cause

F0Wizard renders through the newer `dialog-alike` `F0Dialog` (wired in #4391). Its `DialogContent` inner content `<div>` called `e.preventDefault()` on **every** bubbling `click`:

```tsx
onClick={(e) => {
  e.preventDefault()
  e.stopPropagation()
}}
```

The f0 file field opens the picker via a programmatic `fileInputRef.current.click()`. The hidden `<input type="file">` is a descendant of this div, so that click bubbles up and hits this handler — and `preventDefault()` on the bubbling click **cancels the file chooser's default action**. This would cancel the default action of any inner control, not just file inputs.

The public `patterns/F0Dialog` (used e.g. by task creation) has no such handler, which is why file fields worked there — the file field itself was never the problem.

## Fix

Keep `stopPropagation()` (that's what stops inner clicks being treated as outside-clicks by the overlay handler); drop `preventDefault()`. The outer overlay handler is unchanged.

## Tests

Adds `F0Dialog.file-input-click.test.tsx`: dispatches a bubbling, cancelable click from an inner input and asserts `event.defaultPrevented === false` (fails before the change, passes after) in both modal and non-modal modes.

- New test passes; **137** dialog-alike / F0Wizard / F0WizardForm tests + **24** FileFieldRenderer tests stay green.
- oxfmt / oxlint clean.

## Verification

Verified live against a real app (Factorial trainings creation wizard) by hot-patching the built dist: the OS file picker now opens from the wizard thumbnail dropzone.