### PR TITLE
fix(OneDataCollection): support disabled on primaryActions in dropdown mode

### DIFF
--- a/packages/react/src/components/F0ButtonDropdown/types.ts
+++ b/packages/react/src/components/F0ButtonDropdown/types.ts
@@ -31,6 +31,11 @@ export type ButtonDropdownItem<T = string> = {
    * The description of the item.
    */
   description?: string
+  /**
+   * Whether the item is disabled.
+   * @default false
+   */
+  disabled?: boolean
 }
 
 export type ButtonDropdownGroup<T = string> = {

--- a/packages/react/src/experimental/Navigation/Dropdown/internal.tsx
+++ b/packages/react/src/experimental/Navigation/Dropdown/internal.tsx
@@ -35,6 +35,7 @@ export type DropdownItemObject = Pick<NavigationItem, "label" | "href"> & {
   description?: string
   critical?: boolean
   avatar?: AvatarVariant
+  disabled?: boolean
 }
 
 export type DropdownInternalProps = {
@@ -65,6 +66,7 @@ const DropdownItem = ({ item }: { item: DropdownItemObject }) => {
     description: _description,
     href,
     critical,
+    disabled,
     ...props
   } = item
 
@@ -74,7 +76,11 @@ const DropdownItem = ({ item }: { item: DropdownItemObject }) => {
   )
 
   return (
-    <DropdownMenuItem asChild className={cn(itemClass, "cursor-pointer")}>
+    <DropdownMenuItem
+      asChild
+      className={cn(itemClass, "cursor-pointer")}
+      disabled={disabled}
+    >
       {href ? (
         <Link
           href={href}

--- a/packages/react/src/patterns/OneDataCollection/components/CollectionActions/CollectionActions.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/CollectionActions/CollectionActions.tsx
@@ -76,6 +76,7 @@ export const CollectionActions = ({
             label: action.label,
             icon: action.icon,
             description: action.description,
+            disabled: action.disabled,
             value: index.toString(),
           }))}
           onClick={(value) => {


### PR DESCRIPTION
## Description

When any primary action has a `description`, `CollectionActions` enters dropdown mode and renders via `F0ButtonDropdown`. In this path, the `disabled` prop was silently ignored because it was never passed to the item mapping. This fix threads `disabled` through `DropdownItemObject`, `ButtonDropdownItem`, and the `CollectionActions` item mapping so it reaches the Radix `DropdownMenuItem`.

## Implementation details

- fix: add `disabled?: boolean` to `DropdownItemObject` and pass it explicitly to `<DropdownMenuItem>` so Radix applies `pointer-events-none` and `opacity-50`
- fix: add `disabled?: boolean` to `ButtonDropdownItem` in `F0ButtonDropdown`
- fix: pass `disabled: action.disabled` in the `useDropdownMode` item mapping in `CollectionActions`

## Tested locally
By linking the f0 package to the Factorial repo. We use it to disable the option Create first assignments
Before: 
<img width="1713" height="888" alt="Screenshot 2026-07-14 at 14 50 15" src="https://github.com/user-attachments/assets/29ebd050-f4fd-47a4-816c-8e665768c1de" />


After:
<img width="1510" height="809" alt="Screenshot 2026-07-14 at 20 48 22" src="https://github.com/user-attachments/assets/7ed47556-2826-46b1-a520-74da7a00839d" />


The action with disabled: true now renders correctly as disabled in the dropdown.