### PR TITLE
chore(storybook): [FCT-59727] extend axe coverage to WCAG 2.2 A/AA

### DIFF
--- a/packages/react/.storybook/test-runner.ts
+++ b/packages/react/.storybook/test-runner.ts
@@ -77,7 +77,17 @@ const config: TestRunnerConfig = {
       const violations = await getViolations(page, "#storybook-root", {
         runOnly: {
           type: "tag",
-          values: ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"],
+          // WCAG 2.0, 2.1 and 2.2 at levels A and AA — matches the Plexus
+          // audit scope (UNE-EN 301549 + WCAG 2.1/2.2). AAA and axe's
+          // non-normative best-practice rules are intentionally excluded.
+          values: [
+            "wcag2a",
+            "wcag2aa",
+            "wcag21a",
+            "wcag21aa",
+            "wcag22a",
+            "wcag22aa",
+          ],
         },
       })
 


### PR DESCRIPTION
## Description

https://factorialmakers.atlassian.net/browse/FCT-59727

Extends the Storybook a11y test-runner's axe scope to include **WCAG 2.2 Level A and AA**, alongside the 2.0 and 2.1 A/AA rules it already checks. This aligns the automated gate with the Plexus audit scope (UNE-EN 301549 + WCAG 2.1/2.2). Level AAA and axe's non-normative `best-practice` rules remain intentionally excluded.

## Implementation details

- feat: add `wcag22a` and `wcag22aa` to the `runOnly` tag filter in `.storybook/test-runner.ts`

  <details>
  <summary>Impact & safety</summary>

  - WCAG 2.2 adds success criteria that axe can check, e.g. **2.5.8 Target Size (Minimum)**, **2.5.7 Dragging Movements**, **2.4.11 Focus Not Obscured**, **3.3.7 Redundant Entry** — small controls and overlap issues are the likely new findings.
  - The global a11y mode is `test: "todo"` (`preview.tsx`) and no story on main opts into `test: "error"`, so every newly-detected 2.2 violation is a **non-blocking warning** — CI stays green. This PR only *widens what axe looks at*; it does not make anything fail.
  - The new findings surface as warnings (in the job summary once #4772's summary emitter lands, or in the Storybook Tests log meanwhile), giving a WCAG-2.2 debt baseline to burn down alongside the existing 2.1 work.

  Note: stories currently skipped via the a11y allowlist are still skipped, so this measures 2.2 debt only across stories axe already runs on — a lower bound until those files are de-listed.
  </details>

## Verification

- oxlint clean.
- CI (`Storybook Tests`) **green**: 346/346 suites, 2048 tests pass — the widened scope adds warnings, fails nothing.

## Measured 2.2 baseline (from this PR's CI run)

Widening to 2.2 surfaced exactly **one** new axe rule: **`target-size`** (WCAG 2.2 SC 2.5.8, "touch targets have sufficient size and space"). No other 2.2 rule fired — as expected, since `target-size` is essentially the only 2.2 A/AA criterion axe can auto-detect (focus-not-obscured, dragging, redundant-entry, accessible-auth need manual testing). All findings are non-blocking `todo` warnings.

Components with `target-size` findings (the new 2.2 debt to burn down):

| Story | 
|---|
| `patterns-data-collection-empty-state--empty-to-data-example` |
| `resources-utilities-gridstack--default` |
| `patterns-graph-f0graph--initial-focus` |
| `components-cardselectable--with-selected-content` |
| `components-card--snapshot` |

**Interaction with the enforcement ladder:** the PRs that flip components to `test: "error"` — #4738 (Select) and #4764 (SurveyFormBuilder) — are **clean of `target-size`** (verified: none of the `components-select`, internal `ui/Select`, or `surveyformbuilder` stories appear in the findings), so they stay green under 2.2 scope. Rebase them after this lands to re-confirm. Any *future* ladder PR flipping one of the 5 components above to `error` must fix `target-size` first — which is the intended effect: enforcing a component now means AA including 2.2.

Note: allowlist-skipped stories still don't run axe, so this is a lower bound until those files are de-listed.
