### PR TITLE
fix(react): wrap survey rating options so long labels don't clip

### DIFF
--- a/packages/react/src/sds/surveys/SurveyAnsweringForm/__stories__/SurveyAnsweringForm.stories.tsx
+++ b/packages/react/src/sds/surveys/SurveyAnsweringForm/__stories__/SurveyAnsweringForm.stories.tsx
@@ -265,6 +265,43 @@ const quizElements: SurveyFormBuilderElement[] = [
   },
 ]
 
+const longLabelRatingElements: SurveyFormBuilderElement[] = [
+  {
+    type: "question",
+    question: {
+      id: "q-health",
+      title: "En général, diriez-vous que votre santé est :",
+      description: "Sélectionnez l'option qui correspond le mieux.",
+      type: "rating" as const,
+      options: [
+        { value: 1, label: "Excellente/Très bonne" },
+        { value: 2, label: "Bonne" },
+        { value: 3, label: "Assez bonne" },
+        { value: 4, label: "Plutôt mauvaise" },
+        { value: 5, label: "Mauvaise" },
+      ],
+      required: true,
+    },
+  },
+  {
+    type: "question",
+    question: {
+      id: "q-stress",
+      title: "À quelle fréquence avez-vous été stressé(e) ?",
+      description: "Sur une période récente, selon votre ressenti.",
+      type: "rating" as const,
+      options: [
+        { value: 1, label: "Tout le temps" },
+        { value: 2, label: "Très souvent" },
+        { value: 3, label: "Parfois" },
+        { value: 4, label: "Très peu souvent" },
+        { value: 5, label: "Jamais" },
+      ],
+      required: true,
+    },
+  },
+]
+
 type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
   ? Omit<T, K>
   : never
@@ -480,6 +517,17 @@ export const RightSideMixedCorrectAnswers: Story = {
       },
       "q-next-review": { type: "date", value: new Date("2026-03-20") },
     },
+  },
+}
+
+export const RatingLongLabels: Story = {
+  args: {
+    mode: "all-questions",
+    position: "fullscreen",
+    title: "Questionnaire santé",
+    description:
+      "Rating options with long text labels must wrap instead of clipping.",
+    elements: longLabelRatingElements,
   },
 }
 

--- a/packages/react/src/sds/surveys/SurveyAnsweringForm/components/RatingQuestionField.tsx
+++ b/packages/react/src/sds/surveys/SurveyAnsweringForm/components/RatingQuestionField.tsx
@@ -27,19 +27,21 @@ export function RatingQuestionField({
   }
 
   return (
-    <div className="grid grid-cols-3 gap-3 md:grid-cols-5">
+    <div className="flex flex-wrap gap-3">
       {options.map((option) => (
         <div
           key={option.value}
           className={cn(
-            "flex h-10 min-w-20 items-center justify-center rounded-md border border-solid border-f1-border text-center font-medium",
+            "flex min-h-10 min-w-20 grow basis-auto items-center justify-center rounded-md border border-solid border-f1-border px-3 py-1.5 text-center font-medium",
             disabled ? "cursor-not-allowed" : "cursor-pointer",
             value === option.value &&
               "border-f1-border-selected bg-f1-background-selected-secondary"
           )}
           onClick={() => handleClick(option.value)}
         >
-          <span className="text-base font-medium">{option.label}</span>
+          <span className="text-base font-medium leading-tight">
+            {option.label}
+          </span>
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Problem

In `SurveyAnsweringForm`, the rating (opinion-scale) options were laid out in a **fixed 5-equal-column grid** with fixed-height, no-padding chips. When a label was longer than its column — e.g. `"Excellente/Très bonne"` in a health survey — the text overflowed the chip and was **clipped / cramped into two edge-to-edge lines**, leaving the row uneven.

Reported by Pauline (Slack): the component "breaks when it has a lot of text".

## Before / After

Same survey (`Rating Long Labels` story), same viewport width (~780px):

**Before** — `"Excellente/Très bonne"` wraps into two cramped lines, uneven with its neighbours:

<img width="1568" height="769" alt="before" src="https://github.com/user-attachments/assets/57283d5e-a1c9-4b2e-8826-decbbcafd864" />

**After** — the chip widens to fit the label on a single line; all options share a uniform height and adapt their width:

<img width="1568" height="769" alt="after" src="https://github.com/user-attachments/assets/0713f519-1981-4f3b-838c-ef135d1adbad" />

## Fix

`RatingQuestionField`:
- Container: `grid grid-cols-3 md:grid-cols-5` → `flex flex-wrap gap-3`
- Chips: `h-10` → `min-h-10`, add `grow basis-auto` (width follows content) and `px-3 py-1.5` (breathing room)
- Label: add `leading-tight`

Each chip now grows just enough to fit its label on one line; when they don't all fit, they wrap to the next row **instead of getting taller or clipping**. Uniform 38px height across all chips. Purely presentational — no text or language in the component, so it works for any label in any locale.

## Verification (Storybook, live DOM measurement)

Added a `Rating Long Labels` story reproducing the reported case (existing rating stories only used single-digit `"1"–"5"` labels, which is why this slipped through).

- **Desktop:** all 5 options fit one row, each single-line, all 38px tall, widths adapt to content.
- **Mobile (380px):** options wrap across rows, still single-line, still uniform 38px — no clipping, no taller boxes.

## Scope

Two files: `RatingQuestionField.tsx` (the fix) + `SurveyAnsweringForm.stories.tsx` (regression story). No API/behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
