### PR TITLE
fix(F0Card): make whole card clickable except footer

### DIFF
--- a/packages/react/src/components/F0Card/CardInternal.tsx
+++ b/packages/react/src/components/F0Card/CardInternal.tsx
@@ -243,6 +243,11 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
   ) {
     const linkRef = useRef<HTMLAnchorElement>(null)
 
+    // The card is clickable as a whole only when it actually navigates — via the
+    // overlay link or an onClick. Without either, the body must not look or behave
+    // clickable (no pointer cursor, no role="button" on the header).
+    const isInteractive = !disableOverlayLink && (!!link || !!onClick)
+
     const emulateLinkClick = (
       e: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>
     ) => {
@@ -347,10 +352,40 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
           </div>
         )}
 
-        <div className="flex grow flex-col gap-2">
+        <div
+          className={cn(
+            "flex grow flex-col gap-2",
+            // Show the pointer cursor across the whole clickable body (not just the
+            // title/description), so metadata rows and empty space read as clickable.
+            isInteractive && "cursor-pointer"
+          )}
+          {...(isInteractive
+            ? {
+                // Clicking anywhere in the body (title, description, metadata,
+                // empty space) navigates the card. Interactive regions
+                // (CardOptions, the footer, interactive children) stop
+                // propagation so they keep their own behaviour instead.
+                onClick: (e) => {
+                  // Some metadata renderers (e.g. avatarList/tagList overflow)
+                  // include their own interactive controls — links, form fields
+                  // or popover/menu triggers (aria-haspopup). Let those handle
+                  // their own click instead of navigating the card.
+                  if (
+                    e.target instanceof Element &&
+                    e.target.closest(
+                      'a[href], input, select, textarea, [aria-haspopup]:not([aria-haspopup="false"])'
+                    )
+                  ) {
+                    return
+                  }
+                  emulateLinkClick(e)
+                },
+              }
+            : {})}
+        >
           <div className="flex flex-row items-start justify-between gap-1">
             <CardHeader
-              {...(!disableOverlayLink
+              {...(isInteractive
                 ? {
                     onClick: (e) => {
                       emulateLinkClick(e)
@@ -408,24 +443,31 @@ export const CardInternal = forwardRef<HTMLDivElement, CardInternalProps>(
               />
             )}
           </div>
-          {(metadata || children) && (
+          {metadata && (
+            // Metadata is display-only, so it navigates with the rest of the card:
+            // clicks bubble up to the body handler above. It sits above the overlay
+            // link (z-10) so its icon tooltips stay hoverable.
+            <div
+              className={cn(
+                "relative z-10 flex flex-col gap-0.5",
+                compact && "gap-x-3 gap-y-0",
+                forceVerticalMetadata && "flex-col gap-y-0.5"
+              )}
+            >
+              {metadata.map((item, index) => (
+                <CardMetadata key={index} metadata={item} />
+              ))}
+            </div>
+          )}
+          {children && (
+            // Children can be interactive, so this region swallows clicks
+            // (stopPropagation) and only re-enables pointer events on the
+            // interactive elements inside it — keeping them from navigating the
+            // card while still letting them work.
             <CardContent
               className="pointer-events-none relative z-10 [&_a]:pointer-events-auto [&_button]:pointer-events-auto [&_input]:pointer-events-auto [&_select]:pointer-events-auto [&_textarea]:pointer-events-auto [&_[role='button']]:pointer-events-auto [&_[tabindex]]:pointer-events-auto"
               onClick={(e) => e.stopPropagation()}
             >
-              {metadata && (
-                <div
-                  className={cn(
-                    "flex flex-col gap-0.5",
-                    compact && "gap-x-3 gap-y-0",
-                    forceVerticalMetadata && "flex-col gap-y-0.5"
-                  )}
-                >
-                  {metadata.map((item, index) => (
-                    <CardMetadata key={index} metadata={item} />
-                  ))}
-                </div>
-              )}
               {children}
             </CardContent>
           )}

--- a/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
+++ b/packages/react/src/components/F0Card/__stories__/Card.stories.tsx
@@ -281,10 +281,19 @@ export const WithActions: Story = {
 export const WithActionsAndLink: Story = {
   args: {
     ...WithActions.args,
+    link: "/",
     secondaryActions: {
       label: "View more",
       href: "/",
       target: "_blank",
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The whole card navigates via `link`, except the footer — clicking around the footer actions never triggers card navigation.",
+      },
     },
   },
 }

--- a/packages/react/src/components/F0Card/__tests__/Card.test.tsx
+++ b/packages/react/src/components/F0Card/__tests__/Card.test.tsx
@@ -184,6 +184,77 @@ describe("F0Card Component", () => {
     expect(handlePrimaryAction).toHaveBeenCalledTimes(1)
   })
 
+  it("triggers the card click when a metadata item is clicked", async () => {
+    const user = userEvent.setup()
+    const handleClick = vi.fn()
+
+    render(
+      <F0Card
+        title="Clickable Card"
+        onClick={handleClick}
+        metadata={[
+          {
+            icon: Briefcase,
+            property: { type: "text", label: "Job title", value: "Designer" },
+          },
+        ]}
+      />
+    )
+
+    // Metadata is display-only, so clicking it navigates the card like the rest
+    // of the body (it used to be swallowed by the content region).
+    await user.click(screen.getByText("Designer"))
+    expect(handleClick).toHaveBeenCalledTimes(1)
+  })
+
+  it("does not trigger the card click when interactive children are clicked", async () => {
+    const user = userEvent.setup()
+    const handleClick = vi.fn()
+    const handleChild = vi.fn()
+
+    render(
+      <F0Card title="Clickable Card" onClick={handleClick}>
+        <button type="button" onClick={handleChild}>
+          Child button
+        </button>
+      </F0Card>
+    )
+
+    // Interactive children keep their own behaviour and must not navigate the card.
+    await user.click(screen.getByRole("button", { name: "Child button" }))
+    expect(handleChild).toHaveBeenCalledTimes(1)
+    expect(handleClick).not.toHaveBeenCalled()
+  })
+
+  it("does not trigger the card click from the footer area", async () => {
+    const user = userEvent.setup()
+    const handleClick = vi.fn()
+    const handlePrimaryAction = vi.fn()
+
+    const { container } = render(
+      <F0Card
+        title="Clickable Card"
+        onClick={handleClick}
+        primaryAction={{
+          label: "Primary Action",
+          onClick: handlePrimaryAction,
+        }}
+      />
+    )
+
+    // The footer band holds actions, so clicking it — including the empty space
+    // around the buttons — must never trigger the card's own click/navigation.
+    const footer = container.querySelector(".border-t") as HTMLElement
+    expect(footer).toBeInTheDocument()
+    await user.click(footer)
+    expect(handleClick).not.toHaveBeenCalled()
+
+    // The footer's own action still works, without triggering the card click.
+    await user.click(screen.getByTestId("primary-button"))
+    expect(handlePrimaryAction).toHaveBeenCalledTimes(1)
+    expect(handleClick).not.toHaveBeenCalled()
+  })
+
   it("renders a secondary action link", async () => {
     const secondaryLink: CardSecondaryLink = {
       label: "View more",

--- a/packages/react/src/components/F0Card/components/CardActions.tsx
+++ b/packages/react/src/components/F0Card/components/CardActions.tsx
@@ -55,9 +55,20 @@ export function CardActions({
     <CardFooter
       className={cn(
         "flex-col gap-2 sm:flex-row sm:justify-between [&>div]:z-[1]",
-        "relative -mx-4 mt-4 border-0 border-t border-solid border-t-f1-border-secondary px-4 pt-4",
-        compact && "pt-3"
+        // Sit above the full-card overlay link (z-1) so the footer never triggers
+        // card navigation — only its own buttons/links act, keeping it a safe
+        // place for actions. The negative margins stretch this region to the
+        // card's edges (over the card padding) so the whole footer band, not just
+        // the area right under the buttons, is excluded from the clickable card.
+        // cursor-auto so the footer band doesn't inherit the card's pointer cursor
+        // (the card root sets it when interactive via onClick) — it isn't clickable
+        // as a card; only its own actions are.
+        "relative z-[2] -mx-4 -mb-4 mt-4 cursor-auto border-0 border-t border-solid border-t-f1-border-secondary px-4 pb-4 pt-4",
+        compact && "-mb-3 pb-3 pt-3"
       )}
+      // Stop clicks in the footer from bubbling to the card root's onClick handler
+      // (used when the card is interactive via onClick instead of a link).
+      onClick={(e) => e.stopPropagation()}
     >
       {secondaryActions && (
         <div className="flex w-full flex-col gap-md sm:flex-row [&_a]:justify-center sm:[&_a]:justify-start [&_button]:w-full sm:[&_button]:w-fit [&_div]:w-full [&_div]:justify-center sm:[&_div]:w-fit">


### PR DESCRIPTION
## Description

Only the title/description of an `F0Card` used to act as its click target, while the footer was part of the clickable/navigable area — which is backwards, since the footer is where independent actions live. This makes the entire card body navigate (title, description, metadata rows, and empty space), excludes the footer so its buttons/links stay safe, and keeps the interactive affordances (pointer cursor, header `role="button"`) scoped to cards that are actually clickable.
