### PR TITLE
feat(chat): separate voice notes from file uploads

### DIFF
--- a/packages/react/src/sds/chat/F0Chat/__tests__/ChatComposer.voiceNote.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/ChatComposer.voiceNote.test.tsx
@@ -120,6 +120,42 @@ const recordVoiceNote = async (user: ReturnType<typeof userEvent.setup>) => {
 }
 
 describe("ChatComposer voice notes", () => {
+  it("can disable voice notes without disabling file uploads", () => {
+    renderChat(
+      makeRuntime({
+        uploadFiles: vi.fn(),
+        capabilities: { canSendVoiceNotes: false },
+      })
+    )
+
+    expect(screen.getByRole("button", { name: "Attach file" })).toBeEnabled()
+    expect(
+      screen.queryByRole("button", { name: "Record audio" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("keeps voice dictation independent from the voice-note capability", async () => {
+    const uploadFiles = vi.fn()
+    const transcribe = vi.fn(async () => "Transcribed message")
+    const user = userEvent.setup()
+    renderChat(
+      makeRuntime({
+        uploadFiles,
+        transcribe,
+        capabilities: { canSendVoiceNotes: false },
+      })
+    )
+
+    await user.click(screen.getByRole("button", { name: "Record audio" }))
+    await user.click(
+      await screen.findByRole("button", { name: "Stop and transcribe" })
+    )
+
+    expect(await screen.findByDisplayValue("Transcribed message")).toBeVisible()
+    expect(transcribe).toHaveBeenCalledTimes(1)
+    expect(uploadFiles).not.toHaveBeenCalled()
+  })
+
   it("shows the mic button loading while the note uploads, then sends it", async () => {
     let resolveUpload!: (attachments: F0ChatAttachment[]) => void
     const uploadFiles = vi.fn(

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
@@ -164,10 +164,11 @@ export const ChatComposer = (): ReactNode => {
     "transcription-failed": i18n.chat.transcriptionError,
   }
 
-  // Voice NOTES (WhatsApp-style): when the runtime can upload, the mic records
-  // audio and sends it as its own message on confirm — no transcription.
-  // Dictation (`transcribe`) remains the fallback when there's no uploadFiles.
-  const voiceNotesEnabled = canUpload
+  // Voice NOTES (WhatsApp-style): when the runtime can upload and the channel
+  // allows them, the mic records audio and sends it as its own message on
+  // confirm — no transcription. Dictation (`transcribe`) stays independent.
+  const voiceNotesEnabled =
+    canUpload && capabilities?.canSendVoiceNotes !== false
   // While the confirmed recording uploads, the action row swaps for a "sending
   // voice note" status so the confirm→message gap isn't silent.
   const [isSendingVoiceNote, setIsSendingVoiceNote] = useState(false)

--- a/packages/react/src/sds/chat/F0Chat/providers/F0ChatProvider.tsx
+++ b/packages/react/src/sds/chat/F0Chat/providers/F0ChatProvider.tsx
@@ -53,6 +53,7 @@ const useStableCapabilities = (
       previous.canSend === capabilities.canSend &&
       previous.canReact === capabilities.canReact &&
       previous.canUpload === capabilities.canUpload &&
+      previous.canSendVoiceNotes === capabilities.canSendVoiceNotes &&
       previous.canEditMessage === capabilities.canEditMessage &&
       previous.canDeleteMessage === capabilities.canDeleteMessage)
   if (!same) previousRef.current = capabilities

--- a/packages/react/src/sds/chat/F0Chat/types.ts
+++ b/packages/react/src/sds/chat/F0Chat/types.ts
@@ -340,6 +340,9 @@ export type F0ChatStatus =
  *   pickers and disables toggling existing reaction pills.
  * - `canUpload` (default: whether `uploadFiles` exists): false disables the
  *   attach button, drag & drop and voice notes even when `uploadFiles` exists.
+ * - `canSendVoiceNotes` (default: whether uploads are available): false hides
+ *   the voice-note recorder without disabling file uploads. Voice dictation is
+ *   controlled independently by {@link F0ChatRuntime.transcribe}.
  * - `canEditMessage` (default: own message within {@link F0ChatRuntime.editWindowMs}):
  *   overrides the edit policy per message. Structural gates still apply (the
  *   host must provide `editMessage`; deleted messages and voice notes are
@@ -352,6 +355,7 @@ export type F0ChatCapabilities = {
   canSend?: boolean
   canReact?: boolean
   canUpload?: boolean
+  canSendVoiceNotes?: boolean
   canEditMessage?: (message: F0ChatMessage) => boolean
   canDeleteMessage?: (message: F0ChatMessage) => boolean
 }


### PR DESCRIPTION
## What changed

`F0ChatCapabilities` exposes `canSendVoiceNotes`, so hosts can allow file uploads without also authorizing voice-note recording. Existing consumers keep the current behavior unless they explicitly opt out; dictation remains independently controlled by `transcribe`.

## Why

Supplying `uploadFiles` currently auto-enables voice notes in the chat composer. Factorial's Communications chat wants uploads without voice notes, and hiding the recorder with CSS or dropping uploads are both worse. The explicit capability keeps the choice with the host.

- defaults compatibly for existing hosts
- can disable voice notes while leaving attachments enabled
- does not affect optional voice dictation

## Verification

Focused ChatComposer tests cover upload preservation and dictation independence (4 tests). TypeScript, lint, and formatting pass.

Split out of #4713 so that PR stays a single concern (the composer `toolbarStart` slot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)