### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.42.1",
+  "packages/react": "4.43.0",
   "packages/react-native": "0.58.1",
   "packages/core": "1.54.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.43.0](https://github.com/factorialco/f0/compare/f0-react-v4.42.1...f0-react-v4.43.0) (2026-07-20)
+
+
+### Features
+
+* **OneCalendar:** month and year dropdowns in the DatePicker calendar header ([#4736](https://github.com/factorialco/f0/issues/4736)) ([24d6a64](https://github.com/factorialco/f0/commit/24d6a64c88a8abc7cde598b54d13193f094d895f))
+
 ## [4.42.1](https://github.com/factorialco/f0/compare/f0-react-v4.42.0...f0-react-v4.42.1) (2026-07-20)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.42.1",
+  "version": "4.43.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.43.0</summary>

## [4.43.0](https://github.com/factorialco/f0/compare/f0-react-v4.42.1...f0-react-v4.43.0) (2026-07-20)


### Features

* **OneCalendar:** month and year dropdowns in the DatePicker calendar header ([#4736](https://github.com/factorialco/f0/issues/4736)) ([24d6a64](https://github.com/factorialco/f0/commit/24d6a64c88a8abc7cde598b54d13193f094d895f))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).