### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.42.0",
+  "packages/react": "4.42.1",
   "packages/react-native": "0.58.1",
   "packages/core": "1.54.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.42.1](https://github.com/factorialco/f0/compare/f0-react-v4.42.0...f0-react-v4.42.1) (2026-07-20)
+
+
+### Bug Fixes
+
+* **F0Card:** make whole card clickable except footer ([#4745](https://github.com/factorialco/f0/issues/4745)) ([a23066e](https://github.com/factorialco/f0/commit/a23066e2badb25ba47b10049f123e6373e1c5a1e))
+
 ## [4.42.0](https://github.com/factorialco/f0/compare/f0-react-v4.41.1...f0-react-v4.42.0) (2026-07-17)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.42.0",
+  "version": "4.42.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.42.1</summary>

## [4.42.1](https://github.com/factorialco/f0/compare/f0-react-v4.42.0...f0-react-v4.42.1) (2026-07-20)


### Bug Fixes

* **F0Card:** make whole card clickable except footer ([#4745](https://github.com/factorialco/f0/issues/4745)) ([a23066e](https://github.com/factorialco/f0/commit/a23066e2badb25ba47b10049f123e6373e1c5a1e))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).