### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.36.2",
+  "packages/react": "4.36.3",
   "packages/react-native": "0.58.0",
   "packages/core": "1.54.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.36.3](https://github.com/factorialco/f0/compare/f0-react-v4.36.2...f0-react-v4.36.3) (2026-07-15)
+
+
+### Bug Fixes
+
+* **DetailsItem:** remove 320px max-width cap so items fill their container ([#4696](https://github.com/factorialco/f0/issues/4696)) ([9c7375b](https://github.com/factorialco/f0/commit/9c7375b526fc018d68dddc82de5439dccdddfd90))
+
 ## [4.36.2](https://github.com/factorialco/f0/compare/f0-react-v4.36.1...f0-react-v4.36.2) (2026-07-15)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.36.2",
+  "version": "4.36.3",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.36.3</summary>

## [4.36.3](https://github.com/factorialco/f0/compare/f0-react-v4.36.2...f0-react-v4.36.3) (2026-07-15)


### Bug Fixes

* **DetailsItem:** remove 320px max-width cap so items fill their container ([#4696](https://github.com/factorialco/f0/issues/4696)) ([9c7375b](https://github.com/factorialco/f0/commit/9c7375b526fc018d68dddc82de5439dccdddfd90))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).