### PR TITLE
fix(OneDataCollection/table): keep tag text legible in striked rows

### DIFF
--- a/packages/react/src/components/tags/internal/BaseTag/index.test.tsx
+++ b/packages/react/src/components/tags/internal/BaseTag/index.test.tsx
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest"
+
+import { zeroRender as render } from "@/testing/test-utils"
+
+import { BaseTag } from "./index"
+
+describe("BaseTag", () => {
+  it("marks its subtree with data-no-strike so row strike decorations skip it", () => {
+    const { container } = render(<BaseTag text="Rejected" />)
+
+    const optOut = container.querySelector("[data-no-strike]")
+    expect(optOut).not.toBeNull()
+    // The label lives inside the opted-out subtree.
+    expect(optOut).toHaveTextContent("Rejected")
+  })
+})

--- a/packages/react/src/components/tags/internal/BaseTag/index.test.tsx
+++ b/packages/react/src/components/tags/internal/BaseTag/index.test.tsx
@@ -10,7 +10,6 @@ describe("BaseTag", () => {
 
     const optOut = container.querySelector("[data-no-strike]")
     expect(optOut).not.toBeNull()
-    // The label lives inside the opted-out subtree.
     expect(optOut).toHaveTextContent("Rejected")
   })
 })

--- a/packages/react/src/components/tags/internal/BaseTag/index.tsx
+++ b/packages/react/src/components/tags/internal/BaseTag/index.tsx
@@ -56,8 +56,6 @@ export const BaseTag = forwardRef<HTMLDivElement, BaseTagProps>(
     additionalAccessibleText =
       additionalAccessibleText || (hideLabel ? text : undefined)
     return (
-      // data-no-strike opts the whole tag subtree out of row-level decorations
-      // (e.g. the "striked" referenceRowType), which must not cross tag text.
       <div
         data-no-strike
         className="flex w-fit max-w-full flex-row items-center justify-start gap-1"

--- a/packages/react/src/components/tags/internal/BaseTag/index.tsx
+++ b/packages/react/src/components/tags/internal/BaseTag/index.tsx
@@ -56,7 +56,12 @@ export const BaseTag = forwardRef<HTMLDivElement, BaseTagProps>(
     additionalAccessibleText =
       additionalAccessibleText || (hideLabel ? text : undefined)
     return (
-      <div className="flex w-fit max-w-full flex-row items-center justify-start gap-1">
+      // data-no-strike opts the whole tag subtree out of row-level decorations
+      // (e.g. the "striked" referenceRowType), which must not cross tag text.
+      <div
+        data-no-strike
+        className="flex w-fit max-w-full flex-row items-center justify-start gap-1"
+      >
         <div
           ref={ref}
           className={cn(

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.mdx
@@ -393,7 +393,8 @@ that should be visually distinguished from regular records.
 ### Striked Rows
 
 `referenceRowType` also accepts `"striked"` to render the row with line-through
-text + muted foreground.
+text + muted foreground. Tag cells (status, tag, dot, etc.) opt out of the
+strike so their labels stay legible — see the Status column below.
 
 ```tsx
 {

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -721,9 +721,6 @@ export const StrikedRowsVisualization: Story = {
                   { label: "Name", render: (item) => item.name, id: "name" },
                   { label: "Email", render: (item) => item.email, id: "email" },
                   {
-                    // The strike must NOT cross tag text: on striked (inactive)
-                    // rows the Name/Email cells are struck but this status tag
-                    // stays legible.
                     label: "Status",
                     id: "status",
                     render: (item) => ({

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -720,6 +720,20 @@ export const StrikedRowsVisualization: Story = {
                 columns: [
                   { label: "Name", render: (item) => item.name, id: "name" },
                   { label: "Email", render: (item) => item.email, id: "email" },
+                  {
+                    // The strike must NOT cross tag text: on striked (inactive)
+                    // rows the Name/Email cells are struck but this status tag
+                    // stays legible.
+                    label: "Status",
+                    id: "status",
+                    render: (item) => ({
+                      type: "status",
+                      value: {
+                        status: item.active ? "positive" : "critical",
+                        label: item.active ? "Active" : "Inactive",
+                      },
+                    }),
+                  },
                 ],
               },
             },

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
@@ -202,8 +202,6 @@ describe("TableCollection", () => {
 
       const struckRow = screen.getByText(testData[0].name).closest("tr")
       expect(struckRow?.className).toMatch(/line-through/)
-      // Tags opt out of the strike via data-no-strike (see BaseTag); the
-      // selector must exclude that subtree so tag text is never struck.
       expect(struckRow?.className).toMatch(/:not\(\[data-no-strike\]/)
 
       const plainRow = screen.getByText(testData[1].name).closest("tr")

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
@@ -202,6 +202,9 @@ describe("TableCollection", () => {
 
       const struckRow = screen.getByText(testData[0].name).closest("tr")
       expect(struckRow?.className).toMatch(/line-through/)
+      // Tags opt out of the strike via data-no-strike (see BaseTag); the
+      // selector must exclude that subtree so tag text is never struck.
+      expect(struckRow?.className).toMatch(/:not\(\[data-no-strike\]/)
 
       const plainRow = screen.getByText(testData[1].name).closest("tr")
       expect(plainRow?.className).not.toMatch(/line-through/)

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -114,7 +114,8 @@ const referenceTypeClasses: Record<ReferenceType, string> = {
   none: "",
   striped:
     "bg-[repeating-linear-gradient(45deg,transparent_0px,transparent_8px,hsl(var(--neutral-20))_8px,hsl(var(--neutral-20))_9px)] [background-size:100%_100px]",
-  striked: "[&_*]:line-through text-f1-foreground-secondary",
+  striked:
+    "[&_*:not([data-no-strike]):not([data-no-strike]_*)]:line-through text-f1-foreground-secondary",
 }
 
 const RowComponentInner = <


### PR DESCRIPTION

<img width="1656" height="929" alt="Screenshot 2026-07-14 at 3 06 18 PM" src="https://github.com/user-attachments/assets/08cac4a0-4036-494e-8428-f02112d96532" />


## Summary

The `striked` `referenceRowType` applied `[&_*]:line-through` to **every** descendant of the row, so tag/status chip labels were struck through as well. Reported on **FCT-55976** ("Add a strikethrough in rejected requests once the plan is locked") — QA feedback: *"The strike should not apply to the tags text."*

### Fix
- **`BaseTag`** now carries `data-no-strike` on its wrapper. Every chip (`F0TagStatus`, `F0TagRaw`, `F0Tag`, `F0TagDot`, `F0TagAlert`, `F0TagBalance`) builds on `BaseTag`, so one attribute covers them all.
- **`Row.tsx`** `striked` selector now excludes that subtree:
  `[&_*:not([data-no-strike]):not([data-no-strike]_*)]:line-through`

The chip's inner `inline-flex` already blocks `text-decoration` propagation from ancestor cells, so chips were struck **only** by the direct `[&_*]` match — excluding the tag subtree fully fixes it while text cells keep their strike. This mirrors the existing `[&_svg:not([data-has-color])]` icon opt-out convention.

## Testing
- Added a `BaseTag` test locking the `data-no-strike` opt-out.
- Strengthened the striked `Table` test to assert the selector opts tags out.
- Extended the `StrikedRowsVisualization` story + MDX with a Status column to demonstrate the behavior visually.
- Verified the arbitrary variant compiles: Tailwind emits `… *:not([data-no-strike]):not([data-no-strike] *){text-decoration-line:line-through}`.
- `oxlint` clean; pre-commit hooks green.

## Downstream
Consumer code (Factorial monorepo planning grid) needs **no change** — it already passes `referenceRowType: 'striked'`. Once released, bump `@factorialco/f0-react` in the monorepo to pick this up.