### PR TITLE
fix(SurveyFormBuilder): [FCT-59912] fix Add-option contrast + enforce a11y

### DIFF
--- a/packages/react/.storybook/a11y-skip-allowlist.json
+++ b/packages/react/.storybook/a11y-skip-allowlist.json
@@ -30,10 +30,7 @@
     "src/patterns/OneDataCollection/components/ActionBar/index.stories.tsx": 1,
     "src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/__stories__/useDataCollectionItemNavigation.stories.tsx": 1,
     "src/kits/ai/F0AiChat/__stories__/F0AiFormTools.stories.tsx": 1,
-    "src/kits/surveys/SurveyFormBuilder/Form/index.stories.tsx": 1,
     "src/kits/surveys/SurveyFormBuilder/QuestionTypes/DropdownSingleQuestion/index.stories.tsx": 4,
-    "src/kits/surveys/SurveyFormBuilder/QuestionTypes/RatingQuestion/index.stories.tsx": 5,
-    "src/kits/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/index.stories.tsx": 5,
     "src/ui/OnePagination/index.stories.tsx": 1,
     "src/ui/Select/__stories__/select.stories.tsx": 1,
     "src/ui/value-display/types/country/__stories__/country.stories.tsx": 1

--- a/packages/react/.storybook/a11y-skip-allowlist.json
+++ b/packages/react/.storybook/a11y-skip-allowlist.json
@@ -30,7 +30,6 @@
     "src/patterns/OneDataCollection/components/ActionBar/index.stories.tsx": 1,
     "src/patterns/OneDataCollection/hooks/useDataCollectionItemNavigation/__stories__/useDataCollectionItemNavigation.stories.tsx": 1,
     "src/kits/ai/F0AiChat/__stories__/F0AiFormTools.stories.tsx": 1,
-    "src/kits/surveys/SurveyFormBuilder/QuestionTypes/DropdownSingleQuestion/index.stories.tsx": 4,
     "src/ui/OnePagination/index.stories.tsx": 1,
     "src/ui/Select/__stories__/select.stories.tsx": 1,
     "src/ui/value-display/types/country/__stories__/country.stories.tsx": 1

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/ApplyingChangesTag/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/ApplyingChangesTag/index.tsx
@@ -41,7 +41,7 @@ const ApplyingChangesTag = () => {
           },
         }}
       />
-      <span className="font-medium">
+      <span className="font-medium text-f1-foreground">
         {i18n.t("surveyFormBuilder.labels.applyingChanges")}
       </span>
     </div>

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Form/index.stories.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Form/index.stories.tsx
@@ -2,8 +2,6 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { useState } from "react"
 
-import { withSkipA11y } from "@/lib/storybook-utils/parameters"
-
 import { SurveyFormBuilder } from "."
 import { mockDatasets } from "../../__stories__/mocks"
 import { SurveyFormBuilderElement } from "../types"
@@ -12,6 +10,7 @@ const meta: Meta<typeof SurveyFormBuilder> = {
   title: "Surveys/SurveyFormBuilder",
   component: SurveyFormBuilder,
   tags: ["autodocs"],
+  parameters: { a11y: { test: "error" } },
   render: (args) => {
     const [elements, setElements] = useState<SurveyFormBuilderElement[]>(
       args.elements
@@ -98,8 +97,6 @@ export const ApplyingChanges: Story = {
 }
 
 export const WithQuestionWithDuplicateOptions: Story = {
-  // TODO: Fix a11y issues
-  parameters: withSkipA11y({}),
   args: {
     elements: [
       {

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Form/index.stories.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Form/index.stories.tsx
@@ -90,6 +90,17 @@ export const Empty: Story = {
 }
 
 export const ApplyingChanges: Story = {
+  parameters: {
+    a11y: {
+      // Known contrast issue reported but not blocking: in the applying
+      // state the ApplyingChangesTag label resolves to a light foreground
+      // on its light pill (~1.3:1) due to a theme-context mismatch in this
+      // subtree. `text-f1-foreground` fixes it in light theme but not here;
+      // the proper fix needs the tag to own a theme-consistent fg/bg pair.
+      // Tracked as a follow-up.
+      test: "todo",
+    },
+  },
   args: {
     ...Default.args,
     applyingChanges: true,

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/DropdownSingleQuestion/index.stories.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/DropdownSingleQuestion/index.stories.tsx
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { useState } from "react"
 
-import { withSkipA11y } from "@/lib/storybook-utils/parameters"
 import { createDataSourceDefinition } from "@/hooks/datasource"
 import type { RecordType } from "@/hooks/datasource"
 
@@ -52,6 +51,7 @@ const meta: Meta<typeof DropdownSingleQuestion> = {
   title: "Surveys/SurveyFormBuilder/DropdownSingleQuestion",
   component: DropdownSingleQuestion,
   tags: ["autodocs", "experimental"],
+  parameters: { a11y: { test: "error" } },
   render: (args) => {
     const [elements, setElements] = useState<SurveyFormBuilderElement[]>([
       { type: "question" as const, question: args },
@@ -78,7 +78,6 @@ export default meta
 type Story = StoryObj<typeof DropdownSingleQuestion>
 
 export const Default: Story = {
-  parameters: withSkipA11y({}),
   args: {
     id: "question-1",
     title: "Select your department",
@@ -90,7 +89,6 @@ export const Default: Story = {
 }
 
 export const WithSearchBox: Story = {
-  parameters: withSkipA11y({}),
   args: {
     id: "question-2",
     title: "Select your currency",
@@ -102,7 +100,6 @@ export const WithSearchBox: Story = {
 }
 
 export const WithSearchBoxExplicit: Story = {
-  parameters: withSkipA11y({}),
   args: {
     id: "question-3",
     title: "Select your vendor",
@@ -116,7 +113,6 @@ export const WithSearchBoxExplicit: Story = {
 }
 
 export const WithAllowCreate: Story = {
-  parameters: withSkipA11y({}),
   render: (args) => {
     const [elements, setElements] = useState<SurveyFormBuilderElement[]>([
       { type: "question" as const, question: args },

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/RatingQuestion/index.stories.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/RatingQuestion/index.stories.tsx
@@ -2,8 +2,6 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { useState } from "react"
 
-import { withSkipA11y } from "@/lib/storybook-utils/parameters"
-
 import { RatingQuestion } from "."
 import { SurveyFormBuilderProvider } from "../../Context"
 import { SurveyFormBuilderElement, QuestionElement } from "../../types"
@@ -12,6 +10,7 @@ const meta: Meta<typeof RatingQuestion> = {
   title: "Surveys/SurveyFormBuilder/RatingQuestion",
   component: RatingQuestion,
   tags: ["autodocs", "experimental"],
+  parameters: { a11y: { test: "error" } },
   render: (args) => {
     const [elements, setElements] = useState<SurveyFormBuilderElement[]>([
       { type: "question" as const, question: args as QuestionElement },
@@ -34,8 +33,6 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
-  // TODO: Fix a11y issues
-  parameters: withSkipA11y({}),
   args: {
     id: "question-1",
     title: "Rate your experience",
@@ -53,8 +50,6 @@ export const Default: Story = {
 }
 
 export const WithSelectedValue: Story = {
-  // TODO: Fix a11y issues
-  parameters: withSkipA11y({}),
   args: {
     id: "question-2",
     title: "How would you rate this?",
@@ -76,8 +71,6 @@ export const WithSelectedValue: Story = {
 }
 
 export const SmallRange: Story = {
-  // TODO: Fix a11y issues
-  parameters: withSkipA11y({}),
   args: {
     id: "question-3",
     title: "Satisfaction level",
@@ -92,8 +85,6 @@ export const SmallRange: Story = {
 }
 
 export const WithEmojiOptions: Story = {
-  // TODO: Fix a11y issues
-  parameters: withSkipA11y({}),
   args: {
     id: "question-4",
     title: "Satisfaction level",
@@ -110,8 +101,6 @@ export const WithEmojiOptions: Story = {
 }
 
 export const WithEmojiOptionsDisabled: Story = {
-  // TODO: Fix a11y issues
-  parameters: withSkipA11y({}),
   render: (args) => {
     const [elements, setElements] = useState<SurveyFormBuilderElement[]>([
       { type: "question" as const, question: args as QuestionElement },

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/index.stories.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/index.stories.tsx
@@ -2,8 +2,6 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { useState } from "react"
 
-import { withSkipA11y } from "@/lib/storybook-utils/parameters"
-
 import { SelectQuestion } from "."
 import { SurveyFormBuilderProvider } from "../../Context"
 import { SurveyFormBuilderElement } from "../../types"
@@ -12,6 +10,7 @@ const meta: Meta<typeof SelectQuestion> = {
   title: "Surveys/SurveyFormBuilder/SelectQuestion",
   component: SelectQuestion,
   tags: ["autodocs", "experimental"],
+  parameters: { a11y: { test: "error" } },
   render: (args) => {
     const [elements, setElements] = useState<SurveyFormBuilderElement[]>([
       { type: "question" as const, question: args },
@@ -34,8 +33,6 @@ export default meta
 type Story = StoryObj<typeof SelectQuestion>
 
 export const Default: Story = {
-  // TODO: Fix a11y issues
-  parameters: withSkipA11y({}),
   args: {
     id: "question-1",
     title: "How supported do you feel by your manager and team?",
@@ -52,8 +49,6 @@ export const Default: Story = {
 }
 
 export const WithSelectedValue: Story = {
-  // TODO: Fix a11y issues
-  parameters: withSkipA11y({}),
   args: {
     id: "question-2",
     title: "What is your primary concern?",
@@ -70,8 +65,6 @@ export const WithSelectedValue: Story = {
 }
 
 export const ManyOptions: Story = {
-  // TODO: Fix a11y issues
-  parameters: withSkipA11y({}),
   args: {
     id: "question-3",
     title: "Which areas would you like to improve?",
@@ -90,8 +83,6 @@ export const ManyOptions: Story = {
 }
 
 export const MultiSelect: Story = {
-  // TODO: Fix a11y issues
-  parameters: withSkipA11y({}),
   args: {
     id: "question-4",
     title: "What are your primary concerns?",
@@ -109,8 +100,6 @@ export const MultiSelect: Story = {
 }
 
 export const WithDuplicateOptions: Story = {
-  // TODO: Fix a11y issues
-  parameters: withSkipA11y({}),
   args: {
     id: "question-5",
     title: "What are your primary concerns?",

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/index.tsx
@@ -208,14 +208,12 @@ export const SelectQuestion = ({ options, ...props }: SelectQuestionProps) => {
           </Reorder.Group>
         </DragProvider>
         {!disabled && !answering && !questionLocked && (
-          <div className="opacity-50">
-            <F0Button
-              label={t("surveyFormBuilder.selectQuestion.addOption")}
-              variant="ghost"
-              icon={Add}
-              onClick={handleAddOption}
-            />
-          </div>
+          <F0Button
+            label={t("surveyFormBuilder.selectQuestion.addOption")}
+            variant="ghost"
+            icon={Add}
+            onClick={handleAddOption}
+          />
         )}
       </div>
     </BaseQuestion>

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/SelectQuestion/index.tsx
@@ -208,12 +208,14 @@ export const SelectQuestion = ({ options, ...props }: SelectQuestionProps) => {
           </Reorder.Group>
         </DragProvider>
         {!disabled && !answering && !questionLocked && (
-          <F0Button
-            label={t("surveyFormBuilder.selectQuestion.addOption")}
-            variant="ghost"
-            icon={Add}
-            onClick={handleAddOption}
-          />
+          <div className="opacity-70">
+            <F0Button
+              label={t("surveyFormBuilder.selectQuestion.addOption")}
+              variant="ghost"
+              icon={Add}
+              onClick={handleAddOption}
+            />
+          </div>
         )}
       </div>
     </BaseQuestion>


### PR DESCRIPTION
## Description

https://factorialmakers.atlassian.net/browse/FCT-59912

The SurveyFormBuilder `SelectQuestion`, `RatingQuestion`, `DropdownSingleQuestion`, and `Form` stories were opted out of the axe check via `withSkipA11y()` with `// TODO: Fix a11y issues` notes. Auditing them found **one real violation and three stale opt-outs**: `RatingQuestion` (5 stories), `DropdownSingleQuestion` (4 stories) and the `Form` composite (9 stories) were already axe-clean, while `SelectQuestion` had a genuine **WCAG 1.4.3 (contrast)** failure. This fixes it and turns the check on for all of them.

This clears **every** SurveyFormBuilder entry from `.storybook/a11y-skip-allowlist.json`, completing the surveys group of the skipCi burndown: **36 → 32 files, 54 → 39 skip call-sites**.

## Implementation details

- fix: the **"Add option"** `F0Button` was dimmed via `opacity-50`, dropping its text contrast to **3.42:1** (below the 4.5:1 AA minimum). Raised it to **`opacity-70` (6.73:1)** — keeping the intended muted/secondary look while meeting AA (rather than removing the dimming, which would make it too prominent).
- fix: the SurveyFormBuilder "Applying changes" loading label (`ApplyingChangesTag`) had no explicit text color, inheriting a near-white color on its light pill (invisible). Set `text-f1-foreground` — resolves it in light theme, but CI surfaced a residual contrast reading (~1.3:1) that couldn't be reproduced locally, so the **`ApplyingChanges` story is scoped to `test: "todo"`** (reported, non-blocking) with a tracked follow-up.
- chore: replace the per-story `withSkipA11y()` opt-outs with meta-level `a11y: { test: "error" }` across `SelectQuestion` (5), `RatingQuestion` (5), `DropdownSingleQuestion` (4), and the `Form` composite (9). These now **block CI** on a11y violations (except the one `ApplyingChanges` story on `test: "todo"`). Removed the now-unused `withSkipA11y` imports and stale TODO comments.
- chore: drop all four SurveyFormBuilder entries from `.storybook/a11y-skip-allowlist.json` (the burndown list only shrinks), verified by `a11ySkipAllowlist.test.ts`.

## Verification

CI green: **22 of 23 SurveyFormBuilder stories enforced** at `test:"error"` (the 5 SelectQuestion stories flipped FAIL→PASS after the contrast fix; RatingQuestion, DropdownSingleQuestion + Form were already clean), with `ApplyingChanges` on `test:"todo"` pending the follow-up. Lint + typecheck + allowlist enforcement test clean.

The `DropdownSingleQuestion` opt-outs were confirmed stale by running axe over all 2050 stories twice (WCAG 2.0/2.1/2.2 A+AA, scoped to `#storybook-root`, 1280×720): all 4 of its stories reported **0 violations** in both runs, so enforcing them needed no component changes.

## Screenshots — "Add option" before / after

Small visual change: the "Add option" button's dimming is raised from **50% (3.43:1, fails AA)** to **70% (6.73:1, passes)** — still visibly muted/secondary, just legible. **Design: this keeps the muted intent while meeting AA — please confirm this treatment, or tell us the muted color you'd prefer** (a compliant color token would be more robust than opacity across themes/backgrounds).

| Before (dimmed, fails contrast) | After (fixed) |
| --- | --- |
|<img width="1656" height="554" alt="addoption-before" src="https://github.com/user-attachments/assets/9b81e9e9-8086-4f63-a1f3-43e1e7622876" />|<img width="1656" height="554" alt="addoption-after" src="https://github.com/user-attachments/assets/1055bf36-ec8f-445a-a0a1-8220387f279b" />|

## Note for review

⚠️ These SurveyFormBuilder stories are **not snapshotted by Chromatic** (f0 defaults `disableSnapshot: true`; they don't opt in via `withSnapshot`), so this visual change is **not** covered by visual regression — hence the manual screenshots above. Please eyeball it for design sign-off. (Adding a snapshotted `Snapshot` story is part of the component's Definition-of-Done and is out of scope here.)

ℹ️ A commit was added after the initial approval (`615c1d71d`): it removes the last four `DropdownSingleQuestion` opt-outs and its allowlist entry. No component code changed — stories only, plus the allowlist. Re-approval may be needed depending on branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
