### PR TITLE
fix: relax react-virtuoso to ^4.18.10

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -129,7 +129,7 @@
     "prosemirror-state": "^1.4.3",
     "prosemirror-view": "^1.38.1",
     "react-remove-scroll": "^2.7.1",
-    "react-virtuoso": "^4.18.11",
+    "react-virtuoso": "^4.18.10",
     "rehype-stringify": "^10.0.1",
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -441,7 +441,7 @@ importers:
         specifier: ^2.7.1
         version: 2.7.1(@types/react@18.3.18)(react@18.3.1)
       react-virtuoso:
-        specifier: ^4.18.11
+        specifier: ^4.18.10
         version: 4.18.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       recharts:
         specifier: ^2.12.7


### PR DESCRIPTION
## Why

The main app enforces a 7-day supply-chain quarantine on third-party packages (pnpm `minimumReleaseAge`). `react-virtuoso@4.18.11` was published on July 17, so any f0 release depending on `^4.18.11` cannot be installed there until July 24 — the range has no mature version to fall back to.

## What

Relax the range to `^4.18.10`. Consumers without the quarantine still resolve to the latest 4.18.x; the main app falls back to 4.18.10 (published June 27, already mature).

The only change in 4.18.11 is a fix for horizontal lists switching between LTR and RTL ([changelog](https://github.com/petyosi/react-virtuoso/blob/main/packages/react-virtuoso/CHANGELOG.md)), which F0Chat's vertical transcript doesn't use, so pinning one patch lower is safe.