### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.36.0",
+  "packages/react": "4.36.1",
   "packages/react-native": "0.58.0",
   "packages/core": "1.54.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.36.1](https://github.com/factorialco/f0/compare/f0-react-v4.36.0...f0-react-v4.36.1) (2026-07-15)
+
+
+### Bug Fixes
+
+* **OneDataCollection:** support disabled on primaryActions in dropdown mode ([#4691](https://github.com/factorialco/f0/issues/4691)) ([3b67c38](https://github.com/factorialco/f0/commit/3b67c38240b1224b9c8fd2c8fd064febd27c1046))
+
 ## [4.36.0](https://github.com/factorialco/f0/compare/f0-react-v4.35.3...f0-react-v4.36.0) (2026-07-15)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.36.0",
+  "version": "4.36.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.36.1</summary>

## [4.36.1](https://github.com/factorialco/f0/compare/f0-react-v4.36.0...f0-react-v4.36.1) (2026-07-15)


### Bug Fixes

* **OneDataCollection:** support disabled on primaryActions in dropdown mode ([#4691](https://github.com/factorialco/f0/issues/4691)) ([3b67c38](https://github.com/factorialco/f0/commit/3b67c38240b1224b9c8fd2c8fd064febd27c1046))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).