### PR TITLE
chore(react): relocate Box & Reactions to Components

### DIFF
--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -74,7 +74,9 @@ const config: StorybookConfig = {
     { directory: "../src/layouts", titlePrefix: "Patterns/App shell" },
 
     // ── Kits · functional bundles (AI + Chat promoted from sds) ──
-    { directory: "../src/kits", titlePrefix: "Kits" },
+    { directory: "../src/kits/Charts", titlePrefix: "Kits" },
+    { directory: "../src/kits/F0DataChart", titlePrefix: "Kits" },
+    { directory: "../src/kits/Social", titlePrefix: "Components" }, // Reactions is a generic component
     { directory: "../src/sds/ai", titlePrefix: "Kits" },
     { directory: "../src/sds/chat", titlePrefix: "Kits" },
     { directory: "../src/experimental/AiPromotionChat", titlePrefix: "Kits/AI" },
@@ -88,7 +90,14 @@ const config: StorybookConfig = {
     { directory: "../src/sds/UpsellingKit", titlePrefix: "Domain specific/Growth" },
 
     // ── Resources · hooks, utilities, examples ───────────────────
-    { directory: "../src/lib", titlePrefix: "Resources" },
+    { directory: "../src/lib/F0Box", titlePrefix: "Components" }, // layout primitive → Components
+    { directory: "../src/lib/Await", titlePrefix: "Resources" },
+    { directory: "../src/lib/F0GridStack", titlePrefix: "Resources" },
+    { directory: "../src/lib/OneEllipsis", titlePrefix: "Resources" },
+    { directory: "../src/lib/VirtualList", titlePrefix: "Resources" },
+    { directory: "../src/lib/data-testid", titlePrefix: "Resources" },
+    { directory: "../src/lib/numeric", titlePrefix: "Resources" },
+    { directory: "../src/lib/providers", titlePrefix: "Resources" },
     { directory: "../src/hooks/datasource", titlePrefix: "Resources" },
     { directory: "../src/examples", titlePrefix: "Resources/Examples" },
 

--- a/packages/react/src/kits/Social/Reactions/index.stories.tsx
+++ b/packages/react/src/kits/Social/Reactions/index.stories.tsx
@@ -4,7 +4,7 @@ import { Reactions } from "./index"
 
 const meta: Meta<typeof Reactions> = {
   component: Reactions,
-  title: "Social/Reactions",
+  title: "Reactions",
   tags: ["autodocs", "experimental"],
   parameters: {
     layout: "centered",


### PR DESCRIPTION
## What & why

Two generic building blocks were filed away from **Components**:
- `lib/F0Box` (a layout primitive) → **Components/Box**
- `kits/Social/Reactions` (a generic component, not a functional kit) → **Components/Reactions**

Done via per-subfolder `titlePrefix` routing (no source moves, no import changes) — the `lib/` and `kits/` entries are split so everything else stays in Resources/Kits.

## Test plan
Verified in Storybook: `Components/Box` + `Components/Reactions` present; Box no longer under Resources; Kits = AI · Charts · Chat · F0DataChart; **0 title collisions**.

## Note
`Tabs → Components` is deferred — it's 2 levels deep in `patterns/` (16 sibling folders), so it needs a folder move rather than a routing split. Tracking separately.

Follow-up to the reorg (#4723/#4725/#4726/#4727).

🤖 Generated with [Claude Code](https://claude.com/claude-code)