### PR TITLE
feat(F0Form): forward onOpenChange/loading/searchFn/searchEmptyMessage on select fields

### DIFF
--- a/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
+++ b/packages/react/src/patterns/F0Form/__stories__/F0Form.stories.tsx
@@ -7,6 +7,7 @@ import { F0Button } from "@/components/F0Button"
 import { createDataSourceDefinition } from "@/hooks/datasource"
 import { Archive, ArchiveOpen, ExternalLink, Plus, Settings } from "@/icons/app"
 import { useF0FormDefinition } from "@/patterns/F0WizardForm"
+import { forms } from "@/patterns/forms"
 
 import type {
   FileUploadHookReturn,
@@ -14,8 +15,6 @@ import type {
   FileUploadStatus,
 } from "../fields/types"
 import type { RenderCustomFieldSelectConfig } from "../types"
-
-import { forms } from "@/patterns/forms"
 
 import {
   f0FormField,
@@ -2612,6 +2611,92 @@ export const SelectWithCustomFieldName: Story = {
 }
 
 /**
+ * Lazy-fetch-on-first-open select.
+ *
+ * The select starts with **no** options. Opening the dropdown for the first
+ * time (`onOpenChange`) kicks off a simulated async fetch: `loading` shows a
+ * spinner inside the input while pending, then the resolved `options` populate
+ * the list. Subsequent opens reuse the already-fetched options. The field is
+ * searchable via `showSearchBox`, and a custom `searchEmptyMessage` is shown
+ * while there is nothing to match yet.
+ *
+ * Everything is declared purely in the Zod schema — no imperative wiring in the
+ * component tree beyond the two state flips.
+ */
+export const SelectLazyFetchOnOpen: Story = {
+  render() {
+    const [hasOpened, setHasOpened] = useState(false)
+    const [loading, setLoading] = useState(false)
+    const [options, setOptions] = useState<
+      Array<{ value: string; label: string }>
+    >([])
+
+    const handleOpenChange = useCallback(
+      (open: boolean) => {
+        // Fetch once, on the first open.
+        if (open && !hasOpened) {
+          setHasOpened(true)
+          setLoading(true)
+          // Simulated network request — no real fetch.
+          setTimeout(() => {
+            setOptions([
+              { value: "engineering", label: "Engineering" },
+              { value: "design", label: "Design" },
+              { value: "product", label: "Product" },
+              { value: "marketing", label: "Marketing" },
+              { value: "sales", label: "Sales" },
+            ])
+            setLoading(false)
+          }, 1200)
+        }
+      },
+      [hasOpened]
+    )
+
+    // Rebuild the schema when the fetched options / loading state change so the
+    // select reflects them. Keeps the definition in sync with async state.
+    const formSchema = useMemo(
+      () =>
+        z.object({
+          team: f0FormField.select({
+            label: "Team",
+            placeholder: "Select a team...",
+            helpText:
+              "Options are fetched the first time you open the dropdown",
+            optional: true,
+            options,
+            loading,
+            showSearchBox: true,
+            searchEmptyMessage: loading
+              ? "Loading teams..."
+              : "No teams available yet",
+            onOpenChange: handleOpenChange,
+          }),
+        }),
+      [options, loading, handleOpenChange]
+    )
+
+    const formDefinition = useF0FormDefinition({
+      name: "select-lazy-fetch-on-open",
+      schema: formSchema,
+      defaultValues: { team: undefined },
+      onSubmit: async ({ data }) => {
+        await sleep(500)
+        console.info(`Form submitted: ${JSON.stringify(data, null, 2)}`)
+        return { success: true }
+      },
+      submitConfig: { label: "Save" },
+    })
+
+    return (
+      <div className="max-w-lg">
+        <F0Form formDefinition={formDefinition} />
+      </div>
+    )
+  },
+}
+
+/**
  * Form with server-side validation errors.
  */
 export const ServerValidation: Story = {
@@ -3329,7 +3414,7 @@ export const FormInDialog: Story = {
       <div className="flex flex-col items-start gap-3">
         <F0Button label="Add Team Member" icon={Plus} onClick={handleAdd} />
         {lastResult && (
-          <p className="text-f1-foreground-secondary text-sm">{lastResult}</p>
+          <p className="text-sm text-f1-foreground-secondary">{lastResult}</p>
         )}
       </div>
     )

--- a/packages/react/src/patterns/F0Form/fields/select/SelectFieldRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/fields/select/SelectFieldRenderer.tsx
@@ -6,7 +6,7 @@ import { F0Select } from "@/components/F0Select"
 import { useI18n } from "@/lib/providers/i18n/i18n-provider"
 
 import type { ResolvedField } from "../types"
-import type { F0SelectField } from "./types"
+import type { F0SelectField, F0SelectSearchFn } from "./types"
 
 import { FORM_SIZE } from "../../constants"
 
@@ -30,6 +30,9 @@ function SelectWithOptions({
 }: SelectFieldRendererProps & {
   field: ResolvedField<F0SelectField> & {
     options: NonNullable<F0SelectField["options"]>
+    // searchFn is options-only; add it to the cast since F0SelectField is a
+    // union and searchFn does not exist on the source/customFieldName members.
+    searchFn?: F0SelectSearchFn
   }
 }) {
   const baseProps = {
@@ -39,13 +42,18 @@ function SelectWithOptions({
     options: field.options,
     showSearchBox: field.showSearchBox,
     searchBoxPlaceholder: field.searchBoxPlaceholder,
+    searchEmptyMessage: field.searchEmptyMessage,
+    searchFn: field.searchFn,
     icon: field.icon,
     onCreate: field.onCreate,
+    onOpenChange: field.onOpenChange,
     name: formField.name,
     onBlur: formField.onBlur,
     error,
     status,
-    loading,
+    // Merge form-level loading (async defaultValues) with field-level loading
+    // (e.g. lazy-fetch-on-open). Either being true shows the loading state.
+    loading: loading || field.loading,
     size: FORM_SIZE,
     hideLabel: true as const,
   }
@@ -117,13 +125,17 @@ function SelectWithSource({
     mapOptions: field.mapOptions,
     showSearchBox: field.showSearchBox,
     searchBoxPlaceholder: field.searchBoxPlaceholder,
+    searchEmptyMessage: field.searchEmptyMessage,
+    // No searchFn here: the component forbids searchFn together with source.
     icon: field.icon,
     onCreate: field.onCreate,
+    onOpenChange: field.onOpenChange,
     name: formField.name,
     onBlur: formField.onBlur,
     error,
     status,
-    loading,
+    // Merge form-level loading with field-level loading.
+    loading: loading || field.loading,
     size: FORM_SIZE,
     hideLabel: true as const,
   }

--- a/packages/react/src/patterns/F0Form/fields/select/__tests__/SelectFieldRenderer.test.tsx
+++ b/packages/react/src/patterns/F0Form/fields/select/__tests__/SelectFieldRenderer.test.tsx
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from "vitest"
+import { z } from "zod"
+
+import { createDataSourceDefinition } from "@/hooks/datasource"
+import { Archive } from "@/icons/app"
+import { useF0FormDefinition } from "@/patterns/F0WizardForm/useF0FormDefinition"
+import { zeroRender as render, waitFor } from "@/testing/test-utils"
+
+import { F0Form } from "../../../F0Form"
+import { f0FormField } from "../../../f0Schema"
+
+// Capture every props object passed to the underlying F0Select so we can assert
+// what the F0Form -> SelectFieldRenderer pipeline forwards to it.
+const { selectPropsSpy } = vi.hoisted(() => ({
+  selectPropsSpy: vi.fn(),
+}))
+
+vi.mock("@/components/F0Select", () => ({
+  F0Select: (props: Record<string, unknown>) => {
+    selectPropsSpy(props)
+    return <div data-testid="mock-f0select" />
+  },
+}))
+
+function lastSelectProps(): Record<string, unknown> {
+  const calls = selectPropsSpy.mock.calls
+  return calls[calls.length - 1][0] as Record<string, unknown>
+}
+
+describe("SelectFieldRenderer prop threading", () => {
+  it("forwards onOpenChange, loading, searchEmptyMessage, searchFn, icon and onCreate to F0Select in options mode", async () => {
+    const onOpenChange = vi.fn()
+    const onCreate = vi.fn()
+    const searchFn = vi.fn(() => true)
+
+    const schema = z.object({
+      team: f0FormField.select({
+        label: "Team",
+        optional: true,
+        options: [
+          { value: "eng", label: "Engineering" },
+          { value: "design", label: "Design" },
+        ],
+        showSearchBox: true,
+        loading: true,
+        searchEmptyMessage: "No teams",
+        onOpenChange,
+        onCreate,
+        searchFn,
+        icon: Archive,
+      }),
+    })
+
+    render(
+      <F0Form
+        name="select-props-options"
+        schema={schema}
+        defaultValues={{ team: undefined }}
+        onSubmit={async () => ({ success: true })}
+      />
+    )
+
+    await waitFor(() => expect(selectPropsSpy).toHaveBeenCalled())
+
+    const props = lastSelectProps()
+    expect(props.onOpenChange).toBe(onOpenChange)
+    expect(props.onCreate).toBe(onCreate)
+    expect(props.searchFn).toBe(searchFn)
+    expect(props.searchEmptyMessage).toBe("No teams")
+    expect(props.icon).toBe(Archive)
+    expect(props.options).toHaveLength(2)
+  })
+
+  it("shows loading when the field-level loading flag is set (form not loading)", async () => {
+    const schema = z.object({
+      team: f0FormField.select({
+        label: "Team",
+        optional: true,
+        options: [{ value: "eng", label: "Engineering" }],
+        loading: true,
+      }),
+    })
+
+    render(
+      <F0Form
+        name="select-field-loading"
+        schema={schema}
+        defaultValues={{ team: undefined }}
+        onSubmit={async () => ({ success: true })}
+      />
+    )
+
+    await waitFor(() => expect(selectPropsSpy).toHaveBeenCalled())
+    expect(lastSelectProps().loading).toBe(true)
+  })
+
+  it("shows loading when the form is loading async defaultValues (field flag unset)", async () => {
+    const schema = z.object({
+      team: f0FormField.select({
+        label: "Team",
+        optional: true,
+        options: [{ value: "eng", label: "Engineering" }],
+      }),
+    })
+
+    // Async defaultValues that never resolve keep the form in a loading state.
+    function FormLoadingForm() {
+      const formDefinition = useF0FormDefinition({
+        name: "select-form-loading",
+        schema,
+        defaultValues: () =>
+          new Promise<{ team: string | undefined }>(() => {}),
+        onSubmit: async () => ({ success: true }),
+      })
+      return <F0Form formDefinition={formDefinition} />
+    }
+
+    render(<FormLoadingForm />)
+
+    await waitFor(() => expect(selectPropsSpy).toHaveBeenCalled())
+    expect(lastSelectProps().loading).toBe(true)
+  })
+
+  it("does not show loading when neither form nor field is loading", async () => {
+    const schema = z.object({
+      team: f0FormField.select({
+        label: "Team",
+        optional: true,
+        options: [{ value: "eng", label: "Engineering" }],
+      }),
+    })
+
+    render(
+      <F0Form
+        name="select-no-loading"
+        schema={schema}
+        defaultValues={{ team: undefined }}
+        onSubmit={async () => ({ success: true })}
+      />
+    )
+
+    await waitFor(() => expect(selectPropsSpy).toHaveBeenCalled())
+    expect(lastSelectProps().loading).toBeFalsy()
+  })
+
+  it("does NOT forward searchFn in source mode (component forbids searchFn + source)", async () => {
+    const source = createDataSourceDefinition<{ id: number; name: string }>({
+      dataAdapter: {
+        fetchData: async () => ({
+          records: [{ id: 1, name: "Engineering" }],
+        }),
+      },
+    })
+
+    const schema = z.object({
+      team: f0FormField(z.number().optional(), {
+        label: "Team",
+        source,
+        mapOptions: (item: { id: number; name: string }) => ({
+          value: item.id,
+          label: item.name,
+        }),
+        searchEmptyMessage: "No teams",
+      }),
+    })
+
+    render(
+      <F0Form
+        name="select-source-mode"
+        schema={schema}
+        defaultValues={{ team: undefined }}
+        onSubmit={async () => ({ success: true })}
+      />
+    )
+
+    await waitFor(() => expect(selectPropsSpy).toHaveBeenCalled())
+
+    const props = lastSelectProps()
+    expect(props.source).toBeDefined()
+    expect(props.searchFn).toBeUndefined()
+    // Base props still thread through in source mode
+    expect(props.searchEmptyMessage).toBe("No teams")
+  })
+})

--- a/packages/react/src/patterns/F0Form/fields/select/types.ts
+++ b/packages/react/src/patterns/F0Form/fields/select/types.ts
@@ -55,6 +55,16 @@ export type SelectFieldRenderIf =
 export type SelectValueType = string | number
 
 /**
+ * Predicate used to filter static options against the current search text.
+ * Mirrors the `F0Select` component's `searchFn` signature.
+ * @typeParam T - The value type (string or number)
+ */
+export type F0SelectSearchFn<T extends SelectValueType = string> = (
+  option: F0SelectItemProps<T, unknown>,
+  search?: string
+) => boolean | undefined
+
+/**
  * Base config options shared by all select field variants
  */
 interface F0SelectConfigBase {
@@ -68,6 +78,12 @@ interface F0SelectConfigBase {
   icon?: IconType
   /** Callback to create a new item from the search text. Shows a "+ Create" button in the empty state of the dropdown. */
   onCreate?: (value: string) => Promise<void> | void
+  /** Called when the dropdown opens or closes. Enables lazy-fetch-on-first-open flows. */
+  onOpenChange?: (open: boolean) => void
+  /** Shows a loading indicator inside the select input (e.g. while options are being fetched). */
+  loading?: boolean
+  /** Message shown when the search yields no results. */
+  searchEmptyMessage?: string
 }
 
 /**
@@ -79,6 +95,11 @@ interface F0SelectConfigWithOptions<
 > extends F0SelectConfigBase {
   /** Options for the select dropdown */
   options: F0SelectItemProps<T, unknown>[]
+  /**
+   * Custom predicate to filter static options against the search text.
+   * Only valid in options mode — mutually exclusive with `source`.
+   */
+  searchFn?: F0SelectSearchFn<T>
   source?: never
   mapOptions?: never
 }
@@ -102,6 +123,8 @@ interface F0SelectConfigWithSource<
   /** Function to map data source items to select options */
   mapOptions: (item: R) => F0SelectItemProps<T, R>
   options?: never
+  /** `searchFn` is options-only — invalid alongside `source`. */
+  searchFn?: never
 }
 
 /**
@@ -112,6 +135,8 @@ interface F0SelectConfigWithCustomFieldName extends F0SelectConfigBase {
   options?: never
   source?: never
   mapOptions?: never
+  /** `searchFn` is options-only — invalid with a runtime-provided field. */
+  searchFn?: never
   /** Required: identifies the custom field provider */
   customFieldName: string
 }

--- a/packages/react/src/patterns/F0Form/useSchemaDefinition.ts
+++ b/packages/react/src/patterns/F0Form/useSchemaDefinition.ts
@@ -150,6 +150,8 @@ function configToF0Field(
             }
           : {
               options: "options" in config ? config.options : [],
+              // searchFn is options-only (mutually exclusive with source)
+              searchFn: "searchFn" in config ? config.searchFn : undefined,
             }),
         multiple: "multiple" in config ? config.multiple : undefined,
         clearable,
@@ -158,6 +160,15 @@ function configToF0Field(
         searchBoxPlaceholder:
           "searchBoxPlaceholder" in config
             ? config.searchBoxPlaceholder
+            : undefined,
+        icon: "icon" in config ? config.icon : undefined,
+        onCreate: "onCreate" in config ? config.onCreate : undefined,
+        onOpenChange:
+          "onOpenChange" in config ? config.onOpenChange : undefined,
+        loading: "loading" in config ? config.loading : undefined,
+        searchEmptyMessage:
+          "searchEmptyMessage" in config
+            ? config.searchEmptyMessage
             : undefined,
         renderIf: config.renderIf,
       } as F0Field


### PR DESCRIPTION
## Description

Extend F0Form's native `fieldType: 'select'` config to forward four more props to the underlying `F0Select` — `onOpenChange`, `loading`, `searchFn`, `searchEmptyMessage` — plus fix a pre-existing gap where `icon`/`onCreate` were declared but never threaded.

Today a schema-declared select can't lazy-fetch options on first open, show a loading spinner while they fetch, customize search matching, or set a custom empty-state message. Consumers have to drop to a `fieldType: 'custom'` wrapper around `F0Select` for any of those (e.g. a contacts/vendor picker that lazy-loads on open). This makes those cases expressible with a plain native select field.

Additive/optional props only — non-breaking.

## Screenshots (if applicable)

New Storybook story `F0Form/SelectLazyFetchOnOpen` demonstrates the lazy-fetch-on-first-open flow (options start empty, `onOpenChange` triggers a fake fetch, `loading` spinner shows meanwhile, searchable).

## Implementation details

- **`fields/select/types.ts`** — `onOpenChange`, `loading`, `searchEmptyMessage` added to `F0SelectConfigBase`; `searchFn` added to the options variant only, with `searchFn?: never` on the `source` and `customFieldName` variants so the "options-only" constraint (mirroring `F0Select`, where `searchFn` is invalid alongside `source`) is type-enforced.
- **`useSchemaDefinition.ts`** — threads the new props onto the resolved field; `searchFn` only in the non-`source` branch; `icon`/`onCreate` now threaded (the renderer already read them but the config never set them — silent drop).
- **`SelectFieldRenderer.tsx`** — forwards the props to `F0Select`. Field-level `loading` is OR-merged with the form's async-defaultValues loading (`loading: loading || field.loading`) so neither clobbers the other. No `searchFn` in source mode.
- **Tests/story** — 5 unit tests (prop forwarding, the loading merge, `searchFn` source-mode exclusion) + the lazy-fetch story.

Verified locally: `tsc --noEmit` 0 errors, `vitest --project=unit` 5/5, oxlint/oxfmt clean.

Note: this is the design-system enabler; the form field still stores a string value, so object-valued selects still store an id and re-map at submit.
