### PR TITLE
chore(react): put F0Chat in a Domain specific/Communications holding area

### DIFF
--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -76,7 +76,6 @@ const config: StorybookConfig = {
     // ── Kits · functional bundles (AI + Chat promoted from sds) ──
     { directory: "../src/kits", titlePrefix: "Kits" },
     { directory: "../src/sds/ai", titlePrefix: "Kits" },
-    { directory: "../src/sds/chat", titlePrefix: "Kits" },
     { directory: "../src/experimental/AiPromotionChat", titlePrefix: "Kits/AI" },
 
     // ── Domain specific · owned by a single domain (was "SDS") ───
@@ -84,6 +83,7 @@ const config: StorybookConfig = {
     { directory: "../src/sds/Profile", titlePrefix: "Domain specific" },
     { directory: "../src/sds/inbox", titlePrefix: "Domain specific" },
     { directory: "../src/sds/surveys", titlePrefix: "Domain specific" },
+    { directory: "../src/sds/chat", titlePrefix: "Domain specific/Communications" }, // unvalidated chat — holding area until recurrent use is proven, then promote
     { directory: "../src/sds/TimeLine", titlePrefix: "Domain specific/Time tracking" },
     { directory: "../src/sds/UpsellingKit", titlePrefix: "Domain specific/Growth" },
 

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
@@ -651,8 +651,9 @@ const DocumentConversation = (): ReactNode => {
 }
 
 const meta = {
-  title: "Chat/F0Chat",
+  title: "F0Chat",
   component: F0Chat,
+  tags: ["experimental"],
   parameters: { layout: "fullscreen" },
 } satisfies Meta<typeof F0Chat>
 


### PR DESCRIPTION
## What & why

F0Chat's reuse isn't validated — it's experimental, unclear if it's used in the product, and has no clear single-domain owner. Per the lifecycle, **placement follows proven reuse**: don't promote to Core (Pattern) or commit to a Kit before recurrent use is validated.

So it goes to a new **`Domain specific/Communications`** folder, tagged **experimental** — a holding area. Once recurrent cross-product use is validated it gets promoted: → **Core/Pattern** if generic, or a **Communications Kit** if a real comms bundle forms.

Sidebar-only: routes `src/sds/chat` → `Domain specific/Communications`.

## Test plan
Verified in Storybook: `Domain specific/Communications/F0Chat` (experimental 🚧); no longer in Kits/Patterns; 0 title collisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)