### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.37.1",
+  "packages/react": "4.38.0",
   "packages/react-native": "0.58.1",
   "packages/core": "1.54.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.38.0](https://github.com/factorialco/f0/compare/f0-react-v4.37.1...f0-react-v4.38.0) (2026-07-15)
+
+
+### Features
+
+* **tags:** add size prop to F0TagRaw (md/sm) ([#4553](https://github.com/factorialco/f0/issues/4553)) ([09c4591](https://github.com/factorialco/f0/commit/09c459124f1cda05d11268236b0fa751f6fe1539))
+
 ## [4.37.1](https://github.com/factorialco/f0/compare/f0-react-v4.37.0...f0-react-v4.37.1) (2026-07-15)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.37.1",
+  "version": "4.38.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.38.0</summary>

## [4.38.0](https://github.com/factorialco/f0/compare/f0-react-v4.37.1...f0-react-v4.38.0) (2026-07-15)


### Features

* **tags:** add size prop to F0TagRaw (md/sm) ([#4553](https://github.com/factorialco/f0/issues/4553)) ([09c4591](https://github.com/factorialco/f0/commit/09c459124f1cda05d11268236b0fa751f6fe1539))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).