### PR TITLE
feat(OneCalendar): month and year dropdowns in the DatePicker calendar header

### DIFF
--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -11,7 +11,6 @@ import {
   useRef,
   useState,
 } from "react"
-import { useDebounceCallback } from "usehooks-ts"
 
 import { F0DialogContext } from "@/patterns/F0Dialog"
 import { F0Button } from "@/components/F0Button"
@@ -741,33 +740,48 @@ const F0SelectComponent = forwardRef(function Select<
     source,
   ])
 
-  const debouncedHandleChangeOpenLocal = useDebounceCallback(
-    (open: boolean) => {
-      onOpenChange?.(open)
-      setOpenLocal(open)
-      if (!open) {
-        isApplyingRef.current = false
+  // Debounced open/close via plain setTimeout instead of usehooks-ts'
+  // `useDebounceCallback` (lodash.debounce). lodash decides the trailing edge
+  // by reading `Date.now()`, so under a frozen clock (MockDate in Storybook
+  // stories, mocked dates in tests) the 100ms window never elapses and the
+  // dropdown can never open. setTimeout keeps ticking regardless of the
+  // clock. Semantics match lodash's trailing debounce: rapid calls coalesce
+  // and only the last value is applied.
+  const applyOpenChangeRef = useRef<(open: boolean) => void>(() => {})
+  applyOpenChangeRef.current = (open: boolean) => {
+    onOpenChange?.(open)
+    setOpenLocal(open)
+    if (!open) {
+      isApplyingRef.current = false
+    }
+  }
+  const openChangeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const debouncedHandleChangeOpenLocal = useMemo(() => {
+    const debounced = (open: boolean) => {
+      if (openChangeTimerRef.current !== null) {
+        clearTimeout(openChangeTimerRef.current)
       }
-    },
-    100
-  )
+      openChangeTimerRef.current = setTimeout(() => {
+        openChangeTimerRef.current = null
+        applyOpenChangeRef.current(open)
+      }, 100)
+    }
+    debounced.cancel = () => {
+      if (openChangeTimerRef.current !== null) {
+        clearTimeout(openChangeTimerRef.current)
+        openChangeTimerRef.current = null
+      }
+    }
+    return debounced
+  }, [])
 
-  // Cancel any pending debounced state update on unmount. usehooks-ts'
-  // `useDebounceCallback` has a known bug where its internal unmount cleanup
-  // cancels a different lodash.debounce instance than the one invoked by
-  // callers, so pending trailing-edge timers can fire after the test's jsdom
-  // window is torn down (causing `ReferenceError: window is not defined`
-  // inside react-dom). We track the latest wrapper via a ref and only cancel
-  // on true unmount so we don't drop in-flight timers between renders.
-  const debouncedHandleChangeOpenLocalRef = useRef(
-    debouncedHandleChangeOpenLocal
-  )
-  debouncedHandleChangeOpenLocalRef.current = debouncedHandleChangeOpenLocal
+  // Cancel any pending open/close update on unmount so the trailing timer
+  // can't fire against an unmounted component (or a torn-down jsdom window).
   useEffect(() => {
     return () => {
-      debouncedHandleChangeOpenLocalRef.current.cancel()
+      debouncedHandleChangeOpenLocal.cancel()
     }
-  }, [])
+  }, [debouncedHandleChangeOpenLocal])
 
   const restoreCommittedSelection = useCallback(() => {
     const committedSelection = committedSelectionRef.current

--- a/packages/react/src/components/F0Select/F0Select.tsx
+++ b/packages/react/src/components/F0Select/F0Select.tsx
@@ -148,6 +148,7 @@ const F0SelectComponent = forwardRef(function Select<
     asList = false,
     showPreview = false,
     preserveSelectionOnDatasetChange = true,
+    fitContentWidth = false,
     dataTestId,
     ...props
   }: F0SelectProps<T, R>,
@@ -1084,6 +1085,7 @@ const F0SelectComponent = forwardRef(function Select<
   const selectContent = (
     <SelectContent
       items={items}
+      fitContentWidth={fitContentWidth}
       taller={!!source?.filters}
       emptyMessage={
         searchEmptyMessage ??

--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -135,6 +135,31 @@ describe("Select", () => {
     expect(screen.getByText("Description 1")).toBeInTheDocument()
   })
 
+  it("opens even when Date.now is frozen (MockDate in stories)", async () => {
+    // Regression: the open/close debounce used lodash.debounce, which decides
+    // its trailing edge by reading Date.now(). Stories that freeze the clock
+    // with MockDate (e.g. DatePicker) made the 100ms window never elapse, so
+    // the dropdown could never open. The debounce must ride on setTimeout.
+    const frozenNow = new Date(2025, 6, 30).getTime()
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(frozenNow)
+    try {
+      const user = userEvent.setup()
+      render(
+        <F0Select
+          {...defaultSelectProps}
+          options={mockOptions}
+          onChange={() => {}}
+        />
+      )
+
+      await openSelect(user)
+
+      expect(screen.getByText("Option 1")).toBeInTheDocument()
+    } finally {
+      nowSpy.mockRestore()
+    }
+  })
+
   it("should display selected value", async () => {
     render(
       <F0Select {...defaultSelectProps} options={mockOptions} value="option1" />

--- a/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
+++ b/packages/react/src/components/F0Select/__tests__/F0Select.test.tsx
@@ -160,6 +160,39 @@ describe("Select", () => {
     }
   })
 
+  it("sizes the dropdown to its content when fitContentWidth is set", async () => {
+    const user = userEvent.setup()
+    render(
+      <F0Select
+        {...defaultSelectProps}
+        options={mockOptions}
+        onChange={() => {}}
+        fitContentWidth
+      />
+    )
+
+    await openSelect(user)
+
+    const listbox = screen.getByRole("listbox")
+    expect(listbox.className).toContain("w-max")
+    expect(listbox.className).not.toContain("min-w-80")
+  })
+
+  it("keeps the default 20rem dropdown minimum without fitContentWidth", async () => {
+    const user = userEvent.setup()
+    render(
+      <F0Select
+        {...defaultSelectProps}
+        options={mockOptions}
+        onChange={() => {}}
+      />
+    )
+
+    await openSelect(user)
+
+    expect(screen.getByRole("listbox").className).toContain("min-w-80")
+  })
+
   it("should display selected value", async () => {
     render(
       <F0Select {...defaultSelectProps} options={mockOptions} value="option1" />

--- a/packages/react/src/components/F0Select/types.ts
+++ b/packages/react/src/components/F0Select/types.ts
@@ -74,6 +74,14 @@ type F0SelectBaseProps<T extends string, R = unknown> = {
    * @default true
    */
   preserveSelectionOnDatasetChange?: boolean
+  /**
+   * When true, the dropdown sizes to its widest option (never narrower than
+   * the trigger) instead of the default 20rem minimum. Useful for compact
+   * value pickers like month/year selectors.
+   *
+   * @default false
+   */
+  fitContentWidth?: boolean
 } & WithDataTestIdProps
 
 /**

--- a/packages/react/src/components/OneCalendar/OneCalendar.stories.tsx
+++ b/packages/react/src/components/OneCalendar/OneCalendar.stories.tsx
@@ -615,6 +615,27 @@ export const WithMinAndMaxYear: Story = {
   },
 }
 
+// Day view opened far in the past: the month/year dropdowns let you jump
+// straight to a birthday instead of clicking the arrows hundreds of times.
+export const BirthdayDistantPast: Story = {
+  args: {
+    mode: "single",
+    view: "day",
+    defaultMonth: new Date(1985, 2, 1),
+    defaultSelected: new Date(1985, 2, 15),
+  },
+}
+
+// Year dropdown bounded by minDate/maxDate.
+export const DayWithBoundedYears: Story = {
+  args: {
+    mode: "single",
+    view: "day",
+    minDate: new Date(2020, 0, 1),
+    maxDate: new Date(2027, 11, 31),
+  },
+}
+
 // Compact versions
 export const CompactMonthSingle: OneCalendarInternalStory = {
   args: {

--- a/packages/react/src/components/OneCalendar/OneCalendar.test.tsx
+++ b/packages/react/src/components/OneCalendar/OneCalendar.test.tsx
@@ -145,6 +145,38 @@ describe("OneCalendar", () => {
       expect(await screen.findByText(String(currentYear))).toBeInTheDocument()
     })
 
+    it("disables adjacent-month day cells that fall outside the year range", async () => {
+      // December's grid shows the first days of next January; those lie
+      // outside the selectable years and must not be selectable.
+      const currentYear = new Date().getFullYear()
+      const onSelect = vi.fn()
+      render(
+        <TestWrapper locale="en-US">
+          <OneCalendar
+            mode="single"
+            view="day"
+            defaultSelected={new Date(currentYear, 11, 15)}
+            onSelect={onSelect}
+          />
+        </TestWrapper>
+      )
+
+      expect(await screen.findByText("December")).toBeInTheDocument()
+      onSelect.mockClear()
+
+      // The trailing "1" in December's grid is January 1 of the next year.
+      const grid = screen.getAllByRole("grid")[0]
+      const dayOnes = within(grid).getAllByText("1")
+      const trailingJanuaryFirst = dayOnes[dayOnes.length - 1]
+
+      fireEvent.click(trailingJanuaryFirst)
+      expect(onSelect).not.toHaveBeenCalled()
+
+      // An in-range day still selects fine.
+      fireEvent.click(within(grid).getByText("20"))
+      expect(onSelect).toHaveBeenCalled()
+    })
+
     it("clamps arrow navigation to minDate/maxDate years", async () => {
       render(
         <TestWrapper locale="en-US">

--- a/packages/react/src/components/OneCalendar/OneCalendar.test.tsx
+++ b/packages/react/src/components/OneCalendar/OneCalendar.test.tsx
@@ -122,10 +122,10 @@ describe("OneCalendar", () => {
       expect(screen.getByRole("button", { name: "Next" })).toBeInTheDocument()
     })
 
-    it("keeps showing the year when arrows navigate past the default range", async () => {
-      // The default year list ends at the current year; arrowing from
-      // December into January of the next year must still display that year
-      // in the trigger (regression: it rendered as an ellipsis).
+    it("clamps arrow navigation to the year dropdown range", async () => {
+      // The year list ends at the current year; arrowing from December must
+      // not escape into a year the dropdown can't display (regression: the
+      // trigger rendered an ellipsis). The Next arrow is disabled instead.
       const currentYear = new Date().getFullYear()
       render(
         <TestWrapper locale="en-US">
@@ -137,14 +137,31 @@ describe("OneCalendar", () => {
         </TestWrapper>
       )
 
-      expect(await screen.findByText(String(currentYear))).toBeInTheDocument()
+      expect(await screen.findByText("December")).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Next" })).toBeDisabled()
 
       fireEvent.click(screen.getByRole("button", { name: "Next" }))
+      expect(await screen.findByText("December")).toBeInTheDocument()
+      expect(await screen.findByText(String(currentYear))).toBeInTheDocument()
+    })
+
+    it("clamps arrow navigation to minDate/maxDate years", async () => {
+      render(
+        <TestWrapper locale="en-US">
+          <OneCalendar
+            mode="single"
+            view="day"
+            defaultSelected={new Date(1990, 0, 15)}
+            minDate={new Date(1990, 0, 1)}
+            maxDate={new Date(1995, 11, 31)}
+          />
+        </TestWrapper>
+      )
 
       expect(await screen.findByText("January")).toBeInTheDocument()
-      expect(
-        await screen.findByText(String(currentYear + 1))
-      ).toBeInTheDocument()
+      // January 1990: going back would leave the 1990-1995 window.
+      expect(screen.getByRole("button", { name: "Previous" })).toBeDisabled()
+      expect(screen.getByRole("button", { name: "Next" })).toBeEnabled()
     })
 
     it("stays in sync with the prev/next arrows", async () => {

--- a/packages/react/src/components/OneCalendar/OneCalendar.test.tsx
+++ b/packages/react/src/components/OneCalendar/OneCalendar.test.tsx
@@ -122,6 +122,31 @@ describe("OneCalendar", () => {
       expect(screen.getByRole("button", { name: "Next" })).toBeInTheDocument()
     })
 
+    it("keeps showing the year when arrows navigate past the default range", async () => {
+      // The default year list ends at the current year; arrowing from
+      // December into January of the next year must still display that year
+      // in the trigger (regression: it rendered as an ellipsis).
+      const currentYear = new Date().getFullYear()
+      render(
+        <TestWrapper locale="en-US">
+          <OneCalendar
+            mode="single"
+            view="day"
+            defaultSelected={new Date(currentYear, 11, 15)}
+          />
+        </TestWrapper>
+      )
+
+      expect(await screen.findByText(String(currentYear))).toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole("button", { name: "Next" }))
+
+      expect(await screen.findByText("January")).toBeInTheDocument()
+      expect(
+        await screen.findByText(String(currentYear + 1))
+      ).toBeInTheDocument()
+    })
+
     it("stays in sync with the prev/next arrows", async () => {
       render(
         <TestWrapper locale="en-US">

--- a/packages/react/src/components/OneCalendar/OneCalendar.test.tsx
+++ b/packages/react/src/components/OneCalendar/OneCalendar.test.tsx
@@ -203,6 +203,33 @@ describe("OneCalendar", () => {
       expect(onSelect).toHaveBeenCalled()
     })
 
+    it("does not impose a hidden lower bound when only maxDate is set", async () => {
+      // Codex review regression: with only maxDate, the default window's
+      // floor (currentYear - 120) must not disable consumer-allowed dates.
+      // A very old value stays selectable and the dropdown displays its year.
+      const onSelect = vi.fn()
+      render(
+        <TestWrapper locale="en-US">
+          <OneCalendar
+            mode="single"
+            view="day"
+            defaultSelected={new Date(1850, 5, 15)}
+            maxDate={new Date()}
+            onSelect={onSelect}
+          />
+        </TestWrapper>
+      )
+
+      // The year dropdown stretches to display 1850.
+      expect(await screen.findByText("June")).toBeInTheDocument()
+      expect(await screen.findByText("1850")).toBeInTheDocument()
+
+      // Days in 1850 are not disabled and remain selectable.
+      const grid = screen.getAllByRole("grid")[0]
+      fireEvent.click(within(grid).getByText("20"))
+      expect(onSelect).toHaveBeenCalled()
+    })
+
     it("clamps arrow navigation to minDate/maxDate years", async () => {
       render(
         <TestWrapper locale="en-US">

--- a/packages/react/src/components/OneCalendar/OneCalendar.test.tsx
+++ b/packages/react/src/components/OneCalendar/OneCalendar.test.tsx
@@ -1,5 +1,6 @@
+import { fireEvent } from "@testing-library/react"
 import React from "react"
-import { describe, expect, it, vi } from "vitest"
+import { beforeAll, describe, expect, it, vi } from "vitest"
 
 import { zeroRender as render, screen, within } from "@/testing/test-utils"
 
@@ -51,6 +52,92 @@ describe("OneCalendar", () => {
     expect(within(grid).getByText("do")).toBeInTheDocument() // Domingo
 
     vi.useRealTimers()
+  })
+
+  describe("header month/year dropdowns", () => {
+    beforeAll(() => {
+      // F0Select relies on ResizeObserver and layout APIs jsdom lacks.
+      global.ResizeObserver = class {
+        observe = vi.fn()
+        unobserve = vi.fn()
+        disconnect = vi.fn()
+      } as unknown as typeof ResizeObserver
+      Element.prototype.scrollIntoView = vi.fn()
+    })
+
+    // A null selection makes OneCalendar snap the view to "today", so pin the
+    // month by passing a concrete selected date.
+    const march2024 = new Date(2024, 2, 15)
+
+    it("shows month and year dropdowns in day view", async () => {
+      render(
+        <TestWrapper locale="en-US">
+          <OneCalendar mode="single" view="day" defaultSelected={march2024} />
+        </TestWrapper>
+      )
+
+      const comboboxes = screen.getAllByRole("combobox")
+      expect(comboboxes).toHaveLength(2)
+      expect(await screen.findByText("March")).toBeInTheDocument()
+      expect(await screen.findByText("2024")).toBeInTheDocument()
+    })
+
+    it("shows month and year dropdowns in week view", async () => {
+      render(
+        <TestWrapper locale="en-US">
+          <OneCalendar mode="single" view="week" defaultSelected={march2024} />
+        </TestWrapper>
+      )
+
+      expect(screen.getAllByRole("combobox")).toHaveLength(2)
+      expect(await screen.findByText("March")).toBeInTheDocument()
+    })
+
+    it("shows only a year dropdown in month view", async () => {
+      render(
+        <TestWrapper locale="en-US">
+          <OneCalendar mode="single" view="month" defaultSelected={march2024} />
+        </TestWrapper>
+      )
+
+      // Exactly one dropdown (year); the month picker is the grid itself.
+      const comboboxes = screen.getAllByRole("combobox")
+      expect(comboboxes).toHaveLength(1)
+      expect(comboboxes[0]).toHaveTextContent("2024")
+    })
+
+    it("keeps the plain label (no dropdowns) in quarter view", () => {
+      render(
+        <TestWrapper locale="en-US">
+          <OneCalendar
+            mode="single"
+            view="quarter"
+            defaultSelected={march2024}
+          />
+        </TestWrapper>
+      )
+
+      // No month/year dropdowns; quarter view keeps its plain label + arrows.
+      expect(screen.queryAllByRole("combobox")).toHaveLength(0)
+      expect(screen.getByRole("button", { name: "Next" })).toBeInTheDocument()
+    })
+
+    it("stays in sync with the prev/next arrows", async () => {
+      render(
+        <TestWrapper locale="en-US">
+          <OneCalendar mode="single" view="day" defaultSelected={march2024} />
+        </TestWrapper>
+      )
+
+      expect(await screen.findByText("March")).toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole("button", { name: "Next" }))
+      expect(await screen.findByText("April")).toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole("button", { name: "Previous" }))
+      fireEvent.click(screen.getByRole("button", { name: "Previous" }))
+      expect(await screen.findByText("February")).toBeInTheDocument()
+    })
   })
 
   describe("selectOnCellOnly", () => {

--- a/packages/react/src/components/OneCalendar/OneCalendar.test.tsx
+++ b/packages/react/src/components/OneCalendar/OneCalendar.test.tsx
@@ -6,7 +6,7 @@ import { zeroRender as render, screen, within } from "@/testing/test-utils"
 
 import { defaultTranslations, I18nProvider } from "../../lib/providers/i18n"
 import { L10nProvider } from "../../lib/providers/l10n"
-import { OneCalendar } from "./OneCalendar"
+import { OneCalendar, OneCalendarInternal } from "./OneCalendar"
 import { WeekStartDay } from "./types"
 
 const TestWrapper = ({
@@ -201,6 +201,26 @@ describe("OneCalendar", () => {
       // An in-range day still selects fine.
       fireEvent.click(within(grid).getByText("20"))
       expect(onSelect).toHaveBeenCalled()
+    })
+
+    it("uses short month names in the compact header", async () => {
+      // Compact calendars (filter-picker date filter) have a ~240px header
+      // budget; short month labels + narrower triggers keep the dropdowns
+      // and arrows from overflowing it.
+      render(
+        <TestWrapper locale="en-US">
+          <OneCalendarInternal
+            mode="single"
+            view="day"
+            defaultSelected={new Date(2024, 8, 15)}
+            compact
+          />
+        </TestWrapper>
+      )
+
+      expect(await screen.findByText("Sep")).toBeInTheDocument()
+      expect(screen.queryByText("September")).not.toBeInTheDocument()
+      expect(await screen.findByText("2024")).toBeInTheDocument()
     })
 
     it("does not impose a hidden lower bound when only maxDate is set", async () => {

--- a/packages/react/src/components/OneCalendar/OneCalendar.test.tsx
+++ b/packages/react/src/components/OneCalendar/OneCalendar.test.tsx
@@ -123,9 +123,32 @@ describe("OneCalendar", () => {
     })
 
     it("clamps arrow navigation to the year dropdown range", async () => {
-      // The year list ends at the current year; arrowing from December must
-      // not escape into a year the dropdown can't display (regression: the
-      // trigger rendered an ellipsis). The Next arrow is disabled instead.
+      // Arrowing from December of the last selectable year must not escape
+      // into a year the dropdown can't display (regression: the trigger
+      // rendered an ellipsis). The Next arrow is disabled instead.
+      render(
+        <TestWrapper locale="en-US">
+          <OneCalendar
+            mode="single"
+            view="day"
+            defaultSelected={new Date(2024, 11, 15)}
+            minDate={new Date(2020, 0, 1)}
+            maxDate={new Date(2024, 11, 31)}
+          />
+        </TestWrapper>
+      )
+
+      expect(await screen.findByText("December")).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: "Next" })).toBeDisabled()
+
+      fireEvent.click(screen.getByRole("button", { name: "Next" }))
+      expect(await screen.findByText("December")).toBeInTheDocument()
+      expect(await screen.findByText("2024")).toBeInTheDocument()
+    })
+
+    it("navigates freely into future years within the default window", async () => {
+      // Without minDate/maxDate the window spans 120 years in both
+      // directions, so December of the current year is not an edge.
       const currentYear = new Date().getFullYear()
       render(
         <TestWrapper locale="en-US">
@@ -138,24 +161,27 @@ describe("OneCalendar", () => {
       )
 
       expect(await screen.findByText("December")).toBeInTheDocument()
-      expect(screen.getByRole("button", { name: "Next" })).toBeDisabled()
+      expect(screen.getByRole("button", { name: "Next" })).toBeEnabled()
 
       fireEvent.click(screen.getByRole("button", { name: "Next" }))
-      expect(await screen.findByText("December")).toBeInTheDocument()
-      expect(await screen.findByText(String(currentYear))).toBeInTheDocument()
+      expect(await screen.findByText("January")).toBeInTheDocument()
+      expect(
+        await screen.findByText(String(currentYear + 1))
+      ).toBeInTheDocument()
     })
 
     it("disables adjacent-month day cells that fall outside the year range", async () => {
-      // December's grid shows the first days of next January; those lie
-      // outside the selectable years and must not be selectable.
-      const currentYear = new Date().getFullYear()
+      // December's grid shows the first days of next January; with maxDate
+      // in December those lie outside the window and must not be selectable.
       const onSelect = vi.fn()
       render(
         <TestWrapper locale="en-US">
           <OneCalendar
             mode="single"
             view="day"
-            defaultSelected={new Date(currentYear, 11, 15)}
+            defaultSelected={new Date(2024, 11, 15)}
+            minDate={new Date(2020, 0, 1)}
+            maxDate={new Date(2024, 11, 31)}
             onSelect={onSelect}
           />
         </TestWrapper>

--- a/packages/react/src/components/OneCalendar/OneCalendar.tsx
+++ b/packages/react/src/components/OneCalendar/OneCalendar.tsx
@@ -23,6 +23,7 @@ import {
   WeekStartDay,
   WeekStartsOn,
 } from "./types"
+import { CalendarHeaderDropdowns } from "./components/CalendarHeaderDropdowns"
 import { isActiveDate, toDateRange } from "./utils"
 
 const privateProps = ["compact"] as const
@@ -139,6 +140,23 @@ const OneCalendarInternal = ({
 
   // Get header label
   const getHeaderLabel = () => granularity.label(viewDate, i18n, l10n.locale)
+
+  // The day/week views span a month, so they get both month and year
+  // dropdowns; the month view spans a year, so it gets a year dropdown only.
+  // Every other view keeps its plain label.
+  const headerDropdowns =
+    granularity.calendarView === "day" || granularity.calendarView === "week"
+      ? "month-year"
+      : granularity.calendarView === "month"
+        ? "year"
+        : null
+
+  // Jump straight to a month/year from the dropdowns, animating in the
+  // direction of travel like the prev/next arrows do.
+  const handleHeaderDateChange = (newDate: Date) => {
+    setMotionDirection(newDate.getTime() >= viewDate.getTime() ? 1 : -1)
+    setViewDate(newDate)
+  }
 
   // Handle selection of a date
   const handleSelect = (date: Date | DateRange | null) => {
@@ -304,14 +322,25 @@ const OneCalendarInternal = ({
             compact ? "mx-2 pb-2" : "pb-3"
           )}
         >
-          <div
-            className={cn(
-              "font-medium text-f1-foreground",
-              compact ? "text-md" : "text-lg"
-            )}
-          >
-            {getHeaderLabel()}
-          </div>
+          {headerDropdowns ? (
+            <CalendarHeaderDropdowns
+              viewDate={viewDate}
+              onViewDateChange={handleHeaderDateChange}
+              showMonth={headerDropdowns === "month-year"}
+              locale={l10n.locale}
+              minDate={minDate}
+              maxDate={maxDate}
+            />
+          ) : (
+            <div
+              className={cn(
+                "font-medium text-f1-foreground",
+                compact ? "text-md" : "text-lg"
+              )}
+            >
+              {getHeaderLabel()}
+            </div>
+          )}
           <div className="flex items-center gap-2">
             <F0Button
               onClick={() => navigate(-1)}

--- a/packages/react/src/components/OneCalendar/OneCalendar.tsx
+++ b/packages/react/src/components/OneCalendar/OneCalendar.tsx
@@ -23,7 +23,10 @@ import {
   WeekStartDay,
   WeekStartsOn,
 } from "./types"
-import { CalendarHeaderDropdowns } from "./components/CalendarHeaderDropdowns"
+import {
+  CalendarHeaderDropdowns,
+  getYearBounds,
+} from "./components/CalendarHeaderDropdowns"
 import { isActiveDate, toDateRange } from "./utils"
 
 const privateProps = ["compact"] as const
@@ -131,13 +134,6 @@ const OneCalendarInternal = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- only needs to be run when the defaultSelected changes
   }, [defaultSelected])
 
-  // Handle ui view navigation
-  const navigate = (direction: -1 | 1) => {
-    const newDate = granularity.navigateUIView(viewDate, direction)
-    setMotionDirection(direction)
-    setViewDate(newDate)
-  }
-
   // Get header label
   const getHeaderLabel = () => granularity.label(viewDate, i18n, l10n.locale)
 
@@ -150,6 +146,26 @@ const OneCalendarInternal = ({
       : granularity.calendarView === "month"
         ? "year"
         : null
+
+  // Views with header dropdowns clamp arrow navigation to the year dropdown's
+  // range, so the view can never land on a year the dropdown can't display.
+  const yearBounds = headerDropdowns
+    ? getYearBounds(new Date().getFullYear(), minDate, maxDate)
+    : null
+
+  const canNavigate = (direction: -1 | 1) => {
+    if (!yearBounds) return true
+    const year = granularity.navigateUIView(viewDate, direction).getFullYear()
+    return year >= yearBounds.fromYear && year <= yearBounds.toYear
+  }
+
+  // Handle ui view navigation
+  const navigate = (direction: -1 | 1) => {
+    if (!canNavigate(direction)) return
+    const newDate = granularity.navigateUIView(viewDate, direction)
+    setMotionDirection(direction)
+    setViewDate(newDate)
+  }
 
   // Jump straight to a month/year from the dropdowns, animating in the
   // direction of travel like the prev/next arrows do.
@@ -349,6 +365,7 @@ const OneCalendarInternal = ({
               hideLabel
               icon={ChevronLeft}
               size="sm"
+              disabled={!canNavigate(-1)}
             />
             <F0Button
               onClick={() => navigate(1)}
@@ -357,6 +374,7 @@ const OneCalendarInternal = ({
               hideLabel
               icon={ChevronRight}
               size="sm"
+              disabled={!canNavigate(1)}
             />
           </div>
         </div>

--- a/packages/react/src/components/OneCalendar/OneCalendar.tsx
+++ b/packages/react/src/components/OneCalendar/OneCalendar.tsx
@@ -354,6 +354,7 @@ const OneCalendarInternal = ({
               locale={l10n.locale}
               minDate={minDate}
               maxDate={maxDate}
+              compact={compact}
             />
           ) : (
             <div
@@ -365,7 +366,7 @@ const OneCalendarInternal = ({
               {getHeaderLabel()}
             </div>
           )}
-          <div className="flex items-center gap-2">
+          <div className={cn("flex items-center", compact ? "gap-1" : "gap-2")}>
             <F0Button
               onClick={() => navigate(-1)}
               variant="outline"

--- a/packages/react/src/components/OneCalendar/OneCalendar.tsx
+++ b/packages/react/src/components/OneCalendar/OneCalendar.tsx
@@ -153,6 +153,24 @@ const OneCalendarInternal = ({
     ? getYearBounds(new Date().getFullYear(), minDate, maxDate)
     : null
 
+  // The window also bounds selection: without it, the day grid's adjacent-
+  // month cells (e.g. January days trailing a December view) would let users
+  // select dates outside the selectable years.
+  const { effectiveMinDate, effectiveMaxDate } = useMemo(
+    () => ({
+      effectiveMinDate:
+        minDate ??
+        (yearBounds ? new Date(yearBounds.fromYear, 0, 1) : undefined),
+      effectiveMaxDate:
+        maxDate ??
+        (yearBounds
+          ? new Date(yearBounds.toYear, 11, 31, 23, 59, 59, 999)
+          : undefined),
+    }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- yearBounds is derived from these
+    [minDate, maxDate, headerDropdowns]
+  )
+
   const canNavigate = (direction: -1 | 1) => {
     if (!yearBounds) return true
     const year = granularity.navigateUIView(viewDate, direction).getFullYear()
@@ -208,11 +226,11 @@ const OneCalendarInternal = ({
       }
 
       return isActiveDate(date, granularity, {
-        minDate,
-        maxDate,
+        minDate: effectiveMinDate,
+        maxDate: effectiveMaxDate,
       })
     },
-    [granularity, minDate, maxDate]
+    [granularity, effectiveMinDate, effectiveMaxDate]
   )
 
   const setSelectFromInput = (
@@ -389,8 +407,8 @@ const OneCalendarInternal = ({
           motionDirection,
           setViewDate,
           viewDate,
-          minDate,
-          maxDate,
+          minDate: effectiveMinDate,
+          maxDate: effectiveMaxDate,
           compact,
           weekStartsOn: effectiveWeekStartsOn,
         })}

--- a/packages/react/src/components/OneCalendar/OneCalendar.tsx
+++ b/packages/react/src/components/OneCalendar/OneCalendar.tsx
@@ -149,27 +149,17 @@ const OneCalendarInternal = ({
 
   // Views with header dropdowns clamp arrow navigation to the year dropdown's
   // range, so the view can never land on a year the dropdown can't display.
+  // Selection is NOT clamped to this window — it is bounded only by the
+  // consumer's minDate/maxDate. A consumer-allowed value outside the default
+  // window stretches the range (viewYear) so the dropdown can display it.
   const yearBounds = headerDropdowns
-    ? getYearBounds(new Date().getFullYear(), minDate, maxDate)
+    ? getYearBounds(
+        new Date().getFullYear(),
+        minDate,
+        maxDate,
+        viewDate.getFullYear()
+      )
     : null
-
-  // The window also bounds selection: without it, the day grid's adjacent-
-  // month cells (e.g. January days trailing a December view) would let users
-  // select dates outside the selectable years.
-  const { effectiveMinDate, effectiveMaxDate } = useMemo(
-    () => ({
-      effectiveMinDate:
-        minDate ??
-        (yearBounds ? new Date(yearBounds.fromYear, 0, 1) : undefined),
-      effectiveMaxDate:
-        maxDate ??
-        (yearBounds
-          ? new Date(yearBounds.toYear, 11, 31, 23, 59, 59, 999)
-          : undefined),
-    }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- yearBounds is derived from these
-    [minDate, maxDate, headerDropdowns]
-  )
 
   const canNavigate = (direction: -1 | 1) => {
     if (!yearBounds) return true
@@ -226,11 +216,11 @@ const OneCalendarInternal = ({
       }
 
       return isActiveDate(date, granularity, {
-        minDate: effectiveMinDate,
-        maxDate: effectiveMaxDate,
+        minDate,
+        maxDate,
       })
     },
-    [granularity, effectiveMinDate, effectiveMaxDate]
+    [granularity, minDate, maxDate]
   )
 
   const setSelectFromInput = (
@@ -407,8 +397,8 @@ const OneCalendarInternal = ({
           motionDirection,
           setViewDate,
           viewDate,
-          minDate: effectiveMinDate,
-          maxDate: effectiveMaxDate,
+          minDate,
+          maxDate,
           compact,
           weekStartsOn: effectiveWeekStartsOn,
         })}

--- a/packages/react/src/components/OneCalendar/components/CalendarHeaderDropdowns.tsx
+++ b/packages/react/src/components/OneCalendar/components/CalendarHeaderDropdowns.tsx
@@ -5,10 +5,12 @@ import { F0Select } from "@/components/F0Select"
 import { useI18n } from "@/lib/providers/i18n"
 
 /**
- * How many years back the year dropdown reaches when no `minDate` is given.
- * Wide enough to cover any birthday without rendering an unbounded list.
+ * How many years the year dropdown reaches back (without `minDate`) and
+ * forward (without `maxDate`) from the current year. Wide enough to cover
+ * any birthday or far-future deadline without rendering an unbounded list;
+ * consumers narrow it by setting explicit `minDate`/`maxDate`.
  */
-export const DEFAULT_YEARS_BACK = 120
+export const DEFAULT_YEARS_RANGE = 120
 
 interface SelectOption {
   value: string
@@ -18,9 +20,10 @@ interface SelectOption {
 
 /**
  * Selectable year range for the header dropdowns. Bounds come from
- * `minDate`/`maxDate` when set, otherwise a wide window ending at the current
- * year so distant birthdays are reachable. Arrow navigation is clamped to
- * this same range (see OneCalendar), so the view can never drift outside it.
+ * `minDate`/`maxDate` when set, otherwise a wide window centered on the
+ * current year so both distant birthdays and far-future dates are reachable.
+ * Arrow navigation is clamped to this same range (see OneCalendar), so the
+ * view can never drift outside it.
  */
 export function getYearBounds(
   currentYear: number,
@@ -29,8 +32,10 @@ export function getYearBounds(
 ): { fromYear: number; toYear: number } {
   const fromYear = minDate
     ? minDate.getFullYear()
-    : currentYear - DEFAULT_YEARS_BACK
-  const toYear = maxDate ? maxDate.getFullYear() : currentYear
+    : currentYear - DEFAULT_YEARS_RANGE
+  const toYear = maxDate
+    ? maxDate.getFullYear()
+    : currentYear + DEFAULT_YEARS_RANGE
   return {
     fromYear: Math.min(fromYear, toYear),
     toYear: Math.max(fromYear, toYear),

--- a/packages/react/src/components/OneCalendar/components/CalendarHeaderDropdowns.tsx
+++ b/packages/react/src/components/OneCalendar/components/CalendarHeaderDropdowns.tsx
@@ -1,0 +1,139 @@
+import { endOfMonth, isAfter, isBefore, startOfMonth } from "date-fns"
+import { useMemo } from "react"
+
+import { F0Select } from "@/components/F0Select"
+import { useI18n } from "@/lib/providers/i18n"
+
+/**
+ * How many years back the year dropdown reaches when no `minDate` is given.
+ * Wide enough to cover any birthday without rendering an unbounded list.
+ */
+export const DEFAULT_YEARS_BACK = 120
+
+interface SelectOption {
+  value: string
+  label: string
+  disabled?: boolean
+}
+
+/**
+ * Descending list of selectable years. Bounds come from `minDate`/`maxDate`
+ * when set, otherwise a wide window ending at the current year so distant
+ * birthdays are reachable.
+ */
+export function buildYearOptions(
+  currentYear: number,
+  minDate?: Date,
+  maxDate?: Date
+): SelectOption[] {
+  const fromYear = minDate
+    ? minDate.getFullYear()
+    : currentYear - DEFAULT_YEARS_BACK
+  const toYear = maxDate ? maxDate.getFullYear() : currentYear
+  const hi = Math.max(fromYear, toYear)
+  const lo = Math.min(fromYear, toYear)
+  const options: SelectOption[] = []
+  for (let year = hi; year >= lo; year--) {
+    options.push({ value: String(year), label: String(year) })
+  }
+  return options
+}
+
+/**
+ * The 12 months for the given year, localized. A month is disabled when it
+ * falls entirely outside `minDate`/`maxDate`.
+ */
+export function buildMonthOptions(
+  year: number,
+  locale: string,
+  minDate?: Date,
+  maxDate?: Date
+): SelectOption[] {
+  const formatter = new Intl.DateTimeFormat(locale, { month: "long" })
+  return Array.from({ length: 12 }, (_, month) => {
+    const monthDate = new Date(year, month, 1)
+    const disabled = Boolean(
+      (minDate && isBefore(endOfMonth(monthDate), minDate)) ||
+      (maxDate && isAfter(startOfMonth(monthDate), maxDate))
+    )
+    return {
+      // A stable, locale-independent reference date so day-31 months don't skip.
+      value: String(month),
+      label: formatter.format(new Date(2000, month, 1)),
+      disabled,
+    }
+  })
+}
+
+interface CalendarHeaderDropdownsProps {
+  /** The month/year currently in view (first of the month). */
+  viewDate: Date
+  /** Emits the new view date when the user picks a month or year. */
+  onViewDateChange: (date: Date) => void
+  /** When false, only the year dropdown is shown (e.g. the month granularity). */
+  showMonth: boolean
+  /** Locale used to label the months, matching the granularity `label()`. */
+  locale?: string
+  minDate?: Date
+  maxDate?: Date
+}
+
+/**
+ * Month + year selectors for the calendar header. Replaces the static
+ * "October 2026" label so users can jump directly to a distant month/year
+ * (e.g. a birthday) instead of clicking the prev/next arrows dozens of times.
+ */
+export function CalendarHeaderDropdowns({
+  viewDate,
+  onViewDateChange,
+  showMonth,
+  locale = "en-US",
+  minDate,
+  maxDate,
+}: CalendarHeaderDropdownsProps) {
+  const i18n = useI18n()
+
+  const yearOptions = useMemo(
+    () => buildYearOptions(new Date().getFullYear(), minDate, maxDate),
+    [minDate, maxDate]
+  )
+
+  const monthOptions = useMemo(
+    () => buildMonthOptions(viewDate.getFullYear(), locale, minDate, maxDate),
+    [locale, viewDate, minDate, maxDate]
+  )
+
+  const handleMonthChange = (value: string) => {
+    onViewDateChange(new Date(viewDate.getFullYear(), Number(value), 1))
+  }
+
+  const handleYearChange = (value: string) => {
+    onViewDateChange(new Date(Number(value), viewDate.getMonth(), 1))
+  }
+
+  return (
+    <div className="flex items-center gap-1">
+      {showMonth && (
+        <F0Select
+          size="sm"
+          label={i18n.date.selectMonth}
+          hideLabel
+          placeholder={i18n.date.selectMonth}
+          options={monthOptions}
+          value={String(viewDate.getMonth())}
+          onChange={handleMonthChange}
+        />
+      )}
+      <F0Select
+        size="sm"
+        label={i18n.date.selectYear}
+        hideLabel
+        placeholder={i18n.date.selectYear}
+        showSearchBox
+        options={yearOptions}
+        value={String(viewDate.getFullYear())}
+        onChange={handleYearChange}
+      />
+    </div>
+  )
+}

--- a/packages/react/src/components/OneCalendar/components/CalendarHeaderDropdowns.tsx
+++ b/packages/react/src/components/OneCalendar/components/CalendarHeaderDropdowns.tsx
@@ -71,15 +71,18 @@ export function buildYearOptions(
 
 /**
  * The 12 months for the given year, localized. A month is disabled when it
- * falls entirely outside `minDate`/`maxDate`.
+ * falls entirely outside `minDate`/`maxDate`. The compact calendar uses the
+ * "short" format ("Sep", "sept.") so the trigger fits its narrower header at
+ * a fixed width across locales.
  */
 export function buildMonthOptions(
   year: number,
   locale: string,
   minDate?: Date,
-  maxDate?: Date
+  maxDate?: Date,
+  format: "long" | "short" = "long"
 ): SelectOption[] {
-  const formatter = new Intl.DateTimeFormat(locale, { month: "long" })
+  const formatter = new Intl.DateTimeFormat(locale, { month: format })
   return Array.from({ length: 12 }, (_, month) => {
     const monthDate = new Date(year, month, 1)
     const disabled = Boolean(
@@ -106,6 +109,12 @@ interface CalendarHeaderDropdownsProps {
   locale?: string
   minDate?: Date
   maxDate?: Date
+  /**
+   * Compact calendars (e.g. the filter-picker date filter) have a ~240px
+   * header budget: narrower triggers and short month names keep the
+   * dropdowns and arrows from overflowing it.
+   */
+  compact?: boolean
 }
 
 /**
@@ -120,6 +129,7 @@ export function CalendarHeaderDropdowns({
   locale = "en-US",
   minDate,
   maxDate,
+  compact = false,
 }: CalendarHeaderDropdownsProps) {
   const i18n = useI18n()
 
@@ -135,8 +145,15 @@ export function CalendarHeaderDropdowns({
   )
 
   const monthOptions = useMemo(
-    () => buildMonthOptions(viewDate.getFullYear(), locale, minDate, maxDate),
-    [locale, viewDate, minDate, maxDate]
+    () =>
+      buildMonthOptions(
+        viewDate.getFullYear(),
+        locale,
+        minDate,
+        maxDate,
+        compact ? "short" : "long"
+      ),
+    [locale, viewDate, minDate, maxDate, compact]
   )
 
   const handleMonthChange = (value: string) => {
@@ -148,11 +165,16 @@ export function CalendarHeaderDropdowns({
   }
 
   return (
-    <div className="flex items-center gap-1">
+    // min-w-0 lets the header shrink this side instead of pushing the
+    // prev/next arrows out of the container.
+    <div className="flex min-w-0 items-center gap-1">
       {showMonth && (
         // Fixed width so the trigger (and the popover around it) doesn't
-        // resize when switching between short and long month names.
-        <div className="w-[8.5rem]">
+        // resize when switching between short and long month names. Compact
+        // pairs a narrower trigger with short month labels: 5.5rem fits the
+        // widest short month of the supported locales ("sept." fr) plus the
+        // field's chrome.
+        <div className={compact ? "w-[5.5rem]" : "w-[8.5rem]"}>
           <F0Select
             size="sm"
             label={i18n.date.selectMonth}
@@ -165,7 +187,7 @@ export function CalendarHeaderDropdowns({
           />
         </div>
       )}
-      <div className="w-[6rem]">
+      <div className={compact ? "w-[5.5rem]" : "w-[6rem]"}>
         <F0Select
           size="sm"
           label={i18n.date.selectYear}

--- a/packages/react/src/components/OneCalendar/components/CalendarHeaderDropdowns.tsx
+++ b/packages/react/src/components/OneCalendar/components/CalendarHeaderDropdowns.tsx
@@ -19,19 +19,22 @@ interface SelectOption {
 /**
  * Descending list of selectable years. Bounds come from `minDate`/`maxDate`
  * when set, otherwise a wide window ending at the current year so distant
- * birthdays are reachable.
+ * birthdays are reachable. The list always includes `viewYear` — the arrows
+ * can navigate past the default bounds, and a view year missing from the
+ * options would leave the select with a value it can't display.
  */
 export function buildYearOptions(
   currentYear: number,
   minDate?: Date,
-  maxDate?: Date
+  maxDate?: Date,
+  viewYear?: number
 ): SelectOption[] {
   const fromYear = minDate
     ? minDate.getFullYear()
     : currentYear - DEFAULT_YEARS_BACK
   const toYear = maxDate ? maxDate.getFullYear() : currentYear
-  const hi = Math.max(fromYear, toYear)
-  const lo = Math.min(fromYear, toYear)
+  const hi = Math.max(fromYear, toYear, viewYear ?? -Infinity)
+  const lo = Math.min(fromYear, toYear, viewYear ?? Infinity)
   const options: SelectOption[] = []
   for (let year = hi; year >= lo; year--) {
     options.push({ value: String(year), label: String(year) })
@@ -94,8 +97,14 @@ export function CalendarHeaderDropdowns({
   const i18n = useI18n()
 
   const yearOptions = useMemo(
-    () => buildYearOptions(new Date().getFullYear(), minDate, maxDate),
-    [minDate, maxDate]
+    () =>
+      buildYearOptions(
+        new Date().getFullYear(),
+        minDate,
+        maxDate,
+        viewDate.getFullYear()
+      ),
+    [minDate, maxDate, viewDate]
   )
 
   const monthOptions = useMemo(

--- a/packages/react/src/components/OneCalendar/components/CalendarHeaderDropdowns.tsx
+++ b/packages/react/src/components/OneCalendar/components/CalendarHeaderDropdowns.tsx
@@ -19,16 +19,21 @@ interface SelectOption {
 }
 
 /**
- * Selectable year range for the header dropdowns. Bounds come from
+ * Year range for the header dropdowns and arrow navigation. Bounds come from
  * `minDate`/`maxDate` when set, otherwise a wide window centered on the
  * current year so both distant birthdays and far-future dates are reachable.
- * Arrow navigation is clamped to this same range (see OneCalendar), so the
- * view can never drift outside it.
+ *
+ * The window bounds NAVIGATION, not selection — selection is limited only by
+ * the consumer's `minDate`/`maxDate`. Because a consumer-allowed value can
+ * legitimately sit outside the default window (e.g. a very old date with
+ * only `maxDate` set), the range always stretches to include `viewYear` so
+ * the dropdown can display it.
  */
 export function getYearBounds(
   currentYear: number,
   minDate?: Date,
-  maxDate?: Date
+  maxDate?: Date,
+  viewYear?: number
 ): { fromYear: number; toYear: number } {
   const fromYear = minDate
     ? minDate.getFullYear()
@@ -37,8 +42,8 @@ export function getYearBounds(
     ? maxDate.getFullYear()
     : currentYear + DEFAULT_YEARS_RANGE
   return {
-    fromYear: Math.min(fromYear, toYear),
-    toYear: Math.max(fromYear, toYear),
+    fromYear: Math.min(fromYear, toYear, viewYear ?? Infinity),
+    toYear: Math.max(fromYear, toYear, viewYear ?? -Infinity),
   }
 }
 
@@ -48,9 +53,15 @@ export function getYearBounds(
 export function buildYearOptions(
   currentYear: number,
   minDate?: Date,
-  maxDate?: Date
+  maxDate?: Date,
+  viewYear?: number
 ): SelectOption[] {
-  const { fromYear, toYear } = getYearBounds(currentYear, minDate, maxDate)
+  const { fromYear, toYear } = getYearBounds(
+    currentYear,
+    minDate,
+    maxDate,
+    viewYear
+  )
   const options: SelectOption[] = []
   for (let year = toYear; year >= fromYear; year--) {
     options.push({ value: String(year), label: String(year) })
@@ -113,8 +124,14 @@ export function CalendarHeaderDropdowns({
   const i18n = useI18n()
 
   const yearOptions = useMemo(
-    () => buildYearOptions(new Date().getFullYear(), minDate, maxDate),
-    [minDate, maxDate]
+    () =>
+      buildYearOptions(
+        new Date().getFullYear(),
+        minDate,
+        maxDate,
+        viewDate.getFullYear()
+      ),
+    [minDate, maxDate, viewDate]
   )
 
   const monthOptions = useMemo(

--- a/packages/react/src/components/OneCalendar/components/CalendarHeaderDropdowns.tsx
+++ b/packages/react/src/components/OneCalendar/components/CalendarHeaderDropdowns.tsx
@@ -17,26 +17,37 @@ interface SelectOption {
 }
 
 /**
- * Descending list of selectable years. Bounds come from `minDate`/`maxDate`
- * when set, otherwise a wide window ending at the current year so distant
- * birthdays are reachable. The list always includes `viewYear` — the arrows
- * can navigate past the default bounds, and a view year missing from the
- * options would leave the select with a value it can't display.
+ * Selectable year range for the header dropdowns. Bounds come from
+ * `minDate`/`maxDate` when set, otherwise a wide window ending at the current
+ * year so distant birthdays are reachable. Arrow navigation is clamped to
+ * this same range (see OneCalendar), so the view can never drift outside it.
  */
-export function buildYearOptions(
+export function getYearBounds(
   currentYear: number,
   minDate?: Date,
-  maxDate?: Date,
-  viewYear?: number
-): SelectOption[] {
+  maxDate?: Date
+): { fromYear: number; toYear: number } {
   const fromYear = minDate
     ? minDate.getFullYear()
     : currentYear - DEFAULT_YEARS_BACK
   const toYear = maxDate ? maxDate.getFullYear() : currentYear
-  const hi = Math.max(fromYear, toYear, viewYear ?? -Infinity)
-  const lo = Math.min(fromYear, toYear, viewYear ?? Infinity)
+  return {
+    fromYear: Math.min(fromYear, toYear),
+    toYear: Math.max(fromYear, toYear),
+  }
+}
+
+/**
+ * Descending list of selectable years, spanning `getYearBounds`.
+ */
+export function buildYearOptions(
+  currentYear: number,
+  minDate?: Date,
+  maxDate?: Date
+): SelectOption[] {
+  const { fromYear, toYear } = getYearBounds(currentYear, minDate, maxDate)
   const options: SelectOption[] = []
-  for (let year = hi; year >= lo; year--) {
+  for (let year = toYear; year >= fromYear; year--) {
     options.push({ value: String(year), label: String(year) })
   }
   return options
@@ -97,14 +108,8 @@ export function CalendarHeaderDropdowns({
   const i18n = useI18n()
 
   const yearOptions = useMemo(
-    () =>
-      buildYearOptions(
-        new Date().getFullYear(),
-        minDate,
-        maxDate,
-        viewDate.getFullYear()
-      ),
-    [minDate, maxDate, viewDate]
+    () => buildYearOptions(new Date().getFullYear(), minDate, maxDate),
+    [minDate, maxDate]
   )
 
   const monthOptions = useMemo(

--- a/packages/react/src/components/OneCalendar/components/CalendarHeaderDropdowns.tsx
+++ b/packages/react/src/components/OneCalendar/components/CalendarHeaderDropdowns.tsx
@@ -114,26 +114,34 @@ export function CalendarHeaderDropdowns({
   return (
     <div className="flex items-center gap-1">
       {showMonth && (
+        // Fixed width so the trigger (and the popover around it) doesn't
+        // resize when switching between short and long month names.
+        <div className="w-[8.5rem]">
+          <F0Select
+            size="sm"
+            label={i18n.date.selectMonth}
+            hideLabel
+            placeholder={i18n.date.selectMonth}
+            options={monthOptions}
+            value={String(viewDate.getMonth())}
+            onChange={handleMonthChange}
+            fitContentWidth
+          />
+        </div>
+      )}
+      <div className="w-[6rem]">
         <F0Select
           size="sm"
-          label={i18n.date.selectMonth}
+          label={i18n.date.selectYear}
           hideLabel
-          placeholder={i18n.date.selectMonth}
-          options={monthOptions}
-          value={String(viewDate.getMonth())}
-          onChange={handleMonthChange}
+          placeholder={i18n.date.selectYear}
+          showSearchBox
+          options={yearOptions}
+          value={String(viewDate.getFullYear())}
+          onChange={handleYearChange}
+          fitContentWidth
         />
-      )}
-      <F0Select
-        size="sm"
-        label={i18n.date.selectYear}
-        hideLabel
-        placeholder={i18n.date.selectYear}
-        showSearchBox
-        options={yearOptions}
-        value={String(viewDate.getFullYear())}
-        onChange={handleYearChange}
-      />
+      </div>
     </div>
   )
 }

--- a/packages/react/src/components/OneCalendar/components/__tests__/CalendarHeaderDropdowns.test.tsx
+++ b/packages/react/src/components/OneCalendar/components/__tests__/CalendarHeaderDropdowns.test.tsx
@@ -75,6 +75,28 @@ describe("getYearBounds", () => {
       getYearBounds(2026, new Date(1995, 0, 1), new Date(1990, 0, 1))
     ).toEqual({ fromYear: 1990, toYear: 1995 })
   })
+
+  it("stretches to include a view year outside the window", () => {
+    // Selection is bounded by the consumer's minDate/maxDate only, so an
+    // allowed value can lie outside the default window (e.g. a very old date
+    // when only maxDate is set). The range must include it so the dropdown
+    // can display it.
+    expect(getYearBounds(2026, undefined, new Date(2026, 0, 1), 1850)).toEqual({
+      fromYear: 1850,
+      toYear: 2026,
+    })
+    expect(getYearBounds(2026, new Date(2020, 0, 1), undefined, 2200)).toEqual({
+      fromYear: 2020,
+      toYear: 2200,
+    })
+  })
+
+  it("does not shrink the window when the view year is inside it", () => {
+    expect(getYearBounds(2026, undefined, undefined, 2026)).toEqual({
+      fromYear: 2026 - DEFAULT_YEARS_RANGE,
+      toYear: 2026 + DEFAULT_YEARS_RANGE,
+    })
+  })
 })
 
 describe("buildMonthOptions", () => {

--- a/packages/react/src/components/OneCalendar/components/__tests__/CalendarHeaderDropdowns.test.tsx
+++ b/packages/react/src/components/OneCalendar/components/__tests__/CalendarHeaderDropdowns.test.tsx
@@ -114,6 +114,26 @@ describe("buildMonthOptions", () => {
     expect(options[0].label.toLowerCase()).toBe("enero")
   })
 
+  it("returns localized short month names for compact headers", () => {
+    const english = buildMonthOptions(
+      2026,
+      "en-US",
+      undefined,
+      undefined,
+      "short"
+    )
+    expect(english[8].label).toBe("Sep")
+
+    const spanish = buildMonthOptions(
+      2026,
+      "es-ES",
+      undefined,
+      undefined,
+      "short"
+    )
+    expect(spanish[0].label.toLowerCase()).toContain("ene")
+  })
+
   it("disables months that fall entirely outside min/max", () => {
     // Range is only June–August 2026.
     const options = buildMonthOptions(

--- a/packages/react/src/components/OneCalendar/components/__tests__/CalendarHeaderDropdowns.test.tsx
+++ b/packages/react/src/components/OneCalendar/components/__tests__/CalendarHeaderDropdowns.test.tsx
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildMonthOptions,
+  buildYearOptions,
+  DEFAULT_YEARS_BACK,
+} from "../CalendarHeaderDropdowns"
+
+describe("buildYearOptions", () => {
+  it("defaults to a wide window ending at the current year, newest first", () => {
+    const options = buildYearOptions(2026)
+
+    expect(options).toHaveLength(DEFAULT_YEARS_BACK + 1)
+    expect(options[0]).toEqual({ value: "2026", label: "2026" })
+    expect(options[options.length - 1]).toEqual({
+      value: String(2026 - DEFAULT_YEARS_BACK),
+      label: String(2026 - DEFAULT_YEARS_BACK),
+    })
+  })
+
+  it("reaches far enough back to cover a birthday", () => {
+    const values = buildYearOptions(2026).map((o) => o.value)
+    expect(values).toContain("1985")
+  })
+
+  it("bounds the list to minDate/maxDate years when provided", () => {
+    const options = buildYearOptions(
+      2026,
+      new Date(1990, 0, 1),
+      new Date(1995, 11, 31)
+    )
+
+    expect(options.map((o) => o.value)).toEqual([
+      "1995",
+      "1994",
+      "1993",
+      "1992",
+      "1991",
+      "1990",
+    ])
+  })
+
+  it("stays descending even if min/max are passed inverted", () => {
+    const options = buildYearOptions(
+      2026,
+      new Date(1995, 0, 1),
+      new Date(1990, 0, 1)
+    )
+    expect(options[0].value).toBe("1995")
+    expect(options[options.length - 1].value).toBe("1990")
+  })
+})
+
+describe("buildMonthOptions", () => {
+  it("returns 12 localized months, none disabled without bounds", () => {
+    const options = buildMonthOptions(2026, "en-US")
+
+    expect(options).toHaveLength(12)
+    expect(options[0]).toMatchObject({ value: "0", label: "January" })
+    expect(options[11]).toMatchObject({ value: "11", label: "December" })
+    expect(options.every((o) => !o.disabled)).toBe(true)
+  })
+
+  it("localizes month names", () => {
+    const options = buildMonthOptions(2026, "es-ES")
+    expect(options[0].label.toLowerCase()).toBe("enero")
+  })
+
+  it("disables months that fall entirely outside min/max", () => {
+    // Range is only June–August 2026.
+    const options = buildMonthOptions(
+      2026,
+      "en-US",
+      new Date(2026, 5, 1),
+      new Date(2026, 7, 31)
+    )
+
+    // January (0) is before the range, December (11) is after it.
+    expect(options[0].disabled).toBe(true)
+    expect(options[11].disabled).toBe(true)
+    // June/July/August are within range.
+    expect(options[5].disabled).toBe(false)
+    expect(options[6].disabled).toBe(false)
+    expect(options[7].disabled).toBe(false)
+  })
+
+  it("keeps a partially-covered boundary month enabled", () => {
+    // minDate mid-March: March is partially covered, so it stays enabled.
+    const options = buildMonthOptions(2026, "en-US", new Date(2026, 2, 15))
+    expect(options[2].disabled).toBe(false)
+    expect(options[1].disabled).toBe(true) // February fully before min
+  })
+})

--- a/packages/react/src/components/OneCalendar/components/__tests__/CalendarHeaderDropdowns.test.tsx
+++ b/packages/react/src/components/OneCalendar/components/__tests__/CalendarHeaderDropdowns.test.tsx
@@ -3,25 +3,29 @@ import { describe, expect, it } from "vitest"
 import {
   buildMonthOptions,
   buildYearOptions,
-  DEFAULT_YEARS_BACK,
+  DEFAULT_YEARS_RANGE,
   getYearBounds,
 } from "../CalendarHeaderDropdowns"
 
 describe("buildYearOptions", () => {
-  it("defaults to a wide window ending at the current year, newest first", () => {
+  it("defaults to a wide window centered on the current year, newest first", () => {
     const options = buildYearOptions(2026)
 
-    expect(options).toHaveLength(DEFAULT_YEARS_BACK + 1)
-    expect(options[0]).toEqual({ value: "2026", label: "2026" })
+    expect(options).toHaveLength(DEFAULT_YEARS_RANGE * 2 + 1)
+    expect(options[0]).toEqual({
+      value: String(2026 + DEFAULT_YEARS_RANGE),
+      label: String(2026 + DEFAULT_YEARS_RANGE),
+    })
     expect(options[options.length - 1]).toEqual({
-      value: String(2026 - DEFAULT_YEARS_BACK),
-      label: String(2026 - DEFAULT_YEARS_BACK),
+      value: String(2026 - DEFAULT_YEARS_RANGE),
+      label: String(2026 - DEFAULT_YEARS_RANGE),
     })
   })
 
-  it("reaches far enough back to cover a birthday", () => {
+  it("reaches far enough back for birthdays and forward for deadlines", () => {
     const values = buildYearOptions(2026).map((o) => o.value)
     expect(values).toContain("1985")
+    expect(values).toContain("2076")
   })
 
   it("bounds the list to minDate/maxDate years when provided", () => {
@@ -53,10 +57,10 @@ describe("buildYearOptions", () => {
 })
 
 describe("getYearBounds", () => {
-  it("defaults to the wide window ending at the current year", () => {
+  it("defaults to the wide window centered on the current year", () => {
     expect(getYearBounds(2026)).toEqual({
-      fromYear: 2026 - DEFAULT_YEARS_BACK,
-      toYear: 2026,
+      fromYear: 2026 - DEFAULT_YEARS_RANGE,
+      toYear: 2026 + DEFAULT_YEARS_RANGE,
     })
   })
 

--- a/packages/react/src/components/OneCalendar/components/__tests__/CalendarHeaderDropdowns.test.tsx
+++ b/packages/react/src/components/OneCalendar/components/__tests__/CalendarHeaderDropdowns.test.tsx
@@ -40,6 +40,21 @@ describe("buildYearOptions", () => {
     ])
   })
 
+  it("always includes the year in view, even past the default bounds", () => {
+    // Arrows can navigate beyond the default window (currentYear); the view
+    // year must still be a selectable option or the trigger shows nothing.
+    const options = buildYearOptions(2025, undefined, undefined, 2026)
+    expect(options[0].value).toBe("2026")
+
+    const pastView = buildYearOptions(
+      2025,
+      new Date(2020, 0, 1),
+      new Date(2024, 0, 1),
+      2015
+    )
+    expect(pastView.map((o) => o.value)).toContain("2015")
+  })
+
   it("stays descending even if min/max are passed inverted", () => {
     const options = buildYearOptions(
       2026,

--- a/packages/react/src/components/OneCalendar/components/__tests__/CalendarHeaderDropdowns.test.tsx
+++ b/packages/react/src/components/OneCalendar/components/__tests__/CalendarHeaderDropdowns.test.tsx
@@ -4,6 +4,7 @@ import {
   buildMonthOptions,
   buildYearOptions,
   DEFAULT_YEARS_BACK,
+  getYearBounds,
 } from "../CalendarHeaderDropdowns"
 
 describe("buildYearOptions", () => {
@@ -40,21 +41,6 @@ describe("buildYearOptions", () => {
     ])
   })
 
-  it("always includes the year in view, even past the default bounds", () => {
-    // Arrows can navigate beyond the default window (currentYear); the view
-    // year must still be a selectable option or the trigger shows nothing.
-    const options = buildYearOptions(2025, undefined, undefined, 2026)
-    expect(options[0].value).toBe("2026")
-
-    const pastView = buildYearOptions(
-      2025,
-      new Date(2020, 0, 1),
-      new Date(2024, 0, 1),
-      2015
-    )
-    expect(pastView.map((o) => o.value)).toContain("2015")
-  })
-
   it("stays descending even if min/max are passed inverted", () => {
     const options = buildYearOptions(
       2026,
@@ -63,6 +49,27 @@ describe("buildYearOptions", () => {
     )
     expect(options[0].value).toBe("1995")
     expect(options[options.length - 1].value).toBe("1990")
+  })
+})
+
+describe("getYearBounds", () => {
+  it("defaults to the wide window ending at the current year", () => {
+    expect(getYearBounds(2026)).toEqual({
+      fromYear: 2026 - DEFAULT_YEARS_BACK,
+      toYear: 2026,
+    })
+  })
+
+  it("uses minDate/maxDate years when provided", () => {
+    expect(
+      getYearBounds(2026, new Date(1990, 0, 1), new Date(1995, 11, 31))
+    ).toEqual({ fromYear: 1990, toYear: 1995 })
+  })
+
+  it("normalizes inverted bounds", () => {
+    expect(
+      getYearBounds(2026, new Date(1995, 0, 1), new Date(1990, 0, 1))
+    ).toEqual({ fromYear: 1990, toYear: 1995 })
   })
 })
 

--- a/packages/react/src/hooks/__tests__/useDebouncedState.test.ts
+++ b/packages/react/src/hooks/__tests__/useDebouncedState.test.ts
@@ -1,0 +1,64 @@
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { useDebouncedState } from "../useDebouncedState"
+
+describe("useDebouncedState", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  it("applies only the last value after the delay", () => {
+    vi.useFakeTimers()
+    const { result } = renderHook(() => useDebouncedState("initial", 200))
+
+    act(() => {
+      result.current[1]("first")
+      result.current[1]("second")
+    })
+    expect(result.current[0]).toBe("initial")
+
+    act(() => {
+      vi.advanceTimersByTime(200)
+    })
+    expect(result.current[0]).toBe("second")
+  })
+
+  it("updates even when Date.now is frozen (MockDate in stories)", async () => {
+    // Regression: lodash.debounce (usehooks-ts useDebounceValue) decides its
+    // trailing edge by reading Date.now(), so a frozen clock starved the
+    // update forever. A setTimeout-based debounce must not care.
+    const nowSpy = vi
+      .spyOn(Date, "now")
+      .mockReturnValue(new Date(2025, 6, 30).getTime())
+    const { result } = renderHook(() => useDebouncedState("initial", 50))
+
+    act(() => {
+      result.current[1]("updated")
+    })
+
+    await waitFor(() => expect(result.current[0]).toBe("updated"))
+    nowSpy.mockRestore()
+  })
+
+  it("cancels the pending update on unmount", () => {
+    // Regression: usehooks-ts' unmount cleanup cancels the wrong lodash
+    // instance, letting trailing timers fire after the component (and in
+    // tests, the jsdom window) is gone.
+    vi.useFakeTimers()
+    const clearSpy = vi.spyOn(global, "clearTimeout")
+    const { result, unmount } = renderHook(() =>
+      useDebouncedState("initial", 200)
+    )
+
+    act(() => {
+      result.current[1]("pending")
+    })
+    unmount()
+
+    expect(clearSpy).toHaveBeenCalled()
+    // Advancing past the delay must not throw or dispatch a state update.
+    expect(() => vi.advanceTimersByTime(500)).not.toThrow()
+  })
+})

--- a/packages/react/src/hooks/datasource/useDataSource.ts
+++ b/packages/react/src/hooks/datasource/useDataSource.ts
@@ -2,7 +2,7 @@ import type { Dispatch, SetStateAction } from "react"
 
 import { useDeepCompareEffect } from "@reactuses/core"
 import { useEffect, useMemo, useState } from "react"
-import { useDebounceValue } from "usehooks-ts"
+import { useDebouncedState } from "../useDebouncedState"
 
 import {
   DataSource,
@@ -156,7 +156,9 @@ export function useDataSource<
 
   const [currentSearch, setCurrentSearch] = useState<string | undefined>()
 
-  const [debouncedCurrentSearch, setDebouncedCurrentSearch] = useDebounceValue<
+  // setTimeout-based debounce: usehooks-ts' useDebounceValue (lodash) stalls
+  // under frozen clocks and can fire its trailing timer after unmount.
+  const [debouncedCurrentSearch, setDebouncedCurrentSearch] = useDebouncedState<
     string | undefined
   >(currentSearch, 200)
 

--- a/packages/react/src/hooks/useDebouncedState.ts
+++ b/packages/react/src/hooks/useDebouncedState.ts
@@ -1,0 +1,50 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+
+/**
+ * Debounced state backed by a plain setTimeout, as a safe replacement for
+ * usehooks-ts' `useDebounceValue` (lodash.debounce). lodash has two failure
+ * modes we keep hitting:
+ *
+ * - It decides its trailing edge by reading `Date.now()`, so under a frozen
+ *   clock (MockDate in Storybook stories, mocked dates in tests) the wait
+ *   window never elapses and the debounced update never applies.
+ * - usehooks-ts' unmount cleanup cancels a different lodash instance than
+ *   the one callers invoke, so pending trailing timers can fire after
+ *   unmount (in tests, after the jsdom window is torn down, crashing the
+ *   run with "window is not defined").
+ *
+ * setTimeout keeps ticking regardless of the clock, and the pending timer is
+ * reliably cancelled on unmount. Semantics match a trailing debounce: rapid
+ * calls coalesce and only the last value is applied.
+ */
+export function useDebouncedState<T>(
+  initialValue: T,
+  delay: number
+): [T, (value: T) => void] {
+  const [value, setValue] = useState<T>(initialValue)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const setDebouncedValue = useCallback(
+    (newValue: T) => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current)
+      }
+      timerRef.current = setTimeout(() => {
+        timerRef.current = null
+        setValue(newValue)
+      }, delay)
+    },
+    [delay]
+  )
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    }
+  }, [])
+
+  return [value, setDebouncedValue]
+}

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -248,6 +248,8 @@ export const defaultTranslations = {
     date: "Date",
     custom: "Custom period",
     selectDate: "Select Date",
+    selectMonth: "Select month",
+    selectYear: "Select year",
     compareTo: "Compare to",
     presets: {
       last7Days: "Last 7 days",

--- a/packages/react/src/ui/Select/components/SelectContent.tsx
+++ b/packages/react/src/ui/Select/components/SelectContent.tsx
@@ -70,6 +70,12 @@ type SelectContentProps = (
   scrollMargin?: number
   taller?: boolean
   portalContainer?: HTMLElement | null
+  /**
+   * When true, the dropdown sizes to its widest option (never narrower than
+   * the trigger) instead of the default 20rem minimum. Useful for compact
+   * value pickers like month/year selectors.
+   */
+  fitContentWidth?: boolean
 }
 const SelectContent = forwardRef<
   ElementRef<typeof SelectPrimitive.Content>,
@@ -90,6 +96,7 @@ const SelectContent = forwardRef<
       isLoading,
       scrollMargin,
       forceMinHeight,
+      fitContentWidth = false,
       showLoadingIndicator,
       asChild,
       portalContainer,
@@ -263,7 +270,9 @@ const SelectContent = forwardRef<
           !asList &&
             position === "popper" &&
             !forceMinHeight &&
-            "min-w-80 w-[var(--radix-select-trigger-width)]",
+            (fitContentWidth
+              ? "w-max min-w-[var(--radix-select-trigger-width)]"
+              : "min-w-80 w-[var(--radix-select-trigger-width)]"),
           !asList &&
             position === "popper" &&
             forceMinHeight &&

--- a/packages/react/src/ui/calendar.tsx
+++ b/packages/react/src/ui/calendar.tsx
@@ -75,7 +75,10 @@ function Calendar({
             "[&:has([aria-selected].day-range-middle)]:bg-f1-background-selected-bold [&:has([aria-selected].day-range-start)]:bg-f1-background-selected-bold [&:has([aria-selected].day-range-end)]:bg-f1-background-selected-bold hover:before:bg-f1-background-selected-bold"
         ),
         day: cn(
-          "rounded-[inherit] p-0 aria-selected:opacity-100 z-20 relative",
+          // Explicit text color: buttons don't inherit `color` from the cell
+          // (UA default is black), which made day numbers unreadable in dark
+          // mode. Modifier classes (outside/disabled/selected) override it.
+          "rounded-[inherit] p-0 text-f1-foreground aria-selected:opacity-100 z-20 relative",
           compact
             ? props.showWeekNumber
               ? "h-7 w-[30px] text-sm"


### PR DESCRIPTION
**Jira:** [FCT-59021](https://factorialmakers.atlassian.net/browse/FCT-59021)

## Problem

Setting a date far in the past (a birthday, for example) meant clicking the calendar's prev/next arrows dozens or hundreds of times. The header showed a static "Month Year" label with no way to jump.

## Change

The static title is now **two dropdowns** (month + year), so users can jump straight to any month/year. Behavior by view:

| View | Header |
| --- | --- |
| day / week | month + year dropdowns |
| month | year dropdown only |
| quarter / half-year / year | unchanged (plain label) |

- New `CalendarHeaderDropdowns` component + pure `buildYearOptions` / `buildMonthOptions` / `getYearBounds` helpers.
- Dropdowns share the calendar's `viewDate` state, so they stay in sync with the prev/next arrows.
- Year range derives from `minDate`/`maxDate` when set, otherwise a window of 120 years back to 120 years forward from the current year (covers birthdays and far-future deadlines).
- Reuses `F0Select`, with new `selectMonth` / `selectYear` i18n labels for accessibility.
- Applies to **F0DatePicker** and **OneDateNavigator**, which both render `OneCalendar`.

## Related fixes shipped in this PR

The feature surfaced several adjacent bugs; each is a separate commit.

### fix(F0Select): open/close debounce broken under a frozen clock

The open/close debounce used `usehooks-ts` `useDebounceCallback` (lodash.debounce), which decides its trailing edge by reading `Date.now()`. Under a frozen clock (MockDate in the DatePicker/Calendar stories, mocked dates in tests) the 100ms window never elapsed, so **Select dropdowns could never open**. This affected the new header dropdowns and the pre-existing compare-to select. Replaced with a plain `setTimeout` trailing debounce (same coalescing semantics); also removes the workaround for the usehooks-ts cancel-instance mismatch bug.

### feat(F0Select): `fitContentWidth` + fixed header widths

- `SelectContent` hardcoded a 20rem dropdown minimum; the month/year lists wasted most of it. New opt-in `fitContentWidth` prop sizes the dropdown to its widest option, never narrower than the trigger (month list: 320px → 136px). Default behavior unchanged for all other selects.
- The header triggers have fixed widths (8.5rem month, 6rem year), so neither the triggers nor the DatePicker popover resize with the selected value.

### fix(OneCalendar): arrow navigation clamped to the year window; selection bounded only by `minDate`/`maxDate`

- **Navigation:** the prev/next arrows are disabled when the next step would land on a year outside the dropdown's range, and `navigate()` guards against it (previously the view could drift to a year the dropdown couldn't display, rendering the trigger as an ellipsis). The default window is the current year ±120; explicit `minDate`/`maxDate` replace it.
- **Selection:** bounded strictly by the consumer's `minDate`/`maxDate` — the window imposes no hidden selection bounds (flagged by Codex review). Because an allowed value can therefore sit outside the default window, `getYearBounds` stretches to include the year in view so the dropdown can always display it; the range stays contiguous, so the arrows can walk back toward the window.

**Example:** a document archive picker for historical records sets only `maxDate: new Date()` (no future dates) and receives `value: new Date(1850, 5, 15)` from the database.
- *Without the Codex fix:* the default window floor (current year − 120 = 1906) acted as an implicit `minDate` — June 1850 rendered with every day disabled, and typing `15/06/1850` in the input was rejected, even though the consumer never set a lower bound.
- *With the fix:* the picker opens on June 1850 with the header showing `June` / `1850`, all days selectable, and the year dropdown listing 1850 through today. Navigation still can't wander past today (the `maxDate`).

### fix(datasource): replace `useDebounceValue` with a setTimeout-based debounce

Same lodash bug class, second instance: CI failed with an unhandled `ReferenceError: window is not defined` — a lodash.debounce trailing timer from `useDataSource`'s search debounce (usehooks-ts `useDebounceValue`) firing after `DatePickerPopup.test.tsx` tore down its jsdom window (usehooks-ts' unmount cleanup cancels the wrong lodash instance). This PR surfaced it by mounting two more F0Selects (each with a datasource) in every DatePickerPopup render. New shared `useDebouncedState` hook: plain `setTimeout` trailing debounce, cancelled reliably on unmount, immune to frozen clocks; `useDataSource` now uses it. Remaining known lodash-debounce users (`useDataCollectionStorage`, deprecated `EntitySelect`, `ActivityItemList` throttle) have no frozen-clock context today and can migrate to the hook as follow-up.

### fix(OneCalendar): fit the header dropdowns in the compact calendar

The compact calendar (the filter-picker date filter, 256px wide) has a 240px header budget, but the fixed-width dropdowns + arrows needed 292px — the overflow was invisible in production because `DateFilter` wraps the calendar in `overflow-x-hidden`, silently clipping the prev/next arrows. Compact headers now use narrower triggers (5.5rem each) with **localized short month names** ("Jul", "sept.") and a tighter arrow gap: 232px of content in the 240px budget. Trigger widths are sized against the widest short month of the supported locales and verified untruncated; regular headers are unchanged.

### fix(calendar): day numbers unreadable in dark mode (pre-existing)

Day numbers rendered UA-default black in every theme: `<button>` doesn't inherit `color`, and react-day-picker's reset stylesheet was never imported. Coincidentally readable in light mode, invisible in dark. Fixed with an explicit `text-f1-foreground` on the day button; outside/disabled/selected modifier colors verified to still win via stylesheet rule order and specificity.

## Tests

- Pure-helper unit tests: year/month option building, bounds derivation (including view-year stretching), localization, disabled months.
- Component tests: correct controls per view (day/week = 2 dropdowns, month = 1, quarter = 0), dropdown/arrow sync, arrows disabled at explicit `minDate`/`maxDate` edges, free navigation into future years by default, cells outside consumer bounds not selectable, no hidden lower bound with only `maxDate` (Codex regression, 1850 value).
- F0Select regression tests: opens with `Date.now` frozen; `fitContentWidth` class threading (on and off).
- `useDebouncedState` hook tests: last-value coalescing, updates under a frozen `Date.now`, pending timer cancelled on unmount.
- Full unit suite green (4546 tests) with no unhandled errors. `tsc`, `oxlint` (0 warnings), `oxfmt` clean.

## Stories

- `Calendar > Birthday Distant Past`
- `Calendar > Day With Bounded Years`

## How to review visually

Run `pnpm dev` in `packages/react` and check:
- `Components > DatePicker > Default` — open the picker; the header shows month + year dropdowns and the arrows navigate freely within the ±120-year window.
- `Components > DatePicker > With Min Max Dates` — the arrows disable at the window edges and out-of-range cells are not selectable.
- `Components > Calendar > Birthday Distant Past` and `Day With Bounded Years`.
- `Components > Calendar > Compact Week` / `Compact Day Range` — the compact header fits month + year dropdowns and arrows without clipping; months show short names.
- Toggle dark mode: day numbers are readable in both themes.










[FCT-59021]: https://factorialmakers.atlassian.net/browse/FCT-59021?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ