### PR TITLE
fix(OneDateNavigator): revive persisted string dates before use

### DIFF
--- a/packages/react/src/patterns/OneDateNavigator/OneDateNavigator.tsx
+++ b/packages/react/src/patterns/OneDateNavigator/OneDateNavigator.tsx
@@ -6,7 +6,10 @@ import {
   DatePickerPopup,
   DatePickerPopupProps,
 } from "@/ui/DatePickerPopup/DatePickerPopup"
-import { isSameDatePickerValue } from "@/ui/DatePickerPopup/utils"
+import {
+  isSameDatePickerValue,
+  reviveDatePickerValue,
+} from "@/ui/DatePickerPopup/utils"
 
 import { getGranularityDefinitions } from "@/components/OneCalendar/granularities"
 import {
@@ -37,17 +40,28 @@ function _OneDateNavigator({
   dataTestId,
   ...props
 }: OneDatePickerProps) {
+  // A `value`/`defaultValue` restored from persisted storage (e.g. a
+  // OneDataCollection `date-navigator` filter) arrives with `from`/`to` as
+  // strings after its JSON round-trip. Revive them to `Date` at the boundary so
+  // every downstream consumer — the equality check below, the trigger label,
+  // granularity math — receives real `Date` objects.
+  const revivedValue = useMemo(() => reviveDatePickerValue(value), [value])
+  const revivedDefaultValue = useMemo(
+    () => reviveDatePickerValue(defaultValue),
+    [defaultValue]
+  )
+
   const [localValue, setLocalValue] = useState<DatePickerValue | undefined>(
-    defaultValue ?? value
+    revivedDefaultValue ?? revivedValue
   )
 
   useEffect(() => {
-    if (isSameDatePickerValue(value, localValue)) {
+    if (isSameDatePickerValue(revivedValue, localValue)) {
       return
     }
-    setLocalValue(value || defaultValue)
+    setLocalValue(revivedValue || revivedDefaultValue)
     // eslint-disable-next-line react-hooks/exhaustive-deps -- we only want to update the local value when the value changes
-  }, [value, defaultValue])
+  }, [revivedValue, revivedDefaultValue])
 
   const [compareToValue, setCompareToValue] = useState<
     DateRangeComplete | DateRangeComplete[] | undefined
@@ -88,7 +102,7 @@ function _OneDateNavigator({
       <DatePickerPopup
         onSelect={handleSelect}
         value={localValue}
-        defaultValue={defaultValue}
+        defaultValue={revivedDefaultValue}
         presets={presets}
         granularities={granularities}
         minDate={props.minDate}

--- a/packages/react/src/patterns/OneDateNavigator/__tests__/OneDateNavigator.test.tsx
+++ b/packages/react/src/patterns/OneDateNavigator/__tests__/OneDateNavigator.test.tsx
@@ -69,6 +69,49 @@ describe("OneDateNavigator", () => {
     expect(previousButton).toBeNull()
   })
 
+  // Regression: a value restored from persisted OneDataCollection storage has
+  // round-tripped through JSON, so its `from`/`to` are ISO strings rather than
+  // Date objects. The navigator used to call `.getTime()` on them and throw
+  // `TypeError: from.getTime is not a function`. It must revive them instead.
+  it("renders a defaultValue whose dates were serialized to strings", () => {
+    const onSelect = vi.fn()
+    const serializedDefaultValue = {
+      value: {
+        from: new Date(2023, 0, 1).toISOString(),
+        to: new Date(2023, 0, 31).toISOString(),
+      },
+      granularity: "month" as const,
+    } as unknown as Parameters<typeof OneDateNavigator>[0]["defaultValue"]
+
+    expect(() =>
+      render(
+        <OneDateNavigator
+          onSelect={onSelect}
+          defaultValue={serializedDefaultValue}
+        />
+      )
+    ).not.toThrow()
+
+    expect(screen.getByRole("button", { name: "January 2023" })).toBeDefined()
+  })
+
+  it("renders a controlled value whose dates were serialized to strings", () => {
+    const onSelect = vi.fn()
+    const serializedValue = {
+      value: {
+        from: new Date(2023, 0, 1).toISOString(),
+        to: new Date(2023, 0, 31).toISOString(),
+      },
+      granularity: "month" as const,
+    } as unknown as Parameters<typeof OneDateNavigator>[0]["value"]
+
+    expect(() =>
+      render(<OneDateNavigator onSelect={onSelect} value={serializedValue} />)
+    ).not.toThrow()
+
+    expect(screen.getByRole("button", { name: "January 2023" })).toBeDefined()
+  })
+
   it("renders with go to current hidden", () => {
     const onSelect = vi.fn()
 

--- a/packages/react/src/ui/DatePickerPopup/utils.ts
+++ b/packages/react/src/ui/DatePickerPopup/utils.ts
@@ -1,5 +1,42 @@
 import { DatePickerValue } from "./types"
 
+const coerceToDate = (value: Date | string | number): Date =>
+  value instanceof Date ? value : new Date(value)
+
+/**
+ * Revives a `DatePickerValue` whose `from`/`to` may have been serialized to
+ * strings before reaching us.
+ *
+ * The date range is typed as `Date` objects, but a value that has round-tripped
+ * through `JSON.stringify`/`JSON.parse` — e.g. a `OneDataCollection`
+ * `date-navigator` filter restored from persisted storage — arrives with
+ * `from`/`to` as ISO strings. Downstream consumers (the equality check, the
+ * trigger label, granularity math) all call `Date` methods such as
+ * `.getTime()`, so a string `from` throws
+ * `TypeError: from.getTime is not a function`.
+ *
+ * Returns the original reference untouched when the range is already made of
+ * real `Date` objects (the common case), so this adds no re-render churn.
+ */
+export const reviveDatePickerValue = (
+  value: DatePickerValue | undefined
+): DatePickerValue | undefined => {
+  if (!value?.value) {
+    return value
+  }
+  const { from, to } = value.value as {
+    from: Date | string | number
+    to: Date | string | number
+  }
+  if (from instanceof Date && to instanceof Date) {
+    return value
+  }
+  return {
+    ...value,
+    value: { from: coerceToDate(from), to: coerceToDate(to) },
+  }
+}
+
 export const isSameDatePickerValue = (
   a: DatePickerValue | undefined,
   b: DatePickerValue | undefined


### PR DESCRIPTION
## Problem

`OneDateNavigator` crashes with **`TypeError: from.getTime is not a function`** when its `value`/`defaultValue` has been restored from persisted `OneDataCollection` storage.

Any `OneDataCollection` with a versioned `id` (storage on) that declares a `date-navigator` navigation filter persists the selected range to `localStorage`. `navigationFilters` is in the persisted-feature allowlist (`dataCollectionStorageFeatures`), so the `{ from: Date, to: Date }` range is written via `JSON.stringify` — turning the dates into **ISO strings**.

On the next load, the storage restore path applies the parsed value straight back into live state:

```ts
// dataCollectionLocalStorageHandler.ts
get: async (keyName) => JSON.parse(localStorage.getItem(getKey(keyName)) ?? "{}")  // from/to are now strings
// useDataCollectionStorage.ts
featureProvider.setValue(featureValue)    // pushed back verbatim, no date revival
```

That restored value flows into `OneDateNavigator`, whose equality check and trigger call `Date` methods on it:

- `isSameDatePickerValue` → `a.value?.from.getTime()`
- `DateNavigatorTrigger` → `.from.getTime()`, `granularity.toString(value.value)`, `getPrevNext(value.value)`

`"2026-07-13T…".getTime()` doesn't exist → crash. It reproduces on the **second** load (once a serialized range is sitting in storage); a clean first load works because the initial default is normalized through the filter's `valueConverter`, which the restore path bypasses.

Originally surfaced on Factorial's `/projects/contributors/list` after that collection adopted a `date-navigator` filter.

## Regression origin

This is a latent defect, not caused by any recent release. The two ingredients were introduced separately, and it became reproducible once both were present:

- **#1828** (2025-05-19) — _feat/datenavigator and navigation filters in datacollections_ — added the `date-navigator` navigation filter.
- **#2637** (2025-09-25) — _feat/datacollection sort hide cols_ — **the cause**: introduced the OneDataCollection `localStorage` persistence system, added `navigationFilters` to the persisted-feature set, and shipped `dataCollectionLocalStorageHandler` which `JSON.stringify`s state on write and bare `JSON.parse`s it on read with **no date revival**. From this commit on, any collection combining storage + a `date-navigator` filter is one reload away from the crash.
- **#2841** (2025-10-22) — _feat: datenavigator value prop_ — added `isSameDatePickerValue`, one of the two `.getTime()` sites that throw on a string `from`.

## Fix

Revive `value`/`defaultValue` into real `Date` objects at the `OneDateNavigator` boundary (`reviveDatePickerValue`), so **every** downstream consumer — the equality check, the trigger label, granularity math — receives `Date`s regardless of where the value came from. It's a no-op that returns the same reference when the range already holds `Date` objects, so there's no added re-render churn.

Fixing at this boundary (rather than only patching `isSameDatePickerValue`) is deliberate: the trigger also calls `.getTime()`/granularity math, so a comparator-only patch would just relocate the crash.

## Tests

Added two regression tests to `OneDateNavigator.test.tsx` covering a `defaultValue` and a controlled `value` whose dates were serialized to strings — both previously threw, now render `"January 2023"`.

- ✅ `vitest` (OneDateNavigator + DatePickerPopup) — 16 passed
- ✅ `oxlint` / `oxfmt --check` clean on changed files
- ✅ `tsc` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)