### PR TITLE
perf(OneDataCollection): debounce the collection→URL sync (fixes per-keystroke Sentry session churn)

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/hooks/__tests__/useDataCollectionUrlSync.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/hooks/__tests__/useDataCollectionUrlSync.test.tsx
@@ -1,10 +1,15 @@
-import { afterEach, describe, expect, it, vi } from "vitest"
+import { act } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { DATA_COLLECTION_URL_PARAM_PREFIX } from "@/lib/providers/datacollection/dataCollectionUrlParams"
 import { FiltersDefinition } from "@/patterns/OneFilterPicker/types"
 import { zeroRenderHook as renderHook } from "@/testing/test-utils"
 
 import { useDataCollectionUrlSync } from "../useDataCollectionUrlSync"
+
+// The collection → URL write is debounced (URL_SYNC_DEBOUNCE_MS = 300ms), so
+// advance past it before asserting the URL. Comfortably above the debounce.
+const flushUrlSync = () => act(() => void vi.advanceTimersByTime(400))
 
 const FILTERS = {
   department: { type: "in", label: "Department", options: { options: [] } },
@@ -57,7 +62,12 @@ const hasDcParams = () =>
     k.startsWith(DATA_COLLECTION_URL_PARAM_PREFIX)
   )
 
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
 afterEach(() => {
+  vi.useRealTimers()
   window.history.replaceState(null, "", "/")
 })
 
@@ -95,6 +105,7 @@ describe("useDataCollectionUrlSync — collection → URL", () => {
 
     const { rerender } = setup()
     rerender({ filters: { department: ["Design", "Sales"] } })
+    flushUrlSync()
 
     expect(window.location.pathname).toBe("/people")
     expect(currentParams().has("dc_id")).toBe(false)
@@ -106,10 +117,27 @@ describe("useDataCollectionUrlSync — collection → URL", () => {
 
     const { rerender } = setup()
     rerender({ search: "ada" })
+    flushUrlSync()
     expect(currentParams().get("dc_search")).toBe("ada")
 
     rerender({ search: "" })
+    flushUrlSync()
     expect(hasDcParams()).toBe(false)
+  })
+
+  it("coalesces a burst of search changes into a single URL write", () => {
+    window.history.replaceState(null, "", "/people")
+
+    const { rerender } = setup()
+    // Simulate typing "ada" — three changes within the debounce window.
+    rerender({ search: "a" })
+    rerender({ search: "ad" })
+    rerender({ search: "ada" })
+    // Nothing written yet — the debounce hasn't settled.
+    expect(hasDcParams()).toBe(false)
+
+    flushUrlSync()
+    expect(currentParams().get("dc_search")).toBe("ada")
   })
 })
 
@@ -141,6 +169,7 @@ describe("useDataCollectionUrlSync — visualization", () => {
     expect(setVisualization).not.toHaveBeenCalled()
 
     rerender({ visualization: 0 })
+    flushUrlSync()
     expect(currentParams().has("dc_visualization")).toBe(false)
   })
 
@@ -150,9 +179,11 @@ describe("useDataCollectionUrlSync — visualization", () => {
     const { rerender } = setup({ visualizationKeys: ["table", "card", "list"] })
 
     rerender({ visualization: 2 })
+    flushUrlSync()
     expect(currentParams().get("dc_visualization")).toBe("list")
 
     rerender({ visualization: 0 })
+    flushUrlSync()
     expect(currentParams().has("dc_visualization")).toBe(false)
   })
 })
@@ -165,6 +196,7 @@ describe("useDataCollectionUrlSync — enabled regardless of id", () => {
     expect(setSearch).not.toHaveBeenCalled()
 
     rerender({ search: "changed" })
+    flushUrlSync()
     expect(currentParams().get("dc_search")).toBe("ada")
   })
 
@@ -176,6 +208,7 @@ describe("useDataCollectionUrlSync — enabled regardless of id", () => {
 
     // collection → URL
     rerender({ search: "bob" })
+    flushUrlSync()
     expect(currentParams().get("dc_search")).toBe("bob")
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionUrlSync.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionUrlSync.ts
@@ -1,5 +1,6 @@
-import { useEffect, useState } from "react"
 import { useDeepCompareEffect } from "@reactuses/core"
+import { useCallback, useEffect, useState } from "react"
+import { useDebounceCallback } from "usehooks-ts"
 
 import {
   FiltersDefinition,
@@ -8,9 +9,19 @@ import {
   SortingsState,
 } from "@/hooks/datasource"
 import {
+  type DataCollectionUrlState,
   parseDataCollectionUrlParams,
   syncDataCollectionUrlParams,
 } from "@/lib/providers/datacollection/dataCollectionUrlParams"
+
+/**
+ * Debounce (ms) for the collection → URL write. The search box updates
+ * `currentSearch` on every keystroke, and each write is a `history.replaceState`
+ * — which the browser Sentry SDK treats as a navigation and rotates the session
+ * on, so an un-debounced write spams two session envelopes per letter. Coalesce
+ * a burst of changes into a single write once the user pauses.
+ */
+const URL_SYNC_DEBOUNCE_MS = 300
 
 type UseDataCollectionUrlSyncOptions = {
   /**
@@ -110,10 +121,26 @@ export const useDataCollectionUrlSync = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- apply once when ready
   }, [active, storageReady])
 
-  // collection → URL.
+  // collection → URL. Debounced (see URL_SYNC_DEBOUNCE_MS): a burst of changes —
+  // above all typing in the search box — collapses into a single
+  // `history.replaceState` instead of one per keystroke, so the browser Sentry
+  // session isn't rotated (two session envelopes) on every letter.
+  // Stable identity (empty deps): `useDebounceCallback` re-creates its debounced
+  // instance whenever `func` changes, so an inline arrow here would yield a new
+  // `debouncedSync` every render — re-running the effect below and cancelling
+  // the pending write on each render, which under frequent re-renders would
+  // never let it fire. `syncDataCollectionUrlParams` reads `window.location`
+  // itself and takes the full state as its argument, so it needs no deps.
+  const syncToUrl = useCallback(
+    (state: DataCollectionUrlState<FiltersState<FiltersDefinition>>) =>
+      syncDataCollectionUrlParams(state),
+    []
+  )
+  const debouncedSync = useDebounceCallback(syncToUrl, URL_SYNC_DEBOUNCE_MS)
+
   useDeepCompareEffect(() => {
     if (!active || !urlApplied) return
-    syncDataCollectionUrlParams({
+    debouncedSync({
       filters,
       search,
       sortings,
@@ -124,6 +151,11 @@ export const useDataCollectionUrlSync = ({
           : undefined,
       preset: selectedPresetId,
     })
+    // Cancel a still-pending write when deps change or on unmount, so a stale
+    // snapshot can't land after a newer one — and, on unmount, can't stamp this
+    // collection's `dc_` params onto the page we navigated to. Each change
+    // re-schedules with the latest state, so coalescing is preserved.
+    return () => debouncedSync.cancel()
   }, [
     active,
     urlApplied,
@@ -134,5 +166,6 @@ export const useDataCollectionUrlSync = ({
     visualizationKeys,
     syncVisualization,
     selectedPresetId,
+    debouncedSync,
   ])
 }


### PR DESCRIPTION
## Why

`useDataCollectionUrlSync` reflects every collection state change (filters / search / sortings / visualization) back into the URL through `history.replaceState`, **with no debounce**. The search box updates `currentSearch` on **every keystroke**, so typing writes the URL once per letter.

The browser Sentry SDK (`@sentry/browser` v8, `browserSessionIntegration` — on by default) treats each `history` change as a **navigation** and **rotates the release-health session** on it. So each keystroke emitted **two session envelopes** — one `exited` (previous session) and one `init` (new session):

```
{"type":"session"} {"init":false,"status":"exited","errors":0,...}
{"type":"session"} {"init":true,"status":"ok","errors":0,...}
```

Effect: session counts are **inflated** by typing, crash-free-session rate is **diluted** with trivially-`ok` sessions, plus needless `replaceState`/network churn — across **every** OneDataCollection in the app, not just the one where it was noticed (the People org chart).

## What

Debounce the collection→URL write by **300ms**, so a burst of changes collapses into a **single** `replaceState` once the user pauses.

- The write must carry the **full** state: `setDataCollectionUrlParams` clears and rewrites all `dc_` params, so a search-only write would drop the filter/sort params. Hence the whole sync is debounced, not just search. Filters/sortings/visualization change on discrete clicks (no burst), so the ~300ms delay on them is imperceptible.
- The debounced function is stabilized with `useCallback([])` — `useDebounceCallback` re-creates its debounced instance whenever `func` changes, so an inline arrow would yield a new debounced identity every render, re-running the effect and cancelling the pending write on each render (which under frequent re-renders would never let it fire). `syncDataCollectionUrlParams` reads `window.location` itself and takes the full state as its argument, so it needs no deps.
- Pending writes are **cancelled** on deps-change / unmount, so a stale snapshot can't land after a newer one — nor stamp this collection's `dc_` params onto the page the user navigated to.

The URL → collection apply (on mount, after storage hydration) is unchanged and still immediate.

## ⚠️ Monitoring concern (please read)

This changes **Sentry Release Health**, which is monitoring-critical — flagging it explicitly:

- **Error/exception reporting is untouched.** Those are `type: event` envelopes on a separate path; only `type: session` (release health) envelopes are affected. Factorial's `Sentry.init` only adds `extraErrorDataIntegration` (no BrowserTracing), so no performance/navigation transactions are involved either.
- **Session counts will drop** after this ships (fewer navigation-triggered rotations). This is **more accurate**, not less — today's counts are inflated by per-keystroke rotations. But anyone watching Release Health dashboards/alerts keyed on **session volume** should be aware so a lower baseline isn't mistaken for an outage or a data-loss regression.
- The change is **app-wide** (core ODC hook), so it deserves review from an ODC / observability owner rather than riding along a feature PR — which is why it's split out here.

If we'd rather minimize blast radius, an alternative is to debounce **only search-triggered** writes and keep filter/sort/visualization writes immediate (they don't burst). Happy to switch to that if preferred.

## Testing

- `useDataCollectionUrlSync.test.tsx` updated to fake timers with a `flushUrlSync()` helper; added a coalescing test (typing `a`→`ad`→`ada` yields a single write with `ada`). 11/11 pass locally.
- `oxfmt` + `oxlint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
