### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.35.3",
+  "packages/react": "4.36.0",
   "packages/react-native": "0.58.0",
   "packages/core": "1.54.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.36.0](https://github.com/factorialco/f0/compare/f0-react-v4.35.3...f0-react-v4.36.0) (2026-07-15)
+
+
+### Features
+
+* **F0Graph:** decouple tag column identity from visual type ([#4688](https://github.com/factorialco/f0/issues/4688)) ([bf7e4fb](https://github.com/factorialco/f0/commit/bf7e4fb5d43b37e0969192e39728d547a5e2dc66))
+
 ## [4.35.3](https://github.com/factorialco/f0/compare/f0-react-v4.35.2...f0-react-v4.35.3) (2026-07-14)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.35.3",
+  "version": "4.36.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.36.0</summary>

## [4.36.0](https://github.com/factorialco/f0/compare/f0-react-v4.35.3...f0-react-v4.36.0) (2026-07-15)


### Features

* **F0Graph:** decouple tag column identity from visual type ([#4688](https://github.com/factorialco/f0/issues/4688)) ([bf7e4fb](https://github.com/factorialco/f0/commit/bf7e4fb5d43b37e0969192e39728d547a5e2dc66))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).