### PR TITLE
docs(F0AiChat): fix collapsed chat width in Storybook

### DIFF
--- a/packages/react/src/sds/ai/F0AiChat/__stories__/F0AiChat.stories.tsx
+++ b/packages/react/src/sds/ai/F0AiChat/__stories__/F0AiChat.stories.tsx
@@ -106,7 +106,19 @@ const AiChatWrapper = ({ children }: { children: React.ReactElement }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  return <div className="flex h-[700px] flex-1">{children}</div>
+  // The chat shell has no intrinsic size, so the story frame must supply one:
+  //  - `w-[720px]` (≈ MAX_CHAT_WIDTH): the meta decorator centres the story
+  //    (`layout: "centered"`), so its container shrink-wraps to content. Without
+  //    a fixed width the whole tree collapses to the chat border (~4px) — an
+  //    empty sliver — in both the Canvas and the Docs page.
+  //  - `[&>div]:flex-1`: SidebarWindow animates its width from 0 to "100%" on
+  //    open. That entrance tween never resolves the percentage in Storybook's
+  //    static render, leaving an inline `width: 0` behind. Making the chat a
+  //    growing flex item (flex-basis: 0) ignores that inline width and fills
+  //    the 720px frame.
+  return (
+    <div className="flex h-[700px] w-[720px] [&>div]:flex-1">{children}</div>
+  )
 }
 
 const meta = {


### PR DESCRIPTION
## Description

The **F0AiChat** Storybook page rendered as an empty framed box with a thin vertical line instead of the chat — reported on the [F0AiChat docs page](https://f0.factorial.dev/?path=/docs/kits-ai-f0aichat--documentation).

The chat shell had collapsed to **~4px wide** (just its border). This fixes every F0AiChat story so it renders at a proper width in **both the Canvas and the Docs page** (the bug affected both, not only Docs).

## Screenshots

**Before** — empty box with a ~4px vertical sliver where the chat should be.

**After** — the chat renders at 720px: header, welcome screen (Analyze / Find / Create suggestions), textarea and disclaimer all visible.

_No Figma — this is a Storybook story rendering fix._

## Implementation details

Root cause is a circular width dependency in the story decorator:

- The `meta` decorator uses `layout: "centered"`, so Storybook's story container **shrink-wraps to its content**.
- The chat shell (`SidebarWindow`) is `width: 100%` all the way down with **no intrinsic width**, so the container had nothing to size to → the whole tree collapsed to the chat's border (~4px).

The fix is scoped to the shared `AiChatWrapper` that every F0AiChat story renders through:

- **`w-[720px]`** (≈ `MAX_CHAT_WIDTH`) — gives the frame an explicit width so the centered container has something to size to.
- **`[&>div]:flex-1`** — `SidebarWindow` animates its width from `0` → `"100%"` on open; that entrance tween never resolves the percentage in Storybook's static (non-Chromatic) render, leaving an inline `width: 0` behind. Making the chat a growing flex item (`flex-basis: 0`) ignores that inline width and fills the 720px frame.

### Verification

- All 4 chat instances on the Docs page now measure **720×700** (were 4×700); Canvas verified too.
- Verified locally in Storybook (`pnpm --filter @factorialco/f0-react dev`).
- `oxfmt` + `oxlint` clean. Commit type is `docs` so it won't trigger a release-please version bump (story-only change).

