### PR TITLE
feat(Card): default the header link to a ghost appearance

### DIFF
--- a/packages/react/src/ui/Card/Card.tsx
+++ b/packages/react/src/ui/Card/Card.tsx
@@ -147,9 +147,9 @@ const CardLink = React.forwardRef<
 >(({ className, title, icon = ChevronRight, href, ...rest }, ref) => {
   const sharedClassName = cn(
     "group inline-flex aspect-square h-6 items-center justify-center gap-1", //layout
-    "rounded-sm border border-solid border-f1-border bg-f1-background-inverse-secondary dark:bg-f1-background-tertiary", //appearance
+    "rounded-sm border border-solid border-transparent bg-transparent", //appearance
     "whitespace-nowrap px-0 text-base font-medium text-f1-foreground", //typography
-    "cursor-pointer transition-colors hover:border-f1-border-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-f1-special-ring focus-visible:ring-offset-1", //interaction
+    "cursor-pointer transition-colors hover:bg-f1-background-secondary-hover focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-f1-special-ring focus-visible:ring-offset-1", //interaction
     className
   )
   const iconElement = (

--- a/packages/react/src/ui/Card/__tests__/Card.test.tsx
+++ b/packages/react/src/ui/Card/__tests__/Card.test.tsx
@@ -162,6 +162,14 @@ describe("Card Components", () => {
       const el = screen.getByLabelText("Navigate")
       expect(el.tagName).not.toBe("BUTTON")
     })
+
+    it("uses a ghost appearance by default (transparent, no border, fills on hover)", () => {
+      renderWithWrapper(<CardLink title="Ghost" icon={ChevronRight} />)
+      const el = screen.getByLabelText("Ghost")
+      expect(el).toHaveClass("bg-transparent", "border-transparent")
+      expect(el).toHaveClass("hover:bg-f1-background-secondary-hover")
+      expect(el).not.toHaveClass("bg-f1-background-inverse-secondary")
+    })
   })
 
   describe("CardComment", () => {


### PR DESCRIPTION
## What

Changes the default appearance of `CardLink` (the widget-header link, top-right of every `Widget`) from a boxed control to a ghost icon button.

| | Before | After |
|---|---|---|
| background | `bg-f1-background-inverse-secondary` (dark: `bg-f1-background-tertiary`) | `bg-transparent` |
| border | `border-f1-border` | `border-transparent` |
| hover | `hover:border-f1-border-hover` | `hover:bg-f1-background-secondary-hover` |

Size, layout, typography, focus ring and the icon are unchanged, so the button does not move or resize.

## Why

The boxed style reads as a chip; a ghost affordance is the intended treatment for the subtle top-right action on widget headers.

## Scope

`CardLink` is shared, so this updates the default for **every** widget header link across f0-react (intentional).

## Tests

Adds a `CardLink` unit test asserting the ghost defaults (`bg-transparent`, `border-transparent`, `hover:bg-f1-background-secondary-hover`, and absence of the old fill). Full `Card` suite passes (17/17). Chromatic will cover the visual diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)