### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
   "packages/react": "4.36.3",
-  "packages/react-native": "0.58.0",
+  "packages/react-native": "0.58.1",
   "packages/core": "1.54.0"
 }

--- a/packages/react-native/CHANGELOG.md
+++ b/packages/react-native/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.58.1](https://github.com/factorialco/f0/compare/f0-react-native-v0.58.0...f0-react-native-v0.58.1) (2026-07-15)
+
+
+### Bug Fixes
+
+* **F0Button:** clip press overlay to the button's rounded corners ([#4702](https://github.com/factorialco/f0/issues/4702)) ([2b80c30](https://github.com/factorialco/f0/commit/2b80c30c22fcc77b708b7e50416a7a56b68ad66a))
+
 ## [0.58.0](https://github.com/factorialco/f0/compare/f0-react-native-v0.57.0...f0-react-native-v0.58.0) (2026-07-10)
 
 

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react-native",
-  "version": "0.58.0",
+  "version": "0.58.1",
   "type": "module",
   "description": "React Native components for F0 Design System",
   "main": "expo-router/entry",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react-native: 0.58.1</summary>

## [0.58.1](https://github.com/factorialco/f0/compare/f0-react-native-v0.58.0...f0-react-native-v0.58.1) (2026-07-15)


### Bug Fixes

* **F0Button:** clip press overlay to the button's rounded corners ([#4702](https://github.com/factorialco/f0/issues/4702)) ([2b80c30](https://github.com/factorialco/f0/commit/2b80c30c22fcc77b708b7e50416a7a56b68ad66a))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).