### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.37.0",
+  "packages/react": "4.37.1",
   "packages/react-native": "0.58.1",
   "packages/core": "1.54.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.37.1](https://github.com/factorialco/f0/compare/f0-react-v4.37.0...f0-react-v4.37.1) (2026-07-15)
+
+
+### Bug Fixes
+
+* **OneDataCollection:** count selectable rows in selection banner (FCT-56547) ([#4692](https://github.com/factorialco/f0/issues/4692)) ([83e3b6e](https://github.com/factorialco/f0/commit/83e3b6ecffed369fb4215f0c40814efd0f326d5c))
+
 ## [4.37.0](https://github.com/factorialco/f0/compare/f0-react-v4.36.3...f0-react-v4.37.0) (2026-07-15)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.37.0",
+  "version": "4.37.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.37.1</summary>

## [4.37.1](https://github.com/factorialco/f0/compare/f0-react-v4.37.0...f0-react-v4.37.1) (2026-07-15)


### Bug Fixes

* **OneDataCollection:** count selectable rows in selection banner (FCT-56547) ([#4692](https://github.com/factorialco/f0/issues/4692)) ([83e3b6e](https://github.com/factorialco/f0/commit/83e3b6ecffed369fb4215f0c40814efd0f326d5c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).