### PR TITLE
chore(react): drop dead tagBadges config from Storybook manager

### DIFF
--- a/packages/react/.storybook/manager.ts
+++ b/packages/react/.storybook/manager.ts
@@ -72,68 +72,11 @@ addons.setConfig({
     collapsedRoots: ["playground"],
     renderLabel: renderSidebarLabel,
     filters: {
-      // `internal` is no longer hidden: it is an informational badge (see
-      // tagBadges below), so internal primitives stay visible to contributors
-      // in every build. Only `no-sidebar` is filtered out.
+      // `internal` is no longer hidden — internal primitives stay visible to
+      // contributors in every build. Maturity markers (🚧 / ❌) come from
+      // `renderLabel` above (component-status); there is no separate badge
+      // config. Only `no-sidebar` is filtered out.
       noSidebar: (item) => !item.tags?.includes("no-sidebar"),
     },
   },
-  tagBadges: [
-    {
-      tags: "experimental",
-      badge: {
-        text: "Experimental",
-        bgColor: "#FBF1DE",
-        fgColor: "#8A5A00",
-        borderColor: "#F0DCB0",
-        tooltip: "Experimental — API may still change",
-      },
-      display: {
-        sidebar: ["component", "docs", "group"],
-        toolbar: true,
-      },
-    },
-    {
-      tags: "stable",
-      badge: {
-        text: "✅",
-        bgColor: "transparent",
-        fgColor: "#000000",
-        borderColor: "transparent",
-        tooltip: "Stable",
-      },
-      display: {
-        sidebar: false,
-        toolbar: true,
-      },
-    },
-    {
-      tags: "deprecated",
-      badge: {
-        text: "Deprecated",
-        bgColor: "#F5E7E7",
-        fgColor: "#9B2C2C",
-        borderColor: "#EBC9C9",
-        tooltip: "Deprecated — scheduled for removal",
-      },
-      display: {
-        sidebar: ["component", "docs", "group"],
-        toolbar: true,
-      },
-    },
-    {
-      tags: "internal",
-      badge: {
-        text: "🔒",
-        bgColor: "transparent",
-        fgColor: "#000000",
-        borderColor: "transparent",
-        tooltip: "Internal",
-      },
-      display: {
-        sidebar: ["component", "docs", "group"],
-        toolbar: true,
-      },
-    },
-  ],
 })


### PR DESCRIPTION
## What & why

The `tagBadges` block in `.storybook/manager.ts` is **dead config** — it needs the `storybook-addon-tag-badges` addon, which was never installed or registered, so it rendered nothing.

Maturity is now shown in the sidebar by `renderLabel` (the **component-status** markers 🚧 experimental / ❌ deprecated, by @sauldom102). This removes the leftover parallel badge config so there's a single source of truth for maturity display.

**No visual change** — only dead code removed.

## Test plan
- Storybook starts fine; sidebar maturity markers (🚧/❌) still render via `renderLabel` (verified: `sidebar-status.generated.json` still produced, 242 entries).

Follow-up to the reorg (#4723/#4725/#4726/#4727) and the closing of #4428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)