### PR TITLE
fix(F0Accordion): remove resting box shadow

### DIFF
--- a/packages/react/src/components/F0Accordion/F0Accordion.tsx
+++ b/packages/react/src/components/F0Accordion/F0Accordion.tsx
@@ -48,7 +48,7 @@ const F0AccordionBase = forwardRef<HTMLDivElement, F0AccordionProps>(
         {...rest}
         className={cn(
           "flex flex-col rounded-md border border-solid border-f1-border-secondary",
-          "overflow-hidden bg-f1-background shadow"
+          "overflow-hidden bg-f1-background"
         )}
       >
         {items.map((item, index) => (

--- a/packages/react/src/components/F0Accordion/F0AccordionSkeleton.tsx
+++ b/packages/react/src/components/F0Accordion/F0AccordionSkeleton.tsx
@@ -16,7 +16,7 @@ export const F0AccordionSkeleton = ({
       aria-live="polite"
       className={cn(
         "flex flex-col rounded-md border border-solid border-f1-border-secondary",
-        "overflow-hidden bg-f1-background shadow"
+        "overflow-hidden bg-f1-background"
       )}
     >
       {Array.from({ length: items }).map((_, index) => (


### PR DESCRIPTION
## Description

Remove the hardcoded resting `shadow` from `F0Accordion` so it renders flat, in line with the rest of the library: resting surfaces like `F0Card` are `shadow-none` at rest (shadow only on hover/focus), `F0Widget` only shows shadows in selected/dragging states, and persistent shadows are reserved for overlays (dialogs, popovers, dropdowns).

## Screenshots (if applicable)

N/A — the accordion keeps its border, radius, and background; only the drop shadow is gone.

## Implementation details

- `F0Accordion.tsx`: drop the `shadow` class from the root container
- `F0AccordionSkeleton.tsx`: same removal in the skeleton so loading and loaded states match

No API changes — `F0AccordionProps` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)