### PR TITLE
fix(DetailsItem): remove 320px max-width cap so items fill their container

### DIFF
--- a/packages/react/src/experimental/Lists/DataList/index.tsx
+++ b/packages/react/src/experimental/Lists/DataList/index.tsx
@@ -33,7 +33,7 @@ const _DataList = forwardRef<HTMLUListElement, DataListProps>(
         className={cn(
           isHorizontal
             ? "flex min-h-12 flex-1 flex-col py-1.5 pl-3 pr-1.5 xs:flex-row"
-            : "min-w-32 md:max-w-80"
+            : "min-w-32"
         )}
       >
         {label && (


### PR DESCRIPTION
## What

Remove the ~320px max-width cap (`md:max-w-80`) from the experimental `DetailsItem` so its rows stretch to fill their container by default.

The cap lived on `DataList`'s vertical-layout branch (`min-w-32 md:max-w-80`). `DataList` is internal (not publicly exported) and `DetailsItem` is its only consumer, so this change is scoped in practice to `DetailsItem` / `DetailsItemsList`. `min-w-32` is kept as a sensible minimum.

```diff
- : "min-w-32 md:max-w-80"
+ : "min-w-32"
```

## Why

`DetailsItem` was capped at ~320px with no way to opt out. Consumers abused unrelated layout props to bypass it: the Factorial monolith org-chart side panel sets `isHorizontal` + `verticalLayout` **purely** to drop the cap and fill the drawer, which couples "fill width" to "layout direction" and is confusing. Removing the cap lets the item fill its container so that workaround is no longer needed.

## Behavior change (heads up for review)

This is **not** purely additive: every existing `DetailsItem` / `DetailsItemsList` in vertical layout will now stretch to its container instead of stopping at ~320px. Chromatic will surface the visual diffs for the affected stories.

## Before / after

See the Chromatic visual review linked in the automated comment below for before/after of the `DetailsItem` and `DetailsItemsList` stories.

## Alternative considered

An opt-in `fullWidth` prop (cap stays by default, backwards-compatible) was prototyped as the more conservative option. This PR is the simpler, cap-removed alternative; pick whichever fits the design-system direction.

## Testing

- `pnpm tsc` (type-check) — pass
- `pnpm vitest run src/experimental/Lists` — pass
- lint + format — pass
