### PR TITLE
feat(F0Form): add delete persistence + confirmation to entitiesList

### DIFF
--- a/packages/react/src/experimental/F0FormEditableTable/F0FormEditableTable.tsx
+++ b/packages/react/src/experimental/F0FormEditableTable/F0FormEditableTable.tsx
@@ -222,6 +222,7 @@ type RowCellsProps<R extends RecordType> = {
   onRemoveRow?: (item: R, index: number) => void
   onEditRow?: (item: R, index: number) => void
   canEditRow?: (item: R, index: number) => boolean
+  canRemoveRow?: (item: R, index: number) => boolean
   rowActions?: (item: R, index: number) => F0FormEditableTableRowAction<R>[]
   getCellError?: (
     item: R,
@@ -249,6 +250,7 @@ function RowCells<R extends RecordType>({
   onRemoveRow,
   onEditRow,
   canEditRow,
+  canRemoveRow,
   rowActions,
   getCellError,
   hasActionsColumn,
@@ -259,6 +261,7 @@ function RowCells<R extends RecordType>({
   dragHandle,
 }: RowCellsProps<R>) {
   const showEdit = !!onEditRow && (canEditRow?.(item, index) ?? true)
+  const showRemove = !!onRemoveRow && (canRemoveRow?.(item, index) ?? true)
   const customActions = rowActions?.(item, index) ?? []
   return (
     <>
@@ -345,7 +348,7 @@ function RowCells<R extends RecordType>({
                 disabled={disabled}
               />
             ))}
-            {onRemoveRow && (
+            {showRemove && (
               // The critical variant inverts its icon on `group-hover`, which
               // the surrounding `.group` table row also triggers — turning the
               // icon white on mere row hover. Pin it to the critical color and
@@ -454,6 +457,7 @@ function F0FormEditableTableBase<R extends RecordType>({
   onRemoveRow,
   onEditRow,
   canEditRow,
+  canRemoveRow,
   rowActions,
   getCellError,
   addRow,
@@ -520,6 +524,7 @@ function F0FormEditableTableBase<R extends RecordType>({
       onRemoveRow,
       onEditRow,
       canEditRow,
+      canRemoveRow,
       rowActions,
       getCellError,
       hasActionsColumn,

--- a/packages/react/src/experimental/F0FormEditableTable/types.ts
+++ b/packages/react/src/experimental/F0FormEditableTable/types.ts
@@ -114,6 +114,12 @@ export type F0FormEditableTableProps<R extends RecordType> = {
    */
   canEditRow?: (item: R, index: number) => boolean
   /**
+   * Controls per-row visibility of the remove button (only relevant when
+   * `onRemoveRow` is provided). Independent of `canEditRow`. Defaults to
+   * showing it on every row.
+   */
+  canRemoveRow?: (item: R, index: number) => boolean
+  /**
    * Custom trailing actions per row. Return the actions to show for the given
    * row; because it's resolved per row, the actions can depend on the row's
    * value (e.g. an "Archive" vs "Unarchive" toggle driven by a hidden column).

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -782,6 +782,11 @@ export const defaultTranslations = {
       addBlockedErrorHint:
         "Fix the errors in the existing items before adding another one",
       addBlockedMaxHint: "You've reached the maximum number of items",
+      removeConfirmTitle: "Remove item?",
+      removeConfirmMessage:
+        "This item will be removed. This action cannot be undone.",
+      removeError: "Couldn't remove the item. Please try again.",
+      removeErrorTitle: "Remove failed",
     },
     moreInformation: "More information",
     validation: {

--- a/packages/react/src/patterns/F0Form/__stories__/F0Form.mdx
+++ b/packages/react/src/patterns/F0Form/__stories__/F0Form.mdx
@@ -505,11 +505,11 @@ members: f0FormField.entitiesList({
 
 The three row operations persist through a matching trio:
 
-| Operation | How it persists |
-| --------- | --------------- |
+| Operation | How it persists                             |
+| --------- | ------------------------------------------- |
 | Add       | `createFormDefinition` (its own `onSubmit`) |
 | Edit      | `updateFormDefinition` (its own `onSubmit`) |
-| Remove    | `config.onRemove` |
+| Remove    | `config.onRemove`                           |
 
 `config.onRemove` is the delete counterpart. Removing a row (from the overflow `⋮` menu, per the CRUD "Delete & destructive" doc) now **always confirms first**, then — if `onRemove` is set — runs it with the row item. The row is dropped from the field value only when `onRemove` resolves successfully; returning `{ success: false }` or throwing keeps the row and surfaces an error, and the remove action is disabled while the request is in flight. Without `onRemove`, removal is value-only (the row is spliced out) but the confirmation is still shown.
 

--- a/packages/react/src/patterns/F0Form/__stories__/F0Form.mdx
+++ b/packages/react/src/patterns/F0Form/__stories__/F0Form.mdx
@@ -439,6 +439,8 @@ With more than 2 fields it switches to **dialog** mode by default: the cells are
 
 `editableIds` locks editing to items whose `id` is listed — locked rows render as read-only (disabled) cells. Items without an `id` (rows the user just added) always stay editable.
 
+`removableIds` is the independent counterpart for removal: it locks the remove action to items whose `id` is listed, so a row can be editable but not removable (or vice versa). Omitted → every row is removable, matching `editableIds`. Use it to pin a row (e.g. a resource owner) that must not be deleted while still allowing edits.
+
 ### List-view visualization
 
 When there's no inline editing, set `config.visualization: "list-view"` to render the items as a OneDataCollection **list** instead of a read-only table. Each row shows a title (the first field) and description lines (the rest); **Add** and the per-row **Edit** action open the form dialog, and rows have a **Remove** action. Override the row labelling with `config.listItem` (`title` / `description` / `avatar` functions). Drag-reorder isn't available in list mode.
@@ -553,6 +555,7 @@ config: {
 - `minItems` / `maxItems` — array-length validation; the add button hides at `maxItems`.
 - `labels` — `addButton`, `create`/`update` (each `{ title, description }`) and `edit`/`remove` action labels. The create description doubles as the add button's tooltip; the update title as the icon-only edit action's tooltip.
 - `onRemove` / `confirmRemove` — persist and confirm removals (see [Persisting removals](#persisting-removals)).
+- `editableIds` / `removableIds` — independently lock editing / removal to the listed `id`s (see above).
 - `visualization` — `"editable-table"` (default) or `"list-view"` (see above).
 
 ### Auto-save

--- a/packages/react/src/patterns/F0Form/__stories__/F0Form.mdx
+++ b/packages/react/src/patterns/F0Form/__stories__/F0Form.mdx
@@ -501,9 +501,38 @@ members: f0FormField.entitiesList({
 
 <Canvas of={Stories.EntitiesListFieldFormDefinitions} />
 
+### Persisting removals
+
+The three row operations persist through a matching trio:
+
+| Operation | How it persists |
+| --------- | --------------- |
+| Add       | `createFormDefinition` (its own `onSubmit`) |
+| Edit      | `updateFormDefinition` (its own `onSubmit`) |
+| Remove    | `config.onRemove` |
+
+`config.onRemove` is the delete counterpart. Removing a row (from the overflow `⋮` menu, per the CRUD "Delete & destructive" doc) now **always confirms first**, then — if `onRemove` is set — runs it with the row item. The row is dropped from the field value only when `onRemove` resolves successfully; returning `{ success: false }` or throwing keeps the row and surfaces an error, and the remove action is disabled while the request is in flight. Without `onRemove`, removal is value-only (the row is spliced out) but the confirmation is still shown.
+
+Use `config.confirmRemove` to **name the resource** in the confirmation (what, how much, whether reversible). When omitted, a generic default confirmation is used.
+
+```tsx
+config: {
+  onRemove: async (item) => {
+    await api.delete(item.id)
+    return { success: true }
+  },
+  confirmRemove: (item) => ({
+    type: "critical",
+    title: `Remove ${item.name}?`,
+    msg: "They will lose access immediately. This cannot be undone.",
+    confirm: { label: "Remove" },
+  }),
+}
+```
+
 ### Custom row actions
 
-`config.rowActions` adds trailing action buttons per row. It's resolved per row, so the actions can depend on the row's value — e.g. an Archive / Unarchive toggle driven by a hidden `archived` column. Each action's `onClick` receives `update` / `remove` helpers to mutate that row:
+`config.rowActions` adds trailing action buttons per row. It's resolved per row, so the actions can depend on the row's value — e.g. an Archive / Unarchive toggle driven by a hidden `archived` column. Each action's `onClick` receives `update` / `remove` helpers to mutate that row. The `remove` helper routes through the same confirm + `onRemove` path as the built-in remove, so custom "Delete" actions also confirm and persist:
 
 ```tsx
 config: {
@@ -523,6 +552,7 @@ config: {
 - `canAddItems` (default `true`) — show the add button. Adding is blocked while an existing row is still invalid.
 - `minItems` / `maxItems` — array-length validation; the add button hides at `maxItems`.
 - `labels` — `addButton`, `create`/`update` (each `{ title, description }`) and `edit`/`remove` action labels. The create description doubles as the add button's tooltip; the update title as the icon-only edit action's tooltip.
+- `onRemove` / `confirmRemove` — persist and confirm removals (see [Persisting removals](#persisting-removals)).
 - `visualization` — `"editable-table"` (default) or `"list-view"` (see above).
 
 ### Auto-save

--- a/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
+++ b/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
@@ -2000,13 +2000,17 @@ export const EntitiesListFieldNavigable: Story = {
 }
 
 /**
- * Separate create/update form definitions. Instead of a single `schema`, the
- * field takes a `createFormDefinition` (reduced: name + email) and an
- * `updateFormDefinition` (fuller: adds role + start date), each with its **own**
- * `onSubmit` — so adding vs editing can persist independently (watch the
- * console: `CREATE` vs `UPDATE`). The item is still committed to the field
- * value. `updateFormDefinition`'s schema is canonical, so its extra fields are
- * `optional` to keep freshly-added rows valid.
+ * The full persistence trio: **add** → `createFormDefinition`, **edit** →
+ * `updateFormDefinition`, **remove** → `config.onRemove`. Each runs its own
+ * request independently (watch the console: `CREATE` / `UPDATE` / `DELETE`), and
+ * the field value is kept in sync. `createFormDefinition` is reduced (name +
+ * email) and `updateFormDefinition` is canonical (adds role + start date), so
+ * its extra fields are `optional` to keep freshly-added rows valid.
+ *
+ * Removing opens a confirmation first (custom copy via `config.confirmRemove`,
+ * which names the member), and the row is only dropped once `onRemove` resolves
+ * successfully — return `{ success: false }` or throw to keep it and surface an
+ * error.
  */
 export const EntitiesListFieldFormDefinitions: Story = {
   parameters: { docs: { story: { inline: false, height: "560px" } } },
@@ -2058,6 +2062,19 @@ export const EntitiesListFieldFormDefinitions: Story = {
           labels: {
             addButton: "Add member",
             update: { title: "Edit member" },
+          },
+          // Delete counterpart to create/update: confirm first (naming the
+          // member), then persist. The row is dropped only on success.
+          confirmRemove: (item) => ({
+            type: "critical",
+            title: `Remove ${String(item.name)}?`,
+            msg: "They will lose access immediately. This cannot be undone.",
+            confirm: { label: "Remove" },
+          }),
+          onRemove: async (item) => {
+            await sleep(300)
+            console.info(`DELETE member: ${JSON.stringify(item)}`)
+            return { success: true }
           },
         },
       }),

--- a/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
+++ b/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
@@ -2010,7 +2010,8 @@ export const EntitiesListFieldNavigable: Story = {
  * Removing opens a confirmation first (custom copy via `config.confirmRemove`,
  * which names the member), and the row is only dropped once `onRemove` resolves
  * successfully — return `{ success: false }` or throw to keep it and surface an
- * error.
+ * error. `config.removableIds` pins the first member (editable, but no remove
+ * action) to show that edit and remove gate independently.
  */
 export const EntitiesListFieldFormDefinitions: Story = {
   parameters: { docs: { story: { inline: false, height: "560px" } } },
@@ -2063,6 +2064,10 @@ export const EntitiesListFieldFormDefinitions: Story = {
             addButton: "Add member",
             update: { title: "Edit member" },
           },
+          // `removableIds` is independent of editing: the owner (m-1) stays
+          // editable but has no remove action, while everyone else is
+          // removable. Newly-added rows (no id) stay removable.
+          removableIds: ["m-2"],
           // Delete counterpart to create/update: confirm first (naming the
           // member), then persist. The row is dropped only on success.
           confirmRemove: (item) => ({

--- a/packages/react/src/patterns/F0Form/fields/entitiesList/EntitiesListFieldRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/fields/entitiesList/EntitiesListFieldRenderer.tsx
@@ -470,6 +470,21 @@ export function EntitiesListFieldRenderer({
     [field.editableIds]
   )
 
+  /**
+   * Whether an item can be removed: independent of {@link isRowEditable}.
+   * Every item when `removableIds` is omitted; otherwise items whose `id` is
+   * listed. Items without an `id` (rows just added locally) stay removable.
+   */
+  const isRowRemovable = useCallback(
+    (row: EntitiesListRow): boolean => {
+      if (!field.removableIds) return true
+      const id = row.id
+      if (id === undefined || id === null) return true
+      return field.removableIds.includes(id as string | number)
+    },
+    [field.removableIds]
+  )
+
   // --- Dialog editing (dialog mode, or a split create/update schema) --------
 
   /**
@@ -791,6 +806,13 @@ export function EntitiesListFieldRenderer({
     },
     [findRow, isRowEditable]
   )
+  const canRemoveRowByKey = useCallback(
+    (rowKey: string) => {
+      const row = findRow(rowKey)
+      return row ? isRowRemovable(row) : true
+    },
+    [findRow, isRowRemovable]
+  )
   const itemHref = field.itemHref
   const hrefByKey = useCallback(
     (rowKey: string) => {
@@ -880,6 +902,7 @@ export function EntitiesListFieldRenderer({
           })}
           listItem={field.listItem}
           canEditRow={canEditRowByKey}
+          canRemoveRow={canRemoveRowByKey}
           onEditRow={isNavigable || isDisabled ? undefined : editRowByKey}
           onRowClick={isNavigable || isDisabled ? undefined : editRowByKey}
           onRemoveRow={isDisabled ? undefined : removeRowByKey}
@@ -927,6 +950,7 @@ export function EntitiesListFieldRenderer({
           useDialogMode ? (row) => openItemDialog("edit", row) : undefined
         }
         canEditRow={isRowEditable}
+        canRemoveRow={isRowRemovable}
         rowActions={rowActions}
         editLabel={editLabel}
         removeLabel={removeLabel}

--- a/packages/react/src/patterns/F0Form/fields/entitiesList/EntitiesListFieldRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/fields/entitiesList/EntitiesListFieldRenderer.tsx
@@ -12,6 +12,8 @@ import type { F0FormEditableTableColumn } from "@/experimental/F0FormEditableTab
 import { F0Button } from "@/components/F0Button"
 import { F0FormEditableTable } from "@/experimental/F0FormEditableTable"
 import { Add } from "@/icons/app"
+import { dialogs } from "@/lib/providers/dialogs-alike"
+import type { ConfirmDialogOptions } from "@/lib/providers/dialogs-alike/types"
 import { useI18n } from "@/lib/providers/i18n/i18n-provider"
 import {
   Tooltip,
@@ -319,6 +321,14 @@ export function EntitiesListFieldRenderer({
     makeRows(formField.value)
   )
 
+  // Keys of rows whose `onRemove` persistence hook is currently in flight, so
+  // the row's remove action can be disabled until it settles.
+  const [removingKeys, setRemovingKeys] = useState<Set<string>>(() => new Set())
+  const isRemovePending = useCallback(
+    (rowKey: string) => removingKeys.has(rowKey),
+    [removingKeys]
+  )
+
   // Track the last value we pushed to the form so the sync effect below can
   // tell our own updates apart from external ones (e.g. a form reset).
   const lastCommittedRef = useRef<string>(
@@ -345,6 +355,81 @@ export function EntitiesListFieldRenderer({
       formField.onChange(value)
     },
     [formField, rowItemToForm]
+  )
+
+  const onRemove = field.onRemove
+  const confirmRemove = field.confirmRemove
+  /**
+   * Confirmation-gated, persistence-aware row removal — the delete counterpart
+   * to the add/edit dialogs. Shared by the editable table, the list-view remove
+   * action and the `rowActions` `remove()` helper, so every removal path:
+   *
+   * 1. Confirms first (custom copy via `confirmRemove`, else a generic default),
+   *    per the CRUD "Delete & destructive" doc. Cancelling leaves the row.
+   * 2. Runs `onRemove` (if provided) with the item; a thrown error or a
+   *    `{ success: false }` result keeps the row and shows an error, and the
+   *    action is disabled while the hook is in flight.
+   * 3. Only splices the row from the field value on success.
+   */
+  const performRemove = useCallback(
+    async (row: EntitiesListRow) => {
+      const { __key, ...rawItem } = row
+      // Hand callbacks the item in its form shape (ISO date strings → `Date`),
+      // matching the row value type the schema declares.
+      const item = rowItemToForm(rawItem)
+
+      const confirmOptions: ConfirmDialogOptions = confirmRemove
+        ? confirmRemove(item)
+        : {
+            type: "critical",
+            title: translations.removeConfirmTitle,
+            msg: translations.removeConfirmMessage,
+            confirm: { label: removeLabel },
+          }
+      const confirmed = await dialogs.confirmation(confirmOptions)
+      if (!confirmed) return
+
+      if (onRemove) {
+        setRemovingKeys((prev) => new Set(prev).add(__key))
+        try {
+          const result = await onRemove(item)
+          if (result && result.success === false) {
+            await dialogs.alert({
+              type: "critical",
+              title: translations.removeErrorTitle,
+              msg: translations.removeError,
+            })
+            return
+          }
+        } catch {
+          await dialogs.alert({
+            type: "critical",
+            title: translations.removeErrorTitle,
+            msg: translations.removeError,
+          })
+          return
+        } finally {
+          setRemovingKeys((prev) => {
+            const next = new Set(prev)
+            next.delete(__key)
+            return next
+          })
+        }
+      }
+
+      commit(rows.filter((r) => r.__key !== __key))
+      formField.onBlur()
+    },
+    [
+      rows,
+      commit,
+      formField,
+      onRemove,
+      confirmRemove,
+      rowItemToForm,
+      translations,
+      removeLabel,
+    ]
   )
 
   /**
@@ -626,10 +711,9 @@ export function EntitiesListFieldRenderer({
                     r.__key === row.__key ? { ...r, ...partial } : r
                   )
                 ),
-              remove: () => {
-                commit(rows.filter((r) => r.__key !== row.__key))
-                formField.onBlur()
-              },
+              // Route through the confirm + persist path so custom actions that
+              // call remove() also confirm and hit onRemove.
+              remove: () => void performRemove(row),
             }),
         }))
       }
@@ -695,10 +779,10 @@ export function EntitiesListFieldRenderer({
   )
   const removeRowByKey = useCallback(
     (rowKey: string) => {
-      commit(rows.filter((r) => r.__key !== rowKey))
-      formField.onBlur()
+      const row = findRow(rowKey)
+      if (row) void performRemove(row)
     },
-    [rows, commit, formField]
+    [findRow, performRemove]
   )
   const canEditRowByKey = useCallback(
     (rowKey: string) => {
@@ -738,14 +822,13 @@ export function EntitiesListFieldRenderer({
               commit(
                 rows.map((r) => (r.__key === rowKey ? { ...r, ...partial } : r))
               ),
-            remove: () => {
-              commit(rows.filter((r) => r.__key !== rowKey))
-              formField.onBlur()
-            },
+            // Route through the confirm + persist path so custom actions that
+            // call remove() also confirm and hit onRemove.
+            remove: () => void performRemove(rows[index]),
           }),
       }))
     },
-    [rowActionsFn, rows, commit, formField]
+    [rowActionsFn, rows, commit, formField, performRemove]
   )
 
   // The field renders its own label (FieldRenderer suppresses the default one)
@@ -800,6 +883,7 @@ export function EntitiesListFieldRenderer({
           onEditRow={isNavigable || isDisabled ? undefined : editRowByKey}
           onRowClick={isNavigable || isDisabled ? undefined : editRowByKey}
           onRemoveRow={isDisabled ? undefined : removeRowByKey}
+          isRemovePending={isRemovePending}
           getRowActions={rowActionsFn ? rowActionsByKey : undefined}
           getRowHref={isNavigable ? hrefByKey : undefined}
           editLabel={editTooltipLabel}
@@ -838,10 +922,7 @@ export function EntitiesListFieldRenderer({
         // disabled via `disabled` below) so submitting doesn't shift the layout.
         sortableRows={field.sortable !== false}
         onReorderRows={({ items }) => commit(items)}
-        onRemoveRow={(row) => {
-          commit(rows.filter((r) => r.__key !== row.__key))
-          formField.onBlur()
-        }}
+        onRemoveRow={(row) => void performRemove(row)}
         onEditRow={
           useDialogMode ? (row) => openItemDialog("edit", row) : undefined
         }
@@ -849,7 +930,9 @@ export function EntitiesListFieldRenderer({
         rowActions={rowActions}
         editLabel={editLabel}
         removeLabel={removeLabel}
-        disabled={isDisabled}
+        // The editable table disables the remove control table-wide (there's no
+        // per-row remove disable), so freeze it while any onRemove is in flight.
+        disabled={isDisabled || removingKeys.size > 0}
       />
 
       {rootError && (

--- a/packages/react/src/patterns/F0Form/fields/entitiesList/EntitiesListView.tsx
+++ b/packages/react/src/patterns/F0Form/fields/entitiesList/EntitiesListView.tsx
@@ -71,6 +71,11 @@ interface EntitiesListViewProps {
   onEditRow?: (rowKey: string) => void
   /** Removes a row by key (omitted when the field is disabled). */
   onRemoveRow?: (rowKey: string) => void
+  /**
+   * Whether a row's remove is mid-flight (its `onRemove` hook hasn't settled),
+   * so the remove action is disabled until it does.
+   */
+  isRemovePending?: (rowKey: string) => boolean
   /** Whether a given row can be edited (drives the edit action's presence). */
   canEditRow: (rowKey: string) => boolean
   /** Row click handler — opens the edit dialog (editable mode). */
@@ -104,6 +109,7 @@ export function EntitiesListView({
   listItem,
   onEditRow,
   onRemoveRow,
+  isRemovePending,
   canEditRow,
   onRowClick,
   getRowHref,
@@ -166,12 +172,16 @@ export function EntitiesListView({
                 enabled: action.disabled ? false : undefined,
                 onClick: action.onClick,
               })),
-              ...(onRemoveRow
+              // Remove respects `editableIds` (via `canEditRow`), same as edit:
+              // a locked row (e.g. a pinned owner) is neither editable nor
+              // removable.
+              ...(onRemoveRow && canEditRow(id)
                 ? [
                     {
                       label: removeLabel,
                       icon: Delete,
                       critical: true,
+                      enabled: isRemovePending?.(id) ? false : undefined,
                       onClick: () => onRemoveRow(id),
                     },
                   ]
@@ -185,6 +195,7 @@ export function EntitiesListView({
       hasActions,
       onEditRow,
       onRemoveRow,
+      isRemovePending,
       canEditRow,
       getRowActions,
       getRowHref,

--- a/packages/react/src/patterns/F0Form/fields/entitiesList/EntitiesListView.tsx
+++ b/packages/react/src/patterns/F0Form/fields/entitiesList/EntitiesListView.tsx
@@ -78,6 +78,8 @@ interface EntitiesListViewProps {
   isRemovePending?: (rowKey: string) => boolean
   /** Whether a given row can be edited (drives the edit action's presence). */
   canEditRow: (rowKey: string) => boolean
+  /** Whether a given row can be removed (drives the remove action's presence). */
+  canRemoveRow: (rowKey: string) => boolean
   /** Row click handler — opens the edit dialog (editable mode). */
   onRowClick?: (rowKey: string) => void
   /** Per-row link — makes the row navigable with a trailing arrow (nav mode). */
@@ -111,6 +113,7 @@ export function EntitiesListView({
   onRemoveRow,
   isRemovePending,
   canEditRow,
+  canRemoveRow,
   onRowClick,
   getRowHref,
   getRowActions,
@@ -172,10 +175,10 @@ export function EntitiesListView({
                 enabled: action.disabled ? false : undefined,
                 onClick: action.onClick,
               })),
-              // Remove respects `editableIds` (via `canEditRow`), same as edit:
-              // a locked row (e.g. a pinned owner) is neither editable nor
-              // removable.
-              ...(onRemoveRow && canEditRow(id)
+              // Remove respects `removableIds` (via `canRemoveRow`),
+              // independent of edit: a row can be editable but not removable,
+              // or vice versa. A row outside `removableIds` shows no remove.
+              ...(onRemoveRow && canRemoveRow(id)
                 ? [
                     {
                       label: removeLabel,
@@ -197,6 +200,7 @@ export function EntitiesListView({
       onRemoveRow,
       isRemovePending,
       canEditRow,
+      canRemoveRow,
       getRowActions,
       getRowHref,
       onRowClick,

--- a/packages/react/src/patterns/F0Form/fields/entitiesList/__tests__/EntitiesListFieldRenderer.test.tsx
+++ b/packages/react/src/patterns/F0Form/fields/entitiesList/__tests__/EntitiesListFieldRenderer.test.tsx
@@ -1,6 +1,7 @@
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 import { z } from "zod"
 
+import { dialogs } from "@/lib/providers/dialogs-alike"
 import {
   zeroRender as render,
   screen,
@@ -180,11 +181,21 @@ describe("EntitiesListFieldRenderer — add / remove", () => {
     await userEvent.click(screen.getByRole("button", { name: "Add FAQ" }))
     expect(screen.getAllByRole("row")).toHaveLength(3) // header + 2 rows
 
+    // Removing is now confirmation-gated (per the CRUD "Delete & destructive"
+    // doc) even without an `onRemove` — stub the confirmation to accept.
+    const confirmation = vi
+      .spyOn(dialogs, "confirmation")
+      .mockResolvedValue(true)
+
     // Remove the first data row (the entities list labels its remove action
     // "Remove", consistent with the list-view and overridable via labels.remove)
     const removeButtons = screen.getAllByRole("button", { name: "Remove" })
     await userEvent.click(removeButtons[0])
-    expect(screen.getAllByRole("row")).toHaveLength(2) // header + 1 row
+    await waitFor(() => {
+      expect(screen.getAllByRole("row")).toHaveLength(2) // header + 1 row
+    })
+    expect(confirmation).toHaveBeenCalledTimes(1)
+    confirmation.mockRestore()
   })
 })
 
@@ -332,5 +343,303 @@ describe("EntitiesListFieldRenderer — editableIds", () => {
     expect(screen.queryByDisplayValue("Locked")).toBeNull()
     const lockedCell = screen.getByText("Locked")
     expect(within(lockedCell.closest("tr")!).queryByRole("textbox")).toBeNull()
+  })
+})
+
+describe("EntitiesListFieldRenderer — delete persistence + confirmation", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  /** A single-column (inline) entities list with an optional `onRemove`. */
+  function renderList(
+    onRemove?: (item: unknown) => Promise<{ success: boolean } | void>,
+    extraConfig?: Record<string, unknown>
+  ) {
+    const schema = z.object({
+      faqs: f0FormField.entitiesList({
+        label: "FAQs",
+        schema: z.object({ title: z.string().min(1) }),
+        config: { onRemove, ...extraConfig },
+      }),
+    })
+    return render(
+      <F0Form
+        name="delete"
+        schema={schema}
+        defaultValues={{ faqs: [{ id: "a", title: "One" }] }}
+        onSubmit={async () => ({ success: true })}
+      />
+    )
+  }
+
+  it("shows a confirmation before removing; cancelling keeps the row and skips onRemove", async () => {
+    const confirmation = vi
+      .spyOn(dialogs, "confirmation")
+      .mockResolvedValue(false)
+    const onRemove = vi.fn(async () => ({ success: true }))
+    renderList(onRemove)
+
+    expect(screen.getAllByRole("row")).toHaveLength(2) // header + 1 row
+    await userEvent.click(screen.getByRole("button", { name: "Remove" }))
+
+    await waitFor(() => expect(confirmation).toHaveBeenCalledTimes(1))
+    // Cancelled: row stays, onRemove never runs.
+    expect(onRemove).not.toHaveBeenCalled()
+    expect(screen.getAllByRole("row")).toHaveLength(2)
+  })
+
+  it("confirming calls onRemove with the item and removes the row on success", async () => {
+    vi.spyOn(dialogs, "confirmation").mockResolvedValue(true)
+    const onRemove = vi.fn(async () => ({ success: true }))
+    renderList(onRemove)
+
+    await userEvent.click(screen.getByRole("button", { name: "Remove" }))
+
+    await waitFor(() => {
+      expect(onRemove).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "a", title: "One" })
+      )
+    })
+    await waitFor(() => {
+      expect(screen.getAllByRole("row")).toHaveLength(1) // header only
+    })
+  })
+
+  it("keeps the row when onRemove returns { success: false }", async () => {
+    vi.spyOn(dialogs, "confirmation").mockResolvedValue(true)
+    const alert = vi.spyOn(dialogs, "alert").mockResolvedValue(true)
+    const onRemove = vi.fn(async () => ({ success: false }))
+    renderList(onRemove)
+
+    await userEvent.click(screen.getByRole("button", { name: "Remove" }))
+
+    await waitFor(() => expect(onRemove).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(alert).toHaveBeenCalledTimes(1))
+    // Persistence failed → the row is kept.
+    expect(screen.getAllByRole("row")).toHaveLength(2)
+  })
+
+  it("keeps the row when onRemove throws", async () => {
+    vi.spyOn(dialogs, "confirmation").mockResolvedValue(true)
+    const alert = vi.spyOn(dialogs, "alert").mockResolvedValue(true)
+    const onRemove = vi.fn(async () => {
+      throw new Error("boom")
+    })
+    renderList(onRemove)
+
+    await userEvent.click(screen.getByRole("button", { name: "Remove" }))
+
+    await waitFor(() => expect(alert).toHaveBeenCalledTimes(1))
+    expect(screen.getAllByRole("row")).toHaveLength(2)
+  })
+
+  it("disables the remove action while onRemove is in flight", async () => {
+    vi.spyOn(dialogs, "confirmation").mockResolvedValue(true)
+    let release: (value: { success: boolean }) => void = () => {}
+    const onRemove = vi.fn(
+      () =>
+        new Promise<{ success: boolean }>((resolve) => {
+          release = resolve
+        })
+    )
+    renderList(onRemove)
+
+    const removeButton = screen.getByRole("button", { name: "Remove" })
+    await userEvent.click(removeButton)
+
+    // Pending: the remove control is disabled until onRemove settles.
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Remove" })).toBeDisabled()
+    )
+
+    release({ success: true })
+    await waitFor(() => expect(screen.getAllByRole("row")).toHaveLength(1))
+  })
+
+  it("uses the confirmRemove copy when provided", async () => {
+    const confirmation = vi
+      .spyOn(dialogs, "confirmation")
+      .mockResolvedValue(false)
+    const confirmRemove = vi.fn((item: { title?: unknown }) => ({
+      type: "critical" as const,
+      title: `Delete ${String(item.title)}?`,
+      msg: "This FAQ will be permanently removed.",
+    }))
+    renderList(undefined, { confirmRemove })
+
+    await userEvent.click(screen.getByRole("button", { name: "Remove" }))
+
+    await waitFor(() =>
+      expect(confirmation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "critical",
+          title: "Delete One?",
+          msg: "This FAQ will be permanently removed.",
+        })
+      )
+    )
+    expect(confirmRemove).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "One" })
+    )
+  })
+
+  it("still gates editing via editableIds while remove stays confirm-gated", async () => {
+    vi.spyOn(dialogs, "confirmation").mockResolvedValue(true)
+    const onRemove = vi.fn(async () => ({ success: true }))
+    const schema = z.object({
+      faqs: f0FormField.entitiesList({
+        label: "FAQs",
+        schema: z.object({ title: z.string().min(1) }),
+        config: { editableIds: ["a"], onRemove },
+      }),
+    })
+    render(
+      <F0Form
+        name="editable-delete"
+        schema={schema}
+        defaultValues={{
+          faqs: [
+            { id: "a", title: "Editable" },
+            { id: "b", title: "Locked" },
+          ],
+        }}
+        onSubmit={async () => ({ success: true })}
+      />
+    )
+
+    // Editing gating unchanged: locked row has no input.
+    expect(screen.getByDisplayValue("Editable")).toBeInTheDocument()
+    expect(screen.queryByDisplayValue("Locked")).toBeNull()
+
+    // Removing the locked row still confirms + persists.
+    const lockedRow = screen.getByText("Locked").closest("tr")!
+    await userEvent.click(
+      within(lockedRow).getByRole("button", { name: "Remove" })
+    )
+    await waitFor(() =>
+      expect(onRemove).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "b", title: "Locked" })
+      )
+    )
+  })
+})
+
+describe("EntitiesListFieldRenderer — list-view remove gating (editableIds)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  /**
+   * The list-view row container. Rows have no semantic role, so walk up from
+   * the row's title text to the collection row element (identified by its
+   * `min-h-[64px]` layout class) to scope action queries per row.
+   */
+  function rowOf(name: string): HTMLElement {
+    let el: HTMLElement | null = screen.getByText(name)
+    while (el && !(el.className || "").includes("min-h-[64px]")) {
+      el = el.parentElement
+    }
+    if (!el) throw new Error(`Row for "${name}" not found`)
+    return el
+  }
+
+  /** A pinned-owner + members list, with an optional `editableIds` gate. */
+  function renderMembers(
+    editableIds?: Array<string | number>,
+    onRemove?: () => Promise<{ success: boolean } | void>
+  ) {
+    const schema = z.object({
+      members: f0FormField.entitiesList({
+        label: "Members",
+        schema: z.object({
+          name: z.string().min(1),
+          role: z.string().min(1),
+        }),
+        config: {
+          visualization: "list-view",
+          ...(editableIds ? { editableIds } : {}),
+          ...(onRemove ? { onRemove } : {}),
+        },
+      }),
+    })
+    return render(
+      <F0Form
+        name="members"
+        schema={schema}
+        defaultValues={{
+          members: [
+            { id: "owner", name: "Ada", role: "Owner" },
+            { id: "m1", name: "Bob", role: "Member" },
+            { id: "m2", name: "Cid", role: "Member" },
+          ],
+        }}
+        onSubmit={async () => ({ success: true })}
+      />
+    )
+  }
+
+  it("locks both edit and remove for a row outside editableIds (pinned owner)", async () => {
+    // Everyone editable except the pinned owner.
+    renderMembers(["m1", "m2"])
+
+    // Locked owner row: no edit action and no overflow trigger at all, so the
+    // remove action (which lives in the overflow menu) is unreachable.
+    const owner = rowOf("Ada")
+    expect(within(owner).queryByRole("button", { name: "Edit" })).toBeNull()
+    expect(within(owner).queryByRole("button", { name: "Actions" })).toBeNull()
+
+    // Editable member row: has the edit action and an overflow menu that
+    // contains Remove.
+    const member = rowOf("Bob")
+    expect(
+      within(member).getByRole("button", { name: "Edit" })
+    ).toBeInTheDocument()
+    await userEvent.click(
+      within(member).getByRole("button", { name: "Actions" })
+    )
+    expect(
+      await screen.findByRole("menuitem", { name: "Remove" })
+    ).toBeInTheDocument()
+  })
+
+  it("keeps every row editable and removable when editableIds is omitted (back-compat)", async () => {
+    renderMembers()
+
+    // With no gate, every row exposes the edit action and an overflow trigger.
+    expect(screen.getAllByRole("button", { name: "Edit" })).toHaveLength(3)
+    expect(screen.getAllByRole("button", { name: "Actions" })).toHaveLength(3)
+
+    // The pinned owner is now removable too — its overflow menu has Remove.
+    await userEvent.click(
+      within(rowOf("Ada")).getByRole("button", { name: "Actions" })
+    )
+    expect(
+      await screen.findByRole("menuitem", { name: "Remove" })
+    ).toBeInTheDocument()
+  })
+
+  it("removes an editable row from the overflow menu (confirm + onRemove)", async () => {
+    const confirmation = vi
+      .spyOn(dialogs, "confirmation")
+      .mockResolvedValue(true)
+    const onRemove = vi.fn(async () => ({ success: true }))
+    renderMembers(["m1", "m2"], onRemove)
+
+    await userEvent.click(
+      within(rowOf("Bob")).getByRole("button", { name: "Actions" })
+    )
+    await userEvent.click(
+      await screen.findByRole("menuitem", { name: "Remove" })
+    )
+
+    await waitFor(() => expect(confirmation).toHaveBeenCalledTimes(1))
+    await waitFor(() =>
+      expect(onRemove).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "m1", name: "Bob" })
+      )
+    )
+    // The row is gone once onRemove resolves.
+    await waitFor(() => expect(screen.queryByText("Bob")).toBeNull())
   })
 })

--- a/packages/react/src/patterns/F0Form/fields/entitiesList/__tests__/EntitiesListFieldRenderer.test.tsx
+++ b/packages/react/src/patterns/F0Form/fields/entitiesList/__tests__/EntitiesListFieldRenderer.test.tsx
@@ -346,6 +346,44 @@ describe("EntitiesListFieldRenderer — editableIds", () => {
   })
 })
 
+describe("EntitiesListFieldRenderer — removableIds (editable-table)", () => {
+  it("shows the remove button only for rows inside removableIds", () => {
+    const schema = z.object({
+      faqs: f0FormField.entitiesList({
+        label: "FAQs",
+        schema: z.object({ title: z.string().min(1) }),
+        // Independent of editing: "a" is removable, "b" is not.
+        config: { removableIds: ["a"] },
+      }),
+    })
+
+    render(
+      <F0Form
+        name="removable-table"
+        schema={schema}
+        defaultValues={{
+          faqs: [
+            { id: "a", title: "Removable" },
+            { id: "b", title: "Pinned" },
+          ],
+        }}
+        onSubmit={async () => ({ success: true })}
+      />
+    )
+
+    // The removable row has a Remove button; the pinned row has none.
+    // (Cells are editable inputs, so match on the input value, not text.)
+    const removableRow = screen.getByDisplayValue("Removable").closest("tr")!
+    const pinnedRow = screen.getByDisplayValue("Pinned").closest("tr")!
+    expect(
+      within(removableRow).getByRole("button", { name: "Remove" })
+    ).toBeInTheDocument()
+    expect(
+      within(pinnedRow).queryByRole("button", { name: "Remove" })
+    ).toBeNull()
+  })
+})
+
 describe("EntitiesListFieldRenderer — delete persistence + confirmation", () => {
   afterEach(() => {
     vi.restoreAllMocks()
@@ -525,7 +563,7 @@ describe("EntitiesListFieldRenderer — delete persistence + confirmation", () =
   })
 })
 
-describe("EntitiesListFieldRenderer — list-view remove gating (editableIds)", () => {
+describe("EntitiesListFieldRenderer — list-view remove gating (removableIds)", () => {
   afterEach(() => {
     vi.restoreAllMocks()
   })
@@ -544,10 +582,16 @@ describe("EntitiesListFieldRenderer — list-view remove gating (editableIds)", 
     return el
   }
 
-  /** A pinned-owner + members list, with an optional `editableIds` gate. */
+  /**
+   * A pinned-owner + members list, with independent `editableIds` /
+   * `removableIds` gates (each omitted → all rows).
+   */
   function renderMembers(
-    editableIds?: Array<string | number>,
-    onRemove?: () => Promise<{ success: boolean } | void>
+    opts: {
+      editableIds?: Array<string | number>
+      removableIds?: Array<string | number>
+      onRemove?: () => Promise<{ success: boolean } | void>
+    } = {}
   ) {
     const schema = z.object({
       members: f0FormField.entitiesList({
@@ -558,8 +602,9 @@ describe("EntitiesListFieldRenderer — list-view remove gating (editableIds)", 
         }),
         config: {
           visualization: "list-view",
-          ...(editableIds ? { editableIds } : {}),
-          ...(onRemove ? { onRemove } : {}),
+          ...(opts.editableIds ? { editableIds: opts.editableIds } : {}),
+          ...(opts.removableIds ? { removableIds: opts.removableIds } : {}),
+          ...(opts.onRemove ? { onRemove: opts.onRemove } : {}),
         },
       }),
     })
@@ -579,38 +624,34 @@ describe("EntitiesListFieldRenderer — list-view remove gating (editableIds)", 
     )
   }
 
-  it("locks both edit and remove for a row outside editableIds (pinned owner)", async () => {
-    // Everyone editable except the pinned owner.
-    renderMembers(["m1", "m2"])
+  it("hides remove for a row outside removableIds (pinned owner)", async () => {
+    // Everyone removable except the pinned owner; editing left ungated.
+    renderMembers({ removableIds: ["m1", "m2"] })
 
-    // Locked owner row: no edit action and no overflow trigger at all, so the
-    // remove action (which lives in the overflow menu) is unreachable.
+    // The owner is still editable (editableIds omitted), but not removable:
+    // remove is its only overflow item, so with it gated out there's no ⋮ menu.
     const owner = rowOf("Ada")
-    expect(within(owner).queryByRole("button", { name: "Edit" })).toBeNull()
+    expect(
+      within(owner).getByRole("button", { name: "Edit" })
+    ).toBeInTheDocument()
     expect(within(owner).queryByRole("button", { name: "Actions" })).toBeNull()
 
-    // Editable member row: has the edit action and an overflow menu that
-    // contains Remove.
-    const member = rowOf("Bob")
-    expect(
-      within(member).getByRole("button", { name: "Edit" })
-    ).toBeInTheDocument()
+    // A removable member has the overflow menu with Remove.
     await userEvent.click(
-      within(member).getByRole("button", { name: "Actions" })
+      within(rowOf("Bob")).getByRole("button", { name: "Actions" })
     )
     expect(
       await screen.findByRole("menuitem", { name: "Remove" })
     ).toBeInTheDocument()
   })
 
-  it("keeps every row editable and removable when editableIds is omitted (back-compat)", async () => {
+  it("keeps every row removable when removableIds is omitted (back-compat)", async () => {
     renderMembers()
 
-    // With no gate, every row exposes the edit action and an overflow trigger.
+    // With no gate every row exposes edit and an overflow trigger, and the
+    // pinned owner is removable too.
     expect(screen.getAllByRole("button", { name: "Edit" })).toHaveLength(3)
     expect(screen.getAllByRole("button", { name: "Actions" })).toHaveLength(3)
-
-    // The pinned owner is now removable too — its overflow menu has Remove.
     await userEvent.click(
       within(rowOf("Ada")).getByRole("button", { name: "Actions" })
     )
@@ -619,12 +660,37 @@ describe("EntitiesListFieldRenderer — list-view remove gating (editableIds)", 
     ).toBeInTheDocument()
   })
 
-  it("removes an editable row from the overflow menu (confirm + onRemove)", async () => {
+  it("gates edit and remove independently (removable but not editable)", async () => {
+    // Owner is removable but NOT editable; the axes don't track each other.
+    renderMembers({ editableIds: ["m1", "m2"], removableIds: ["owner"] })
+
+    // Check the member first: opening a row's overflow menu marks the rest of
+    // the page inert (Radix focus-trap), so assert the un-opened rows before
+    // clicking into the owner's menu below.
+    // A member is editable but not removable: pencil, no ⋮ menu.
+    const member = rowOf("Bob")
+    expect(
+      within(member).getByRole("button", { name: "Edit" })
+    ).toBeInTheDocument()
+    expect(within(member).queryByRole("button", { name: "Actions" })).toBeNull()
+
+    // The owner is not editable (no pencil) but is removable (⋮ → Remove).
+    const owner = rowOf("Ada")
+    expect(within(owner).queryByRole("button", { name: "Edit" })).toBeNull()
+    await userEvent.click(
+      within(owner).getByRole("button", { name: "Actions" })
+    )
+    expect(
+      await screen.findByRole("menuitem", { name: "Remove" })
+    ).toBeInTheDocument()
+  })
+
+  it("removes a removable row from the overflow menu (confirm + onRemove)", async () => {
     const confirmation = vi
       .spyOn(dialogs, "confirmation")
       .mockResolvedValue(true)
     const onRemove = vi.fn(async () => ({ success: true }))
-    renderMembers(["m1", "m2"], onRemove)
+    renderMembers({ removableIds: ["m1", "m2"], onRemove })
 
     await userEvent.click(
       within(rowOf("Bob")).getByRole("button", { name: "Actions" })

--- a/packages/react/src/patterns/F0Form/fields/entitiesList/types.ts
+++ b/packages/react/src/patterns/F0Form/fields/entitiesList/types.ts
@@ -253,6 +253,16 @@ export interface F0EntitiesListOptions<T = EntitiesListItem> {
    * (pencil) action that opens the edit dialog.
    */
   editableIds?: Array<string | number>
+  /**
+   * Restricts which items can be removed, matched against each item's `id`
+   * property. The remove counterpart to {@link editableIds}, and independent
+   * of it — a row can be editable but not removable, or vice versa. When
+   * omitted, every item is removable. Items without an `id` (e.g. rows just
+   * added by the user and not yet persisted) stay removable. A row hidden from
+   * this list shows no remove action (`list-view`) / no remove button
+   * (`editable-table`).
+   */
+  removableIds?: Array<string | number>
   /** Minimum number of rows required (defaults to 1 unless the field is optional) */
   minItems?: number
   /** Maximum number of rows allowed. When reached the add button is hidden. */
@@ -356,6 +366,8 @@ export type F0EntitiesListField = F0BaseField & {
   labels?: F0EntitiesListLabels
   /** Ids of the items that can be edited (matched against `item.id`) */
   editableIds?: Array<string | number>
+  /** Ids of the items that can be removed (matched against `item.id`) */
+  removableIds?: Array<string | number>
   /** Maximum number of rows allowed */
   maxItems?: number
   /** Per-column presentation options, keyed by item-schema property name */

--- a/packages/react/src/patterns/F0Form/fields/entitiesList/types.ts
+++ b/packages/react/src/patterns/F0Form/fields/entitiesList/types.ts
@@ -4,6 +4,7 @@ import type { AvatarVariant } from "@/components/avatars/F0Avatar"
 import type { IconType } from "@/components/F0Icon"
 import type { NewColor } from "@/components/tags/F0TagDot"
 import type { StatusVariant } from "@/components/tags/F0TagStatus"
+import type { ConfirmDialogOptions } from "@/lib/providers/dialogs-alike/types"
 import type { F0FormDefinitionSingleSchema } from "@/patterns/F0WizardForm/types"
 
 import type {
@@ -265,6 +266,26 @@ export interface F0EntitiesListOptions<T = EntitiesListItem> {
    * update or remove the row.
    */
   rowActions?: (item: T, index: number) => F0EntitiesListRowAction<T>[]
+  /**
+   * Persistence hook for removing a row — the delete counterpart to
+   * `createFormDefinition` (add) and `updateFormDefinition` (edit). Called with
+   * the row's item **after** the user confirms the destructive action. Return
+   * `{ success: false }` or throw to keep the row and surface an error; return
+   * `{ success: true }` (or nothing) to drop it from the field value.
+   *
+   * When omitted, removal is value-only (the row is spliced from the array with
+   * no network call) — but the confirmation is still shown, per the CRUD
+   * "Delete & destructive" guidance.
+   */
+  onRemove?: (item: T) => Promise<{ success: boolean } | void>
+  /**
+   * Per-item confirmation copy for the remove action, so callers can **name the
+   * resource** and its scope (per the CRUD "Delete & destructive" doc). Receives
+   * the row item and returns the confirmation dialog options
+   * (`title`, `msg`, `type`, `confirm`/`cancel` labels). When omitted, a generic
+   * default confirmation is shown.
+   */
+  confirmRemove?: (item: T) => ConfirmDialogOptions
 }
 
 /**
@@ -344,6 +365,10 @@ export type F0EntitiesListField = F0BaseField & {
     item: EntitiesListItem,
     index: number
   ) => F0EntitiesListRowAction[]
+  /** Persistence hook for removing a row (runs after the user confirms) */
+  onRemove?: (item: EntitiesListItem) => Promise<{ success: boolean } | void>
+  /** Per-item confirmation copy for the remove action */
+  confirmRemove?: (item: EntitiesListItem) => ConfirmDialogOptions
   /** Conditional rendering based on another field's value */
   renderIf?: EntitiesListFieldRenderIf
 }

--- a/packages/react/src/patterns/F0Form/useSchemaDefinition.ts
+++ b/packages/react/src/patterns/F0Form/useSchemaDefinition.ts
@@ -315,6 +315,8 @@ function configToF0Field(
         maxItems: listOptions?.maxItems,
         columns: listOptions?.columns,
         rowActions: listOptions?.rowActions,
+        onRemove: listOptions?.onRemove,
+        confirmRemove: listOptions?.confirmRemove,
         renderIf: config.renderIf,
       } as F0Field
     }

--- a/packages/react/src/patterns/F0Form/useSchemaDefinition.ts
+++ b/packages/react/src/patterns/F0Form/useSchemaDefinition.ts
@@ -312,6 +312,7 @@ function configToF0Field(
         itemHref: listOptions?.itemHref,
         labels: listOptions?.labels,
         editableIds: listOptions?.editableIds,
+        removableIds: listOptions?.removableIds,
         maxItems: listOptions?.maxItems,
         columns: listOptions?.columns,
         rowActions: listOptions?.rowActions,


### PR DESCRIPTION
## What

Adds **delete-action persistence + confirmation** to the F0Form `entitiesList` field, making removal symmetric with how add/edit already persist (`createFormDefinition` / `updateFormDefinition`).

New config on `F0EntitiesListOptions`:

```ts
onRemove?:      (item: T) => Promise<{ success: boolean } | void>
confirmRemove?: (item: T) => ConfirmDialogOptions
removableIds?:  Array<string | number>
```

Removal flow (`performRemove`): **confirm → persist → splice**
1. Shows a confirmation via `dialogs.confirmation(...)` — `confirmRemove(item)` copy if provided, else a sensible default. Cancel/dismiss aborts (nothing changes).
2. If confirmed, `await onRemove(item)`. A throw or `{ success: false }` **keeps the row** and surfaces a critical alert.
3. Only splices the row from the field value on success.

All four removal paths route through it — list-view overflow, editable-table, and both `rowActions` `remove()` helpers. A per-row pending state disables the action while `onRemove` is in flight.

Also: removal gets its own gating axis, **`removableIds`** — the remove counterpart to `editableIds`, and independent of it. A row can be editable but not removable (e.g. a pinned resource owner) or vice versa. Omitted → every row removable, mirroring `editableIds`. Wired through both visualizations: list-view and the editable-table (`F0FormEditableTable` gains a `canRemoveRow` prop).

## Why

`entitiesList` could self-persist add and edit (each dialog has its own `onSubmit`), but **remove only spliced the local array** — there was no hook to persist a deletion, and no confirmation. Per the "CRUD patterns / Delete & destructive" doc, every destructive action must confirm. Consumers with server-backed lists had to bolt on a custom `rowAction` to actually delete. This closes that gap natively.

## Behavior changes (flag for reviewers)

- The built-in remove now **always shows a confirmation** (previously immediate).
- Removal is gated by the new **`removableIds`**, independent of `editableIds`. Omitted → all rows removable (matches the prior default), so this is additive: existing lists behave unchanged unless they set `removableIds`.
- `onRemove` is optional; without it, removal stays value-only, just confirmed.

## Testing

- New list-view gating suite (`removableIds`): row outside it has no remove but stays editable; `removableIds` omitted → all removable (back-compat); edit/remove gate **independently** (removable-not-editable and editable-not-removable); removable row → Remove fires `dialogs.confirmation` + `onRemove(item)` and the row disappears.
- New editable-table test: the remove button shows only for rows inside `removableIds`.
- `entitiesList` renderer suite: **19 passed** (+5). Full `src/patterns/F0Form` (+ `F0FormEditableTable`): **494 passed**. `tsc` 0 errors. oxlint + oxfmt clean.
- Storybook: extended `Patterns/Forms/F0Form → Entities List Field Form Definitions` to demonstrate `onRemove`/`confirmRemove` and pin the first member via `removableIds` (logs CREATE/UPDATE/DELETE).
