### PR TITLE
chore(react): dissolve the Internal Storybook section into a badge

### DIFF
--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -95,8 +95,36 @@ const config: StorybookConfig = {
     // ── Deprecated · scheduled for removal, with migration ───────
     { directory: "../src/deprecated", titlePrefix: "Deprecated" },
 
-    // ── Internal · primitives not exported from the package ──────
-    { directory: "../src/ui", titlePrefix: "🔒 Internal" },
+    // ── ui/ dissolved: "internal" is a badge, not a section. Items go to
+    //    their altitude (primitive / component / pattern); privacy is the
+    //    `internal` tag/badge and stays visible to contributors. ──────────
+    // Core · internal primitives (chrome that wraps public components)
+    { directory: "../src/ui/Action", titlePrefix: "Components/Primitives" },
+    { directory: "../src/ui/Card", titlePrefix: "Components/Primitives" },
+    { directory: "../src/ui/ChevronToggle", titlePrefix: "Components/Primitives" },
+    { directory: "../src/ui/Counter", titlePrefix: "Components/Primitives" },
+    { directory: "../src/ui/DatePickerPopup", titlePrefix: "Components/Primitives" },
+    { directory: "../src/ui/Dialog", titlePrefix: "Components/Primitives" },
+    { directory: "../src/ui/IconBadge", titlePrefix: "Components/Primitives" },
+    { directory: "../src/ui/OverflowList", titlePrefix: "Components/Primitives" },
+    { directory: "../src/ui/Select", titlePrefix: "Components/Primitives" },
+    { directory: "../src/ui/Spinner", titlePrefix: "Components/Primitives" },
+    { directory: "../src/ui/Toast", titlePrefix: "Components/Primitives" },
+    { directory: "../src/ui/VerticalOverflowList", titlePrefix: "Components/Primitives" },
+    // Core · components (the widget itself; no public wrapper)
+    { directory: "../src/ui/ButtonCopy", titlePrefix: "Components" },
+    { directory: "../src/ui/ButtonGroup", titlePrefix: "Components" },
+    { directory: "../src/ui/F0Wizard", titlePrefix: "Components" },
+    { directory: "../src/ui/OnePagination", titlePrefix: "Components" },
+    { directory: "../src/ui/OnePreset", titlePrefix: "Components" },
+    { directory: "../src/ui/Shortcut", titlePrefix: "Components" },
+    { directory: "../src/ui/value-display", titlePrefix: "Components" },
+    { directory: "../src/ui/Omnibutton", titlePrefix: "Components" }, // deprecated (badge)
+    // Patterns
+    { directory: "../src/ui/Kanban", titlePrefix: "Patterns" },
+    { directory: "../src/ui/Lane", titlePrefix: "Patterns" },
+    // Resources
+    { directory: "../src/ui/OneRestrictComponent", titlePrefix: "Resources" },
     ...(process.env.STORYBOOK_PUBLIC_BUILD ? [] : []),
   ],
   staticDirs: ["../public", "./static"],

--- a/packages/react/.storybook/manager.ts
+++ b/packages/react/.storybook/manager.ts
@@ -72,12 +72,9 @@ addons.setConfig({
     collapsedRoots: ["playground"],
     renderLabel: renderSidebarLabel,
     filters: {
-      internal: (item) => {
-        return (
-          !process.env.STORYBOOK_PUBLIC_BUILD ||
-          !item.tags?.includes("internal")
-        )
-      },
+      // `internal` is no longer hidden: it is an informational badge (see
+      // tagBadges below), so internal primitives stay visible to contributors
+      // in every build. Only `no-sidebar` is filtered out.
       noSidebar: (item) => !item.tags?.includes("no-sidebar"),
     },
   },

--- a/packages/react/src/ui/Lane/__stories__/Lane.stories.tsx
+++ b/packages/react/src/ui/Lane/__stories__/Lane.stories.tsx
@@ -27,7 +27,7 @@ const FETCH_DELAY = 1500
 
 const meta = {
   component: Lane,
-  title: "Lane",
+  title: "Kanban/Lane",
   parameters: {
     docs: {
       story: { inline: false, height: "750px" },


### PR DESCRIPTION
## What & why

PR 3a of the Storybook reorg. **Dissolves the `🔒 Internal` section** — consistent with how Experimental was already dissolved: a maturity/visibility *state* is a **badge**, not a top-level category.

The `ui/` folder is no longer a browsable "Internal" bucket. Its stories now sit at their **altitude**, and `internal` becomes an informational badge (not a filter).

## Changes (3 files)

- **`main.ts`** — route each `ui/*` subfolder to its home:
  - internal primitives → `Components/Primitives` (Card, Select, Dialog, Spinner, Toast, DatePickerPopup, OverflowList, VerticalOverflowList, IconBadge, Action, Counter, ChevronToggle)
  - standalone widgets → `Components` (F0Wizard, ButtonCopy, Pagination, ValueDisplay, ButtonGroup, Shortcut, OnePreset)
  - `Kanban` / `Lane` / `KanbanLane` → `Patterns/Kanban`
  - `OneRestrictComponent` → `Resources`
  - `Omnibutton` → `Components` (keeps its `deprecated` badge)
- **`manager.ts`** — remove the sidebar filter that **hid** `internal`-tagged stories in the public build. `internal` stays a badge; primitives are now visible to contributors in every build (matches the lifecycle — primitives get a page *"so DS contributors can find and reuse it"*).
- **`ui/Lane`** — retitle so it nests under `Patterns/Kanban`.

## Scope & stacking

**Stacked on #4725.** Follow-ups: dissolve Deprecated the same way (3b); cross-section moves `Tabs / Box / Reactions → Components`; and internal-badge tag consistency on the primitives that don't yet carry the tag.

## Test plan

Verified in Storybook `/index.json`: **no `🔒 Internal` root**; `Components/Primitives` holds the primitives; widgets under `Components`; `Patterns/Kanban` nests Kanban/Lane; **0 title collisions**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
