### PR TITLE
fix(OneFilterPicker): default NumberFilter to its first declared mode

### DIFF
--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/NumberFilter/NumberFilter.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/NumberFilter/NumberFilter.tsx
@@ -44,6 +44,19 @@ export type NumberFilterComponentProps = FilterTypeComponentProps<
   isCompactMode?: boolean
 }
 
+// The initial mode comes from the first entry in `modes` (defaulting to
+// "single"). Seeding the matching empty value lets a filter locked to
+// `modes: ["range"]` render both range inputs from the start. An empty range is
+// `isEmpty`, so it still adds no chip and applies no constraint.
+const emptyValueForMode = (mode: "single" | "range"): NumberFilterValue =>
+  mode === "range"
+    ? {
+        mode: "range",
+        from: { value: undefined, closed: true },
+        to: { value: undefined, closed: true },
+      }
+    : { mode: "single", value: undefined }
+
 /**
  * A number filter component that provides number input.
  */
@@ -69,14 +82,11 @@ export function NumberFilter({
     options.modes === undefined || options.modes?.length > 1
 
   const [localValue, setLocalValue] = useState<NumberFilterValue>(
-    value ?? {
-      mode: "single",
-      value: undefined,
-    }
+    value ?? emptyValueForMode(options.mode)
   )
 
   useDeepCompareEffect(() => {
-    setLocalValue(value)
+    setLocalValue(value ?? emptyValueForMode(options.mode))
   }, [value])
 
   const handleModeChange = (checked: boolean) => {

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/NumberFilter/__tests__/NumberFilter.test.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/NumberFilter/__tests__/NumberFilter.test.tsx
@@ -1,0 +1,42 @@
+import "@testing-library/jest-dom/vitest"
+import { describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { NumberFilter } from "../NumberFilter"
+
+describe("NumberFilter", () => {
+  it("starts in range mode (both inputs, no value) when modes is locked to ['range']", () => {
+    render(
+      <NumberFilter
+        schema={{
+          label: "Participation rate",
+          options: { modes: ["range"], min: 0, max: 100 },
+        }}
+        value={undefined}
+        onChange={vi.fn()}
+      />
+    )
+
+    // Two inputs (from/to) instead of the single "Value" input.
+    expect(screen.getAllByRole("textbox")).toHaveLength(2)
+    expect(screen.getByText("Greater or equal to")).toBeInTheDocument()
+    expect(screen.getByText("Less or equal to")).toBeInTheDocument()
+    expect(screen.queryByText("Value")).not.toBeInTheDocument()
+    // A single locked mode hides the range toggle.
+    expect(screen.queryByText("Use range")).not.toBeInTheDocument()
+  })
+
+  it("defaults to single mode when no modes are provided", () => {
+    render(
+      <NumberFilter
+        schema={{ label: "Participation rate", options: {} }}
+        value={undefined}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getAllByRole("textbox")).toHaveLength(1)
+    expect(screen.getByText("Value")).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Problem

A `NumberFilter` locked to range mode (`options.modes: ["range"]`) still opens in **single** mode — one "Value" input — until the user has a non-empty range value. You cannot present an always-range filter (two empty min/max inputs) out of the box.

## Root cause

`NumberFilter` derives its initial mode from the incoming `value`, not from `modes`:

```ts
const [localValue, setLocalValue] = useState(value ?? { mode: "single", value: undefined })
useDeepCompareEffect(() => { setLocalValue(value) }, [value])
```

The component *computes* the intended default mode…

```ts
const options = { mode: schema.options?.modes?.[0] ?? "single", ...schema.options }
```

…but `options.mode` is **never read** — it's dead code. Seeding an empty range via `currentFilters` doesn't help either: the number filter's `isEmpty` treats an empty range as empty, so it's coerced to the `undefined` empty value before reaching the component, which then falls back to single mode.

## Fix

Wire the already-computed default mode into the initial state and the value-sync effect via a small `emptyValueForMode` helper:

```ts
const [localValue, setLocalValue] = useState(value ?? emptyValueForMode(options.mode))
useDeepCompareEffect(() => { setLocalValue(value ?? emptyValueForMode(options.mode)) }, [value])
```

Now `modes: ["range"]` renders both range inputs from the start. The seeded range is empty, so it stays `isEmpty` → no chip, no constraint. This also fixes the previous quirk where the in-panel **Clear** dropped a locked-range filter back to single mode.

## Behavior change

- No `modes` (the common case) → unchanged (single).
- `modes` starting with `"single"` → unchanged (single).
- `modes` starting with `"range"` (e.g. `["range"]` or `["range", "single"]`) → now opens in **range** by default (previously single). This matches the documented intent that the first entry in `modes` is the default; the mode toggle (when present) still lets users switch.

## Tests

Added `NumberFilter.test.tsx`:
- `modes: ["range"]` with no value → renders two inputs (range), no "Value" single input, no mode toggle.
- no `modes` → renders a single "Value" input.

Type build + unit tests green.

## Downstream

Unblocks the Performance Reviews list participation-rate filter (a 0–100 min/max range) in the monorepo once this ships and `@factorialco/f0-react` is bumped.
