### PR TITLE
fix(EditableTable): render display-only cells without field icons

### DIFF
--- a/packages/react/src/components/F0InputField/F0InputField.tsx
+++ b/packages/react/src/components/F0InputField/F0InputField.tsx
@@ -476,6 +476,7 @@ const F0InputField = forwardRef<HTMLDivElement, InputFieldProps<string>>(
           >
             {(icon || avatar) && (
               <div
+                data-slot="icon"
                 className={cn(
                   "pointer-events-none absolute left-2 top-[5px] my-auto h-5 w-5 shrink-0",
                   size === "md" && "left-3 top-[9px]"

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/DateCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/DateCell.tsx
@@ -56,9 +56,17 @@ export function DateCell<R extends RecordType>({
         <F0DatePicker
           className={cn(
             "[&_input]:!py-0",
+            // The cell is taller (48px) than a standalone input, so the icon's
+            // fixed top offset no longer centers it — pin it to the full height
+            // and let its auto margins center it vertically.
+            "[&_[data-slot='icon']]:!inset-y-0",
             "[&_[data-slot='placeholder']]:!flex",
             "[&_[data-slot='placeholder']]:!items-center",
             "[&_[data-slot='placeholder']]:!py-0",
+            // The placeholder is absolutely positioned with no right edge, so
+            // bound it to the cell width; only then does truncate clip the
+            // text instead of letting it spill past the column.
+            "[&_[data-slot='placeholder']]:!right-0",
             "[&_[data-slot='placeholder']]:!truncate"
           )}
           placeholder={inputPlaceholder ?? editableColumn.inputPlaceholder}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/ReadOnlyCellContent.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/ReadOnlyCellContent.tsx
@@ -24,9 +24,10 @@ type ReadOnlyCellContentProps<R extends RecordType> = Pick<
   /** Extra classes for the content container (background, muted text, ...). */
   className?: string
   /**
-   * Show the field affordances (leading url/email/date icon and the select
-   * chevron). Disabled cells keep them so the column still reads as its field
-   * type; display-only cells opt out and render just the value as plain text.
+   * Show the field affordances (leading url/email/date icon, the select
+   * chevron and number/money/percentage units). Disabled cells keep them so
+   * the column still reads as its field type; display-only cells opt out and
+   * render just the value as plain text.
    */
   showFieldAffordances?: boolean
 }
@@ -100,8 +101,11 @@ export function ReadOnlyCellContent<R extends RecordType>({
     : undefined
 
   // Number/money/percentage cells show a unit next to the value (e.g. "%",
-  // "€"); mirror it here so read-only cells match the editable ones.
-  const units = resolveUnits(editableColumn.numberConfig, item)
+  // "€"); mirror it here so read-only cells match the editable ones. Treated as
+  // a field affordance, so display-only cells opt out of it too.
+  const units = showFieldAffordances
+    ? resolveUnits(editableColumn.numberConfig, item)
+    : undefined
   const unitsBefore = editableColumn.numberConfig?.unitsPosition === "before"
   const unit = units ? (
     <span className="shrink-0 select-none pt-px text-sm">{units}</span>

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/ReadOnlyCellContent.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/ReadOnlyCellContent.tsx
@@ -23,6 +23,12 @@ type ReadOnlyCellContentProps<R extends RecordType> = Pick<
   iconColor?: F0IconProps["color"]
   /** Extra classes for the content container (background, muted text, ...). */
   className?: string
+  /**
+   * Show the field affordances (leading url/email/date icon and the select
+   * chevron). Disabled cells keep them so the column still reads as its field
+   * type; display-only cells opt out and render just the value as plain text.
+   */
+  showFieldAffordances?: boolean
 }
 
 /**
@@ -37,15 +43,18 @@ export function ReadOnlyCellContent<R extends RecordType>({
   item,
   iconColor = "default",
   className,
+  showFieldAffordances = true,
 }: ReadOnlyCellContentProps<R>) {
   const i18n = useI18n()
 
   // A date column shows the shared calendar icon (same as the editable date
   // cell / F0Form date field); otherwise a text cell's url/email icon.
-  const leadingIcon = editableColumn.dateConfig
-    ? getFieldInputIcon("date")
-    : resolveTextCellIcon(editableColumn.textConfig)
-  const isSelect = !!editableColumn.selectConfig
+  const leadingIcon = showFieldAffordances
+    ? editableColumn.dateConfig
+      ? getFieldInputIcon("date")
+      : resolveTextCellIcon(editableColumn.textConfig)
+    : undefined
+  const isSelect = showFieldAffordances && !!editableColumn.selectConfig
   const alignRight = editableColumn.align === "right"
 
   // Date cells store an ISO string; format it here so a read-only date cell

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/NonEditableCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/NonEditableCell.tsx
@@ -18,7 +18,11 @@ export function NonEditableCell<R extends RecordType>({
       hintPosition="right"
       cursor="default"
     >
-      <ReadOnlyCellContent editableColumn={editableColumn} item={item} />
+      <ReadOnlyCellContent
+        editableColumn={editableColumn}
+        item={item}
+        showFieldAffordances={false}
+      />
     </BaseCell>
   )
 }


### PR DESCRIPTION
## Description

Display-only cells in the EditableTable were rendering the leading url/email/date icon and the select chevron that #4674 added to shared read-only content. This restores the previous behaviour: display-only cells now show just the value as plain text, while disabled cells keep the field affordances so a disabled column still reads as its field type.

## Implementation details

- fix: add `showFieldAffordances` prop (default `true`) to `ReadOnlyCellContent` that gates the leading icon and the select chevron
- fix: pass `showFieldAffordances={false}` from the display-only cell (`NonEditableCell`); disabled cells are unchanged

Value formatting (readable dates, multi-select labels, number units) is preserved in display-only cells since it is text content, not an icon.

BEFORE:

<img width="1571" height="284" alt="Captura de pantalla 2026-07-20 a las 12 33 44" src="https://github.com/user-attachments/assets/db9027e0-e763-407c-939f-917d363b3d57" />

NOW:

<img width="1654" height="748" alt="Captura de pantalla 2026-07-20 a las 12 29 42" src="https://github.com/user-attachments/assets/5529e7cd-33b6-4750-bc33-e6f7a7a395a6" />
