### PR TITLE
fix(datasource): guard setCurrentSortings against equal values

### DIFF
--- a/packages/react/src/hooks/datasource/__test__/useDataSource.test.tsx
+++ b/packages/react/src/hooks/datasource/__test__/useDataSource.test.tsx
@@ -1,0 +1,70 @@
+import { act, renderHook } from "@testing-library/react"
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  BaseDataAdapter,
+  BaseFetchOptions,
+  BaseResponse,
+  GroupingDefinition,
+  RecordType,
+} from "../types"
+import { SortingsDefinition } from "../types/sortings.typings"
+import { useDataSource } from "../useDataSource"
+
+interface TestRecord extends RecordType {
+  id: number
+}
+
+type TestFilters = Record<string, never>
+
+const baseAdapter: BaseDataAdapter<
+  TestRecord,
+  TestFilters,
+  BaseFetchOptions<TestFilters>,
+  BaseResponse<TestRecord>
+> = {
+  fetchData: vi.fn(() => ({ records: [] })),
+}
+
+const renderDataSource = () =>
+  renderHook(() =>
+    useDataSource<
+      TestRecord,
+      TestFilters,
+      SortingsDefinition,
+      GroupingDefinition<TestRecord>
+    >({
+      dataAdapter: baseAdapter,
+      defaultSortings: { field: "status", order: "asc" },
+    })
+  )
+
+describe("useDataSource — setCurrentSortings", () => {
+  it("ignores a deep-equal sortings value so it does not trigger a redundant refetch", () => {
+    const { result } = renderDataSource()
+
+    const before = result.current.currentSortings
+    expect(before).toEqual({ field: "status", order: "asc" })
+
+    act(() => {
+      // Equal value, new object reference — as URL/storage hydration produces.
+      result.current.setCurrentSortings({ field: "status", order: "asc" })
+    })
+
+    // Reference preserved → no state change → no downstream refetch.
+    expect(result.current.currentSortings).toBe(before)
+  })
+
+  it("applies a different sortings value", () => {
+    const { result } = renderDataSource()
+
+    act(() => {
+      result.current.setCurrentSortings({ field: "name", order: "desc" })
+    })
+
+    expect(result.current.currentSortings).toEqual({
+      field: "name",
+      order: "desc",
+    })
+  })
+})

--- a/packages/react/src/hooks/datasource/useDataSource.ts
+++ b/packages/react/src/hooks/datasource/useDataSource.ts
@@ -138,10 +138,33 @@ export function useDataSource<
   }, [externalCurrentFilters])
 
   /******************* SORTINGS ***************************************************/
-  const [currentSortings, setCurrentSortings] =
+  const [currentSortings, _setCurrentSortings] =
     useState<SortingsState<Sortings> | null>(
       externalCurrentSortings ?? defaultSortings ?? null
     )
+
+  // Skip re-applying an equal-but-new sortings value (e.g. URL/storage hydration
+  // re-setting the current sort) so it doesn't trigger a redundant refetch.
+  // Mirrors `setCurrentFilters` above.
+  const setCurrentSortings: Dispatch<
+    SetStateAction<SortingsState<Sortings> | null>
+  > = (value) => {
+    if (typeof value === "function") {
+      _setCurrentSortings((prev) => {
+        const next = (
+          value as (
+            prevState: SortingsState<Sortings> | null
+          ) => SortingsState<Sortings> | null
+        )(prev)
+        return JSON.stringify(next) === JSON.stringify(prev) ? prev : next
+      })
+    } else {
+      if (JSON.stringify(currentSortings) === JSON.stringify(value)) {
+        return
+      }
+      _setCurrentSortings(value)
+    }
+  }
 
   useDeepCompareEffect(() => {
     if (!externalCurrentSortings) return


### PR DESCRIPTION
## Problem

Any `OneDataCollection` that passes `defaultSortings` fetches its data **twice on mount** with identical variables: the first fetch fires, then the URL/storage hydration layer re-applies the current sort via `setCurrentSortings` with an equal-but-new object, triggering a redundant second fetch (spinner + stale rows re-load once the app shell settles).

## Root cause

In `useDataSource`, `setCurrentFilters` already bails out when the next value is deep-equal to the current one:

```ts
if (JSON.stringify(currentFilters) === JSON.stringify(value)) return
```

`setCurrentSortings` was a raw `useState` setter with **no such guard**, so re-applying an equal sort (as URL sync does on mount) churned state and refetched. Filters didn't repro because they were already guarded — which is why the double-fetch is sort-triggered.

Collections without `defaultSortings` (e.g. Goals) don't repro because nothing writes `dc_sort` to the URL, so there's no sort to re-apply.

## Fix

Wrap `setCurrentSortings` with the same deep-equality guard `setCurrentFilters` has, for both the value and updater-function forms. An equal-but-new sortings object now preserves the reference → no state change → no redundant refetch.

## Tests

Added `useDataSource.test.tsx`:
- deep-equal `setCurrentSortings` preserves the reference (no refetch)
- a different value still applies

All datasource unit tests green.
