### PR TITLE
chore(react): Storybook Patterns cleanup — casing + App shell & Filters

### DIFF
--- a/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
@@ -517,7 +517,7 @@ const WelcomeCards = () => {
 }
 
 const meta: Meta<typeof ApplicationFrame> = {
-  title: "ApplicationFrame",
+  title: "App shell/ApplicationFrame",
   component: ApplicationFrame,
   tags: ["autodocs", "experimental"],
   parameters: {

--- a/packages/react/src/patterns/F0FilterPickerContent/__stories__/F0FilterPickerContent.stories.tsx
+++ b/packages/react/src/patterns/F0FilterPickerContent/__stories__/F0FilterPickerContent.stories.tsx
@@ -46,7 +46,7 @@ const simpleFilterDefinition = {
 } as const satisfies FiltersDefinition
 
 const meta = {
-  title: "FilterPickerContent",
+  title: "Filters/FilterPickerContent",
   component: F0FilterPickerContent,
   tags: ["autodocs"],
   parameters: {

--- a/packages/react/src/patterns/OneDataCollection/__stories__/actions/actions.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/actions/actions.mdx
@@ -11,7 +11,7 @@ import * as ActionsStories from "./collection-actions.stories"
 import * as ItemActionsStories from "./item-actions.stories"
 import * as IndexStories from "../index.stories"
 
-<Meta title="Data collection/Actions" />
+<Meta title="Data Collection/Actions" />
 
 # Data collection / Actions
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/callbacks/callbacks.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/callbacks/callbacks.mdx
@@ -8,7 +8,7 @@ import {
 
 import * as CallbacksStories from "./callbacks.stories"
 
-<Meta title="Data collection/Callbacks" />
+<Meta title="Data Collection/Callbacks" />
 
 # Data collection / Callbacks
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/controls.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/controls.mdx
@@ -2,6 +2,6 @@ import { Meta, Controls } from "@storybook/addon-docs/blocks"
 
 import * as DataCollectionStories from "./index.stories"
 
-<Meta title="Data collection/Controls" tags={["no-sidebar"]} />
+<Meta title="Data Collection/Controls" tags={["no-sidebar"]} />
 
 <Controls of={DataCollectionStories.BasicTableView} />

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/by-view/by-view.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/by-view/by-view.stories.tsx
@@ -28,7 +28,7 @@ import {
 } from "../shared"
 
 const meta = {
-  title: "Data collection/CRUD patterns/By view",
+  title: "Data Collection/CRUD patterns/By view",
   tags: ["!autodocs"],
   parameters: {
     layout: "fullscreen",

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/create/create.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/create/create.stories.tsx
@@ -29,7 +29,7 @@ import {
 } from "../shared"
 
 const meta = {
-  title: "Data collection/CRUD patterns/Create",
+  title: "Data Collection/CRUD patterns/Create",
   parameters: {
     layout: "fullscreen",
   },

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/delete/delete.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/delete/delete.stories.tsx
@@ -25,7 +25,7 @@ import {
 } from "../shared"
 
 const meta = {
-  title: "Data collection/CRUD patterns/Delete",
+  title: "Data Collection/CRUD patterns/Delete",
   parameters: {
     layout: "fullscreen",
   },

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/overview.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/overview.mdx
@@ -7,7 +7,7 @@ import containerRightDialog from "./assets/container-right-dialog.png"
 import containerWizardDialog from "./assets/container-wizard-dialog.png"
 import containerConfirmationDialog from "./assets/container-confirmation-dialog.png"
 
-<Meta title="Data collection/CRUD patterns/Overview" />
+<Meta title="Data Collection/CRUD patterns/Overview" />
 
 # Data collection / CRUD patterns
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/read/read.stories.tsx
@@ -34,7 +34,7 @@ import {
 } from "../shared"
 
 const meta = {
-  title: "Data collection/CRUD patterns/Read",
+  title: "Data Collection/CRUD patterns/Read",
   parameters: {
     layout: "fullscreen",
   },

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/update/update.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/update/update.stories.tsx
@@ -29,7 +29,7 @@ import {
 } from "../shared"
 
 const meta = {
-  title: "Data collection/CRUD patterns/Update",
+  title: "Data Collection/CRUD patterns/Update",
   parameters: {
     layout: "fullscreen",
   },

--- a/packages/react/src/patterns/OneDataCollection/__stories__/empty-state.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/empty-state.mdx
@@ -7,7 +7,7 @@ import {
 } from "@storybook/addon-docs/blocks"
 import * as EmptyState from "./empty-states.stories"
 
-<Meta title="Data collection/Empty State" />
+<Meta title="Data Collection/Empty State" />
 
 # Data collection Empty State
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/filters/filters.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/filters/filters.mdx
@@ -2,7 +2,7 @@ import { Meta, Canvas } from "@storybook/addon-docs/blocks"
 import LinkTo from "@storybook/addon-links/react"
 import * as DataCollectionFiltersStories from "./filters.stories"
 
-<Meta title="Data collection/Filters" />
+<Meta title="Data Collection/Filters" />
 
 # Data collection Filters
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/full-height.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/full-height.mdx
@@ -9,7 +9,7 @@ import { DoDonts } from "@/lib/storybook-utils/do-donts"
 
 import * as FullHeightStories from "./full-height.stories"
 
-<Meta title="Data collection/Full height" />
+<Meta title="Data Collection/Full height" />
 
 # Data collection Full height
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/full-height.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/full-height.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from "./mockData"
 
 const meta = {
-  title: "Data collection/Full height",
+  title: "Data Collection/Full height",
   component: ExampleComponent,
   parameters: {
     layout: "padded",

--- a/packages/react/src/patterns/OneDataCollection/__stories__/grouping.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/grouping.mdx
@@ -9,7 +9,7 @@ import { DoDonts } from "@/lib/storybook-utils/do-donts"
 
 import * as GroupingStories from "./grouping.stories"
 
-<Meta title="Data collection/Grouping" />
+<Meta title="Data Collection/Grouping" />
 
 # Data collection Grouping
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/index.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/index.mdx
@@ -24,7 +24,7 @@ import * as ActionDataCollectionStories from "./actions/collection-actions.stori
 import * as DataCollectionTableViewStories from "./visualizations/table/table.stories"
 import { Spinner } from "@/experimental"
 
-<Meta title="Data collection" />
+<Meta title="Data Collection" />
 
 # Data collection
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/loading/loading.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/loading/loading.mdx
@@ -7,7 +7,7 @@ import {
 } from "@storybook/addon-docs/blocks"
 import { DoDonts } from "@/lib/storybook-utils/do-donts"
 
-<Meta title="Data collection/Loading" />
+<Meta title="Data Collection/Loading" />
 
 # Data collection / Loading
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/navigation-filters/navigation-filters.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/navigation-filters/navigation-filters.mdx
@@ -3,9 +3,9 @@ import { DoDonts } from "@/lib/storybook-utils/do-donts"
 
 import * as DataCollectionNavigationFiltersStories from "./navigation-filters.stories"
 
-<Meta title="Data collection/Navigation filters" />
+<Meta title="Data Collection/Navigation filters" />
 
-# Data collection/Navigation filters
+# Data Collection/Navigation filters
 
 ## Introduction
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/pagination/pagination.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/pagination/pagination.mdx
@@ -9,7 +9,7 @@ import { DoDonts } from "@/lib/storybook-utils/do-donts"
 
 import * as DataCollectionStories from "../index.stories"
 
-<Meta title="Data collection/Pagination" />
+<Meta title="Data Collection/Pagination" />
 
 # Data collection / Pagination
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/persistence.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/persistence.mdx
@@ -11,7 +11,7 @@ import * as ActionsStories from "./actions/collection-actions.stories"
 import * as ItemActionsStories from "./actions/item-actions.stories"
 import * as IndexStories from "./index.stories"
 
-<Meta title="Data collection/Status Persistence" />
+<Meta title="Data Collection/Status Persistence" />
 
 # Data collection / Status Persistence
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/selectable-bulk-actions.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/selectable-bulk-actions.mdx
@@ -10,7 +10,7 @@ import { DoDonts } from "@/lib/storybook-utils/do-donts"
 import * as DataCollectionStories from "./index.stories"
 import * as ActionDataCollectionStories from "./actions/collection-actions.stories"
 
-<Meta title="Data collection/Selectable and bulk actions" />
+<Meta title="Data Collection/Selectable and bulk actions" />
 
 # Data collection Selectable and bulk actions
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/sorting/sorting.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/sorting/sorting.mdx
@@ -9,7 +9,7 @@ import { DoDonts } from "@/lib/storybook-utils/do-donts"
 
 import * as DataCollectionStories from "../index.stories"
 
-<Meta title="Data collection/Sorting" />
+<Meta title="Data Collection/Sorting" />
 
 # Data collection / Sorting
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/top-header.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/top-header.mdx
@@ -8,7 +8,7 @@ import {
 import LinkTo from "@storybook/addon-links/react"
 import * as EmptyState from "./empty-states.stories"
 
-<Meta title="Data collection/Top Header" />
+<Meta title="Data Collection/Top Header" />
 
 # Data collection Top Header
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations.mdx
@@ -4,9 +4,9 @@ import { FeatureGrid } from "~/docs/components/FeatureGrid"
 import { Kanban, List, Pencil, Table } from "@/icons/app"
 import * as GraphStories from "./visualizations/graph.stories"
 
-<Meta title="Data collection/Visualizations" />
+<Meta title="Data Collection/Visualizations" />
 
-# Data collection/Visualizations
+# Data Collection/Visualizations
 
 ## Introduction
 

--- a/packages/react/src/patterns/OneDateNavigator/__stories__/OneDateNavigator.stories.tsx
+++ b/packages/react/src/patterns/OneDateNavigator/__stories__/OneDateNavigator.stories.tsx
@@ -16,7 +16,7 @@ import { predefinedPresets } from "../presets"
 import { DatePickerValue } from "../types"
 
 const meta = {
-  title: "DateNavigator",
+  title: "Filters/DateNavigator",
   component: OneDateNavigator,
   parameters: {
     docs: {

--- a/packages/react/src/patterns/OneDateNavigator/__stories__/compareTo.mdx
+++ b/packages/react/src/patterns/OneDateNavigator/__stories__/compareTo.mdx
@@ -1,6 +1,6 @@
 import { Meta, Canvas } from "@storybook/addon-docs/blocks"
 
-<Meta title="DateNavigator/Compare To" />
+<Meta title="Filters/DateNavigator/Compare To" />
 
 import * as DateNavigatorStories from "./OneDateNavigator.stories"
 

--- a/packages/react/src/patterns/OneDateNavigator/__stories__/presets.mdx
+++ b/packages/react/src/patterns/OneDateNavigator/__stories__/presets.mdx
@@ -1,6 +1,6 @@
 import { Meta } from "@storybook/addon-docs/blocks"
 
-<Meta title="DateNavigator/Presets" />
+<Meta title="Filters/DateNavigator/Presets" />
 
 # DateNavigator Presets
 

--- a/packages/react/src/patterns/OneFilterPicker/__stories__/OneFilterPicker.stories.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/__stories__/OneFilterPicker.stories.tsx
@@ -33,7 +33,7 @@ import {
 } from "./mockData"
 
 const meta = {
-  title: "FilterPicker",
+  title: "Filters/FilterPicker",
   component: (props: OneFilterPickerRootProps<FiltersDefinition>) => {
     return <OneFilterPickerComponent {...props} />
   },

--- a/packages/react/src/patterns/OneFilterPicker/__stories__/OneFiltersPicker.internal.mdx
+++ b/packages/react/src/patterns/OneFilterPicker/__stories__/OneFiltersPicker.internal.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks"
 
-<Meta title="FilterPicker/Internal" tags={["internal"]} />
+<Meta title="Filters/FilterPicker/Internal" tags={["internal"]} />
 
 # FilterPicker Internal
 

--- a/packages/react/src/patterns/OneFilterPicker/__stories__/OneFiltersPicker.mdx
+++ b/packages/react/src/patterns/OneFilterPicker/__stories__/OneFiltersPicker.mdx
@@ -1,6 +1,6 @@
 import { Meta, Story, Canvas } from "@storybook/addon-docs/blocks"
 
-<Meta title="FilterPicker" />
+<Meta title="Filters/FilterPicker" />
 import * as OneFiltersPickerStories from "./OneFilterPicker.stories"
 
 # FiltersPicker

--- a/packages/react/src/patterns/OneFilterPicker/__stories__/presets.mdx
+++ b/packages/react/src/patterns/OneFilterPicker/__stories__/presets.mdx
@@ -9,7 +9,7 @@ import { DoDonts } from "@/lib/storybook-utils/do-donts"
 
 import * as OneFiltersPickerStories from "./OneFilterPicker.stories"
 
-<Meta title="FilterPicker/Presets" />
+<Meta title="Filters/FilterPicker/Presets" />
 
 # FiltersPicker / Presets
 

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/__stories__/InFilter.stories.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/__stories__/InFilter.stories.tsx
@@ -14,7 +14,7 @@ import type { InFilterOptionItem, InFilterOptions } from "../types"
 import { InFilter } from "../InFilter"
 
 const meta = {
-  title: "FilterPicker/Filters/InFilter",
+  title: "Filters/FilterPicker/Filters/InFilter",
   component: InFilter,
   parameters: {
     layout: "centered",

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/NumberFilter/__stories__/NumberFilter.stories.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/NumberFilter/__stories__/NumberFilter.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 import { NumberFilter } from "../NumberFilter"
 
 const meta = {
-  title: "FilterPicker/Filters/NumberFilter",
+  title: "Filters/FilterPicker/Filters/NumberFilter",
   component: NumberFilter,
   parameters: {
     layout: "centered",

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/SearchFilter/__stories__/SearchFilter.stories.tsx
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/SearchFilter/__stories__/SearchFilter.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 import { SearchFilter } from "../SearchFilter"
 
 const meta = {
-  title: "FilterPicker/Filters/SearchFilter",
+  title: "Filters/FilterPicker/Filters/SearchFilter",
   component: SearchFilter,
   parameters: {
     layout: "centered",


### PR DESCRIPTION
## What & why

PR 2 of the Storybook reorg series. Cleans up the **Patterns** section: fixes a casing bug and introduces two coherent groups. All changes are title-only.

## Changes

- **Casing fix:** normalize `Data collection` → `Data Collection`. Inconsistent casing (24 vs 6 stories/docs) was splitting OneDataCollection into **two** sidebar nodes.
- **App shell:** `ApplicationFrame` now sits under `Patterns/App shell`, alongside the layouts (it *is* the app shell).
- **Filters:** `FilterPicker`, `FilterPickerContent` and `DateNavigator` grouped under `Patterns/Filters` (DateNavigator is a temporal navigation filter).

## Scope & stacking

**Stacked on #4723** (base branch = `chore/f0-storybook-reorder`). Merge #4723 first, then this rebases onto `main`.

Deferred to later PRs (need cross-section folder moves or the Internal/Deprecated dissolution): `Tabs → Components`, `Box → Components`, dissolve Internal & Deprecated into badges, then functional subgroups.

## Test plan

Verified in Storybook via `/index.json`:

- Patterns 2nd level: `App shell · Filters · Data Collection · AnalyticsDashboard · Graph · Co-creation · CRUD patterns · Dialog · Forms · Navigation · …`
- Single `Data Collection` node (no lowercase duplicate).
- No `DateNavigator` / `FilterPicker` / `FilterPickerContent` as separate top nodes (now under `Filters`).
- 0 title collisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
