### PR TITLE
F0TagPerson: match Figma spec (24px avatar, 32px pill)

### DIFF
--- a/packages/react/src/components/tags/internal/TagAvatar/index.tsx
+++ b/packages/react/src/components/tags/internal/TagAvatar/index.tsx
@@ -20,14 +20,22 @@ export const F0TagAvatar = forwardRef<HTMLDivElement, Props>(
       { componentName: "F0TagAvatar" }
     )
 
+    const isPerson = avatar.type === "person"
+
     return (
       <BaseTag
         ref={ref}
         deactivated={deactivated}
-        className="border-[1px] border-solid border-f1-border-secondary py-[1px] pl-[1px]"
-        left={<F0Avatar avatar={avatar} size="xs" />}
+        className={
+          isPerson
+            ? // Person tag: larger avatar in a 32px pill, using BaseTag's default
+              // padding (2px / 4px / 8px). Matches the Figma spec.
+              "h-8 border-[1px] border-solid border-f1-border-secondary"
+            : "border-[1px] border-solid border-f1-border-secondary py-[1px] pl-[1px]"
+        }
+        left={<F0Avatar avatar={avatar} size={isPerson ? "sm" : "xs"} />}
         text={text}
-        shape={avatar.type === "person" ? "rounded" : "square"}
+        shape={isPerson ? "rounded" : "square"}
       />
     )
   }


### PR DESCRIPTION
## What
Polish `F0TagPerson` so it matches the Figma spec. Today the person tag renders with a **20px (`xs`) avatar** and **1px padding**, which looks noticeably smaller/tighter than design — enough that product teams have been **hand-rebuilding the component** instead of using it (most recently in the **approval-flows** in Composer based off of Oskar's Figma files).

## The gap (current f0 vs Figma)
| | f0 today | Figma (target) |
|---|---|---|
| Avatar | `xs` = 20px | `sm` = **24px** |
| Padding | `py-[1px] pl-[1px]` (1px top/bottom, 1px left, 8px right) | **2px** top/bottom, **4px** left, 8px right |
| Pill height | content-driven (~30px) | **32px** |

Border (1px `f1-border-secondary`), radius (`rounded-full`) and gap (4px) already match.

## The change
In `internal/TagAvatar/index.tsx`, the **person** variant now uses a `sm` (24px) avatar and an `h-8` (32px) pill, and drops the `py-[1px] pl-[1px]` override so `BaseTag`'s default padding (2/4/8) applies.

**Scoped to person tags only** — `F0TagAvatar` is shared with the square (company/team) avatar tags, and those are intentionally left untouched via an `isPerson` branch. Happy to broaden or refactor the scoping however Foundations prefers.

## Before → after
- Before: `[A] Admins` — small avatar, tight pill
<img width="393" height="118" alt="image" src="https://github.com/user-attachments/assets/f556ac94-717a-4c85-a6f0-2973c55c3e6e" />

- After: `[D] Direct manager` — 24px avatar, 32px pill (matches the prototype/Figma)
<img width="680" height="155" alt="image" src="https://github.com/user-attachments/assets/807a9575-aa98-42c5-8758-1ae0f3cfe61b" />


## Note
I couldn't run the full package build/visual-regression here — please run the `TagPerson` story + any snapshot/VR checks. One-file change, no API/prop changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)