### PR TITLE
feat(DetailsItem): add fullWidth prop to stretch to container width

### DIFF
--- a/packages/react/src/experimental/Lists/DetailsItem/__tests__/DetailsItem.test.tsx
+++ b/packages/react/src/experimental/Lists/DetailsItem/__tests__/DetailsItem.test.tsx
@@ -14,6 +14,33 @@ describe("DetailsItem", () => {
     expect(screen.getByText("Hello")).toBeInTheDocument()
   })
 
+  describe("fullWidth", () => {
+    // The ~320px cap (`md:max-w-80`) lives on DataList's inner div; DetailsItem
+    // drops it from the outside via the `[&>div]:md:max-w-none` variant only
+    // when `fullWidth` is set.
+    const capOverride = "[&>div]:md:max-w-none"
+
+    it("keeps the width cap by default", () => {
+      const { container } = render(
+        <DetailsItem title="Email" content={{ type: "item", text: "a@b.co" }} />
+      )
+
+      expect(container.firstChild).not.toHaveClass(capOverride)
+    })
+
+    it("drops the width cap when fullWidth is set", () => {
+      const { container } = render(
+        <DetailsItem
+          title="Email"
+          content={{ type: "item", text: "a@b.co" }}
+          fullWidth
+        />
+      )
+
+      expect(container.firstChild).toHaveClass(capOverride)
+    })
+  })
+
   describe("file content", () => {
     const fileContent = {
       type: "file" as const,

--- a/packages/react/src/experimental/Lists/DetailsItem/index.stories.tsx
+++ b/packages/react/src/experimental/Lists/DetailsItem/index.stories.tsx
@@ -4,7 +4,7 @@ import { expect, within } from "storybook/test"
 
 import { DetailsItem } from "./index"
 
-const meta: Meta = {
+const meta = {
   title: "List/DetailsItem",
   component: DetailsItem,
   tags: ["autodocs", "experimental"],
@@ -18,7 +18,7 @@ const meta: Meta = {
       },
     },
   },
-}
+} satisfies Meta<typeof DetailsItem>
 
 export default meta
 type Story = StoryObj<typeof meta>

--- a/packages/react/src/experimental/Lists/DetailsItem/index.stories.tsx
+++ b/packages/react/src/experimental/Lists/DetailsItem/index.stories.tsx
@@ -62,6 +62,50 @@ export const Horizontal: Story = {
   },
 }
 
+/**
+ * Set `fullWidth` to drop the default ~320px (`max-w-80`) cap so the item
+ * stretches to 100% of its container. Reach for it when the item lives in a
+ * wide surface such as a side panel or drawer, instead of abusing
+ * `isHorizontal` to remove the cap. `fullWidth` is independent of
+ * `isHorizontal` / `verticalLayout` (those control layout direction, this
+ * controls width). The 600px bordered box below shows the two side by side.
+ */
+export const FullWidth: Story = {
+  args: {
+    title: "Address",
+    content: {
+      type: "item",
+      text: "Paseo Mara, 62, Bajos\nPáez del Vallès\nCeuta",
+      action: {
+        type: "copy",
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[600px] rounded-md border border-solid border-f1-border-secondary p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  render: (args) => (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-1">
+        <span className="text-sm text-f1-foreground-secondary">
+          Default: capped at ~320px
+        </span>
+        <DetailsItem {...args} fullWidth={false} />
+      </div>
+      <div className="flex flex-col gap-1">
+        <span className="text-sm text-f1-foreground-secondary">
+          fullWidth: fills the 600px container
+        </span>
+        <DetailsItem {...args} fullWidth />
+      </div>
+    </div>
+  ),
+}
+
 export const WithDataTestId: Story = {
   args: {
     ...Default.args,

--- a/packages/react/src/experimental/Lists/DetailsItem/index.tsx
+++ b/packages/react/src/experimental/Lists/DetailsItem/index.tsx
@@ -70,6 +70,14 @@ export interface DetailsItemType {
    * long-form text fields like rich-text or textarea.
    */
   verticalLayout?: boolean
+  /**
+   * When true, removes the default ~320px (`max-w-80`) width cap so the item
+   * stretches to 100% of its container width. Independent of `isHorizontal` /
+   * `verticalLayout` (those control layout direction, this controls width).
+   * Use it to fill a wide container such as a side panel or drawer instead of
+   * abusing `isHorizontal` to drop the cap.
+   */
+  fullWidth?: boolean
   spacingAtTheBottom?: boolean
 }
 
@@ -116,6 +124,7 @@ const _DetailsItem = forwardRef<HTMLDivElement, DetailsItemType>(
       content,
       isHorizontal = false,
       verticalLayout = false,
+      fullWidth = false,
       spacingAtTheBottom,
     },
     ref
@@ -131,7 +140,9 @@ const _DetailsItem = forwardRef<HTMLDivElement, DetailsItemType>(
           isHorizontal && !verticalLayout && "xs:[&_ul>li]:p-0 [&_ul]:flex-1",
           isHorizontal &&
             verticalLayout &&
-            "[&_ul>li>*]:px-0 [&_ul]:flex-1 xs:[&>div]:flex-col"
+            "[&_ul>li>*]:px-0 [&_ul]:flex-1 xs:[&>div]:flex-col",
+          // Drop DataList's `md:max-w-80` cap so the item fills its container.
+          fullWidth && "[&>div]:md:max-w-none"
         )}
       >
         <DataList label={title} isHorizontal={isHorizontal}>

--- a/packages/react/src/experimental/Lists/DetailsItemsList/index.stories.tsx
+++ b/packages/react/src/experimental/Lists/DetailsItemsList/index.stories.tsx
@@ -150,6 +150,63 @@ export const TableView: Story = {
   },
 }
 
+/**
+ * `fullWidth` set on individual `details` items flows through the list, so each
+ * item drops the ~320px cap and fills the container. Reach for it when the list
+ * renders in a wide surface such as a side panel or drawer. The 600px bordered
+ * box mimics such a container.
+ */
+export const FullWidth: Story = {
+  args: {
+    title: "Details",
+    details: [
+      {
+        title: "Legal entity",
+        content: {
+          type: "item",
+          text: "Everyday Software SL",
+          action: {
+            type: "copy",
+          },
+        },
+        fullWidth: true,
+      },
+      {
+        title: "Address",
+        content: {
+          type: "item",
+          text: "Paseo Mara, 62, Bajos\nPáez del Vallès\nCeuta",
+          action: {
+            type: "copy",
+          },
+        },
+        fullWidth: true,
+      },
+      {
+        title: "Manager",
+        content: {
+          type: "person",
+          firstName: "Saul",
+          lastName: "Dominguez",
+          avatarUrl: "/avatars/person01.jpg",
+          action: {
+            type: "navigate",
+            href: "",
+          },
+        },
+        fullWidth: true,
+      },
+    ],
+  },
+  decorators: [
+    (Story) => (
+      <div className="w-[600px] rounded-md border border-solid border-f1-border-secondary p-4">
+        <Story />
+      </div>
+    ),
+  ],
+}
+
 export const WithDataTestId: Story = {
   args: {
     ...Primary.args,

--- a/packages/react/src/experimental/Lists/DetailsItemsList/index.tsx
+++ b/packages/react/src/experimental/Lists/DetailsItemsList/index.tsx
@@ -69,6 +69,7 @@ const _DetailsItemsList = forwardRef<HTMLDivElement, DetailsItemsListProps>(
                   spacingAtTheBottom={item.spacingAtTheBottom}
                   isHorizontal={tableView}
                   verticalLayout={item.verticalLayout}
+                  fullWidth={item.fullWidth}
                 />
                 {tableView && index !== details.length - 1 && (
                   <div className="h-[1px] w-full bg-f1-border-secondary" />


### PR DESCRIPTION
## Description

Adds an optional `fullWidth` boolean prop (default `false`) to the experimental `DetailsItem` so it can drop its ~320px width cap and stretch to 100% of its container. Purely additive and backwards-compatible: existing consumers render exactly as before.

**Motivation.** `DetailsItem` caps its width at ~320px (`max-w-80`, on `DataList`'s inner row). There was no way to make it fill its container, so consumers reached for unrelated props to bypass the cap. The Factorial monolith org-chart side panel sets `isHorizontal` + `verticalLayout` purely to drop the cap and fill the drawer, which couples "fill width" to "layout direction" and is confusing. `fullWidth` is the explicit, intent-revealing replacement, kept orthogonal to `isHorizontal` / `verticalLayout` (those control layout direction; this controls width).

## Screenshots (if applicable)

New Storybook story: **Experimental / List / DetailsItem → `FullWidth`** (and **Experimental / List / DetailsItemsList → `FullWidth`**). Each renders inside a 600px container to contrast the two states. See the Chromatic build on this PR for the rendered story.

Verified in Storybook at desktop width (the `md:max-w-80` cap only applies at `md`+):

| State | inner `max-width` (computed) | measured width in 600px box |
| --- | --- | --- |
| default (unset) | `320px` | 320px (capped) |
| `fullWidth` | `none` | 566px (fills container) |

## Implementation details

- `DetailsItemType`: added `fullWidth?: boolean` with a JSDoc note (flows through `DetailsItemsList`'s `details: DetailsItemType[]` and surfaces in autodocs prop tables).
- `DetailsItem`: destructure `fullWidth = false`; when set, add `[&>div]:md:max-w-none` to the wrapper, dropping the `md:max-w-80` cap that lives on the child `DataList` row. This reuses the same arbitrary-variant idiom the component already uses to reach that child (e.g. `xs:[&>div]:flex-col`), so no change to `DataList`'s public API.
- `DetailsItemsList`: plumb `fullWidth={item.fullWidth}` through the per-item render (that layer picks props explicitly rather than spreading).
- Stories: added `FullWidth` stories to `DetailsItem` and `DetailsItemsList` with a 600px wrapper and a short doc note on when to use it.
- Tests: added coverage asserting the cap-override class is present only when `fullWidth` is set.

Local checks: `oxfmt --check`, `oxlint` (0 warnings), `tsc` typecheck, `vitest` (DetailsItem), and `storybook build` all pass.

> Draft for human review; do not merge.
