### PR TITLE
feat(OneDataCollection): add programmatic nested-table expansion control

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.mdx
@@ -775,3 +775,124 @@ shown at the end of the expanded children. When clicked:
 ```
 
 <Canvas of={TableStories.TableWithMixedNestedRecords} meta={TableStories} />
+
+### Programmatic Expansion Control
+
+Expansion of nested rows can be controlled programmatically through the
+`nested` option of the table visualization. It supports declarative
+auto-expansion on mount, an imperative controller for runtime operations,
+control over how children pages are loaded, and expand animations.
+
+```tsx
+{
+  type: "table",
+  options: {
+    columns: [...],
+    nested: {
+      defaultExpanded: 1,                // boolean | depth number | predicate
+      defaultExpandedChildren: "all",    // "paginated" (default) | "all"
+      control: nestedTable,              // from useNestedTable()
+      expandAnimation: "stagger",        // "none" (default) | "fade" | "stagger" | "slide" | "pop"
+      onExpandedChange: ({ item, depth, expanded }) => { ... },
+    },
+  },
+}
+```
+
+`onExpandedChange` fires when a row's expansion changes explicitly — via user
+interaction or a targeted controller operation (`expand`, `collapse`,
+`toggle`) — and is not called for policy-based auto-expansion
+(`defaultExpanded`, `expandAll`, `collapseAll`).
+
+#### Declarative auto-expansion: `defaultExpanded`
+
+Evaluated when the table mounts, and re-evaluated for rows revealed later by
+lazy loading — so a policy cascades naturally through a tree that loads on
+demand:
+
+- `true` — expand every row at every depth
+- `number` — expand rows whose depth is lower than the value: `1` expands
+  root rows (2 visible levels), `2` also expands their children, etc.
+- `(context: { item, depth }) => boolean` — any practical criteria, e.g.
+  expand a specific branch or rows matching a business rule
+
+```tsx
+// Expand the first two levels
+nested: { defaultExpanded: 2 }
+
+// Expand only the Engineering branch
+nested: {
+  defaultExpanded: (ctx) => ctx.depth === 0 || ctx.item.id.startsWith("engineering"),
+}
+```
+
+#### Children load mode: "show more" vs eager loading
+
+By default expanded rows keep their children paginated behind a "show more"
+row. Set `defaultExpandedChildren: "all"` (or `children: "all"` on controller
+operations) to fetch every page eagerly so the subtree is fully visible. Eager
+loading is guarded by the reported `total` and a page cap, so a misbehaving
+adapter cannot cause an infinite fetch loop.
+
+#### Imperative controller: `useNestedTable`
+
+Create a controller with `useNestedTable()` and pass it via
+`options.nested.control`. Operations invoked before the table mounts are
+queued and applied once it is ready.
+
+```tsx
+const nestedTable = useNestedTable<OrgNode>()
+
+nestedTable.expandAll() // whole tree
+nestedTable.expandAll({ depth: 2 }) // first two levels
+nestedTable.expandAll({
+  where: (ctx) => ctx.item.type === "folder", // criteria-based
+  children: "all", // and load all their pages
+})
+nestedTable.expand("node-42", { children: "all" }) // by item id
+nestedTable.collapse((ctx) => ctx.depth > 1) // by predicate
+nestedTable.toggle("node-42")
+nestedTable.expandTo(["dept-2", "team-21"]) // reveal a deep node by its id path
+nestedTable.collapseAll()
+nestedTable.isExpanded("node-42")
+nestedTable.getExpandedItems()
+```
+
+`expand`, `collapse` and `toggle` target rows by item `id` or with a
+predicate, and apply to the rows currently rendered. `expandAll` installs a
+policy that also applies to rows revealed later, and an explicit `collapse`
+always wins over an active policy.
+
+`expandTo` expands a specific path of item ids (ancestor → descendant)
+without touching the rest of the tree. Ids not rendered yet stay pending and
+are expanded as soon as lazy loading reveals them, so a single call is enough
+to reach a node buried under collapsed, not-yet-loaded ancestors.
+
+<Canvas of={TableStories.TableNestedProgrammaticControl} meta={TableStories} />
+
+#### Auto-expand examples
+
+Expand the first level on mount, keeping children paginated:
+
+<Canvas of={TableStories.TableNestedAutoExpandFirstLevel} meta={TableStories} />
+
+Expand a branch matching a criteria, loading all its pages eagerly:
+
+<Canvas of={TableStories.TableNestedAutoExpandCriteria} meta={TableStories} />
+
+#### Expand animations
+
+`expandAnimation` animates the mount of the rows revealed on expansion:
+
+- `"fade"` — all revealed rows fade in at once
+- `"stagger"` — rows fade in and settle downwards one after another
+- `"slide"` — rows slide in from the left with a soft spring, sequentially
+- `"pop"` — rows scale up into place with a springy pop, sequentially
+
+Sequenced animations stagger by sibling index and depth, so even when a
+cached subtree mounts in a single pass (re-expanding already-loaded data)
+the reveal still cascades level by level. All animations are GPU-composited
+(`opacity`/`transform` only), collapse stays instant, and every mode
+respects `prefers-reduced-motion`.
+
+<Canvas of={TableStories.TableNestedExpandAnimation} meta={TableStories} />

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -8,9 +8,19 @@ import {
   CompoundTone,
 } from "@/ui/value-display/types/compound"
 
+import { ChildrenPaginationInfo } from "@/hooks/datasource/types/nested.typings"
+
 import { ExampleComponent, getMockVisualizations } from "../../mockData"
 import { useDataCollectionSource } from "../../../hooks/useDataCollectionSource"
 import { OneDataCollection } from "../../../index"
+import {
+  NestedChildrenDisplayMode,
+  nestedChildrenDisplayModes,
+  NestedExpandAnimation,
+  nestedExpandAnimations,
+  NestedTableOptions,
+  useNestedTable,
+} from "../../../visualizations/collection/Table/nested"
 
 const meta = {
   title: "Data Collection/Visualizations/Table",
@@ -884,6 +894,475 @@ export const WithColumnAddRemove: Story = {
               },
             },
           ]}
+        />
+      </div>
+    )
+  },
+}
+
+/**
+ * Nested tables — programmatic expansion control
+ * ------------------------------------------------------------------
+ * The stories below share an org-chart dataset (departments → teams →
+ * squads → members) with unique ids and real children pagination, so the
+ * "show more" vs "load all" behaviors can be exercised.
+ */
+
+type OrgNode = {
+  id: string
+  name: string
+  role: string
+  children?: OrgNode[]
+}
+
+const ORG_MEMBER_NAMES = [
+  "Ana García",
+  "Liam Chen",
+  "Maya Patel",
+  "Noah Kim",
+  "Sara López",
+  "Tom Becker",
+  "Zoe Martin",
+  "Iris Novak",
+]
+
+const buildOrgMembers = (
+  parentId: string,
+  count: number,
+  role: string
+): OrgNode[] =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `${parentId}.member-${index + 1}`,
+    name: ORG_MEMBER_NAMES[index % ORG_MEMBER_NAMES.length],
+    role,
+  }))
+
+const orgTree: OrgNode[] = [
+  {
+    id: "engineering",
+    name: "Engineering",
+    role: "Department",
+    children: [
+      {
+        id: "engineering.platform",
+        name: "Platform",
+        role: "Team",
+        children: [
+          {
+            id: "engineering.platform.core",
+            name: "Core Squad",
+            role: "Squad",
+            children: buildOrgMembers(
+              "engineering.platform.core",
+              7,
+              "Backend Engineer"
+            ),
+          },
+          {
+            id: "engineering.platform.infra",
+            name: "Infra Squad",
+            role: "Squad",
+            children: buildOrgMembers(
+              "engineering.platform.infra",
+              5,
+              "Site Reliability Engineer"
+            ),
+          },
+        ],
+      },
+      {
+        id: "engineering.frontend",
+        name: "Frontend",
+        role: "Team",
+        children: [
+          {
+            id: "engineering.frontend.web",
+            name: "Web Squad",
+            role: "Squad",
+            children: buildOrgMembers(
+              "engineering.frontend.web",
+              6,
+              "Frontend Engineer"
+            ),
+          },
+          {
+            id: "engineering.frontend.ds",
+            name: "Design Systems Squad",
+            role: "Squad",
+            children: buildOrgMembers(
+              "engineering.frontend.ds",
+              4,
+              "UI Engineer"
+            ),
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: "product",
+    name: "Product",
+    role: "Department",
+    children: [
+      {
+        id: "product.discovery",
+        name: "Discovery",
+        role: "Team",
+        children: buildOrgMembers("product.discovery", 5, "Product Manager"),
+      },
+      {
+        id: "product.growth",
+        name: "Growth",
+        role: "Team",
+        children: buildOrgMembers("product.growth", 8, "Growth Manager"),
+      },
+    ],
+  },
+  {
+    id: "design",
+    name: "Design",
+    role: "Department",
+    children: buildOrgMembers("design", 6, "Product Designer"),
+  },
+]
+
+const countOrgDescendants = (node: OrgNode): number =>
+  node.children?.reduce(
+    (total, child) => total + 1 + countOrgDescendants(child),
+    0
+  ) ?? 0
+
+const ORG_CHILDREN_PER_PAGE = 3
+
+const useOrgTreeSource = () =>
+  useDataCollectionSource({
+    dataAdapter: {
+      fetchData: async () => ({ records: orgTree }),
+    },
+    itemsWithChildren: (item: OrgNode) => !!item.children?.length,
+    childrenCount: ({ item }: { item: OrgNode }) => item.children?.length,
+    fetchChildren: async ({
+      item,
+      pagination,
+    }: {
+      item: OrgNode
+      pagination?: ChildrenPaginationInfo
+    }) => {
+      await new Promise((resolve) => setTimeout(resolve, 400))
+      const all = item.children ?? []
+      const currentPage = (pagination?.currentPage ?? 0) + 1
+      const start = (currentPage - 1) * ORG_CHILDREN_PER_PAGE
+      return {
+        records: all.slice(start, start + ORG_CHILDREN_PER_PAGE),
+        paginationInfo: {
+          total: all.length,
+          perPage: ORG_CHILDREN_PER_PAGE,
+          currentPage,
+          pagesCount: Math.ceil(all.length / ORG_CHILDREN_PER_PAGE),
+          hasMore: currentPage * ORG_CHILDREN_PER_PAGE < all.length,
+        },
+      }
+    },
+  })
+
+const orgColumns = [
+  {
+    id: "name",
+    label: "Name",
+    width: 320,
+    render: (item: OrgNode) => item.name,
+  },
+  { id: "role", label: "Role", render: (item: OrgNode) => item.role },
+  {
+    id: "people",
+    label: "People",
+    render: (item: OrgNode) => {
+      const descendants = countOrgDescendants(item)
+      return descendants > 0 ? String(descendants) : "—"
+    },
+  },
+]
+
+const OrgNestedTable = ({
+  nested,
+}: {
+  nested?: NestedTableOptions<OrgNode>
+}) => {
+  const source = useOrgTreeSource()
+
+  return (
+    <OneDataCollection
+      source={source}
+      visualizations={[
+        {
+          type: "table",
+          options: { columns: orgColumns, nested },
+        },
+      ]}
+    />
+  )
+}
+
+const NestedDemoSection = ({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) => (
+  <div className="flex flex-col gap-1" role="group" aria-label={title}>
+    <span className="text-sm font-medium text-f1-foreground">{title}</span>
+    <div className="flex flex-wrap items-center gap-2">{children}</div>
+  </div>
+)
+
+/**
+ * Full playground for the programmatic API: create a controller with
+ * `useNestedTable()`, pass it via `options.nested.control` and drive the
+ * tree from anywhere. The toolbar also switches the children load mode
+ * ("show more" vs eager) and the expand animation at runtime, and can reset
+ * the table (and its children cache) back to its initial state.
+ */
+export const TableNestedProgrammaticControl: Story = {
+  render: function Render() {
+    const nestedTable = useNestedTable<OrgNode>()
+    const [childrenMode, setChildrenMode] =
+      useState<NestedChildrenDisplayMode>("paginated")
+    const [expandAnimation, setExpandAnimation] =
+      useState<NestedExpandAnimation>("stagger")
+    const [lastEvent, setLastEvent] = useState("—")
+    const [resetKey, setResetKey] = useState(0)
+
+    return (
+      <div className="flex flex-col gap-4">
+        <NestedDemoSection title="Bulk expansion (expandAll / collapseAll)">
+          <F0Button
+            size="sm"
+            label="Expand all"
+            onClick={() => nestedTable.expandAll({ children: childrenMode })}
+          />
+          <F0Button
+            size="sm"
+            label="Expand 1 level"
+            onClick={() =>
+              nestedTable.expandAll({ depth: 1, children: childrenMode })
+            }
+          />
+          <F0Button
+            size="sm"
+            label="Expand 2 levels"
+            onClick={() =>
+              nestedTable.expandAll({ depth: 2, children: childrenMode })
+            }
+          />
+          <F0Button
+            size="sm"
+            variant="critical"
+            label="Collapse all"
+            onClick={() => nestedTable.collapseAll()}
+          />
+        </NestedDemoSection>
+        <NestedDemoSection title="Targeted operations (expand / toggle / expandTo)">
+          <F0Button
+            size="sm"
+            variant="outline"
+            label="Expand Engineering branch (all pages)"
+            onClick={() =>
+              nestedTable.expandAll({
+                where: (ctx) => ctx.item.id.startsWith("engineering"),
+                children: "all",
+              })
+            }
+          />
+          <F0Button
+            size="sm"
+            variant="outline"
+            label="Toggle Platform team"
+            onClick={() => nestedTable.toggle("engineering.platform")}
+          />
+          <F0Button
+            size="sm"
+            variant="outline"
+            label="Reveal Core Squad (expandTo)"
+            onClick={() =>
+              nestedTable.expandTo(
+                [
+                  "engineering",
+                  "engineering.platform",
+                  "engineering.platform.core",
+                ],
+                { children: childrenMode }
+              )
+            }
+          />
+        </NestedDemoSection>
+        <div className="flex flex-wrap items-start gap-4">
+          <NestedDemoSection title="Children load mode">
+            {nestedChildrenDisplayModes.map((mode) => (
+              <F0Button
+                key={mode}
+                size="sm"
+                variant={childrenMode === mode ? "default" : "outline"}
+                label={mode === "paginated" ? "Show more" : "Load all"}
+                onClick={() => setChildrenMode(mode)}
+              />
+            ))}
+          </NestedDemoSection>
+          <NestedDemoSection title="Expand animation">
+            {nestedExpandAnimations.map((animation) => (
+              <F0Button
+                key={animation}
+                size="sm"
+                variant={expandAnimation === animation ? "default" : "outline"}
+                label={animation}
+                onClick={() => setExpandAnimation(animation)}
+              />
+            ))}
+          </NestedDemoSection>
+          <NestedDemoSection title="Table state">
+            <F0Button
+              size="sm"
+              variant="outline"
+              label="Reset to initial state"
+              onClick={() => {
+                setResetKey((key) => key + 1)
+                setLastEvent("—")
+              }}
+            />
+            <span
+              role="status"
+              className="text-sm text-f1-foreground-secondary"
+            >
+              Last change: {lastEvent}
+            </span>
+          </NestedDemoSection>
+        </div>
+        <OrgNestedTable
+          key={resetKey}
+          nested={{
+            control: nestedTable,
+            expandAnimation,
+            onExpandedChange: ({ item, depth, expanded }) =>
+              setLastEvent(
+                `${item.name} (depth ${depth}) → ${expanded ? "expanded" : "collapsed"}`
+              ),
+          }}
+        />
+      </div>
+    )
+  },
+}
+
+/**
+ * Declarative auto-expansion: `defaultExpanded: 1` opens every root row on
+ * mount (2 visible levels). Children keep their "show more" pagination.
+ */
+export const TableNestedAutoExpandFirstLevel: Story = {
+  render: () => <OrgNestedTable nested={{ defaultExpanded: 1 }} />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    // The defaultExpanded: 1 policy expands root rows, revealing depth-1 rows
+    await canvas.findByText("Platform")
+    await canvas.findByText("Discovery")
+    // …but depth-1 rows stay collapsed, so their children are not rendered
+    expect(canvas.queryByText("Core Squad")).toBeNull()
+  },
+}
+
+/**
+ * Criteria-based auto-expansion: a predicate receives `{ item, depth }`, so
+ * any practical rule works — here every root department is expanded and the
+ * whole Engineering branch is expanded with its children pages loaded
+ * eagerly (no "show more" rows), while deeper levels outside Engineering
+ * stay collapsed.
+ */
+export const TableNestedAutoExpandCriteria: Story = {
+  render: function Render() {
+    const [resetKey, setResetKey] = useState(0)
+
+    return (
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-wrap items-center gap-2">
+          <F0Button
+            size="sm"
+            variant="outline"
+            label="Reset to initial state"
+            onClick={() => setResetKey((key) => key + 1)}
+          />
+        </div>
+        <OrgNestedTable
+          key={resetKey}
+          nested={{
+            defaultExpanded: (ctx) =>
+              ctx.depth === 0 || ctx.item.id.startsWith("engineering"),
+            defaultExpandedChildren: "all",
+          }}
+        />
+      </div>
+    )
+  },
+}
+
+/**
+ * Expand animations: `"fade"` reveals all rows at once, while `"stagger"`,
+ * `"slide"` and `"pop"` sequence them by sibling index and depth — so a
+ * cached subtree still cascades level by level. Collapse stays instant and
+ * `prefers-reduced-motion` disables every mode. Use the toolbar to switch
+ * modes, replay the animation on cached data (Collapse all → Expand all),
+ * or reset the table (clearing the children cache).
+ */
+export const TableNestedExpandAnimation: Story = {
+  render: function Render() {
+    const nestedTable = useNestedTable<OrgNode>()
+    const [expandAnimation, setExpandAnimation] =
+      useState<NestedExpandAnimation>("stagger")
+    const [resetKey, setResetKey] = useState(0)
+
+    return (
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-wrap items-center gap-4">
+          <div
+            className="flex items-center gap-2"
+            role="group"
+            aria-label="Expand animation"
+          >
+            {nestedExpandAnimations.map((animation) => (
+              <F0Button
+                key={animation}
+                size="sm"
+                variant={expandAnimation === animation ? "default" : "outline"}
+                label={animation}
+                onClick={() => setExpandAnimation(animation)}
+              />
+            ))}
+          </div>
+          <div className="flex items-center gap-2">
+            <F0Button
+              size="sm"
+              label="Expand all"
+              onClick={() => nestedTable.expandAll()}
+            />
+            <F0Button
+              size="sm"
+              variant="outline"
+              label="Collapse all"
+              onClick={() => nestedTable.collapseAll()}
+            />
+            <F0Button
+              size="sm"
+              variant="outline"
+              label="Reset to initial state"
+              onClick={() => setResetKey((key) => key + 1)}
+            />
+          </div>
+        </div>
+        <OrgNestedTable
+          key={resetKey}
+          nested={{
+            control: nestedTable,
+            defaultExpanded: 1,
+            expandAnimation,
+          }}
         />
       </div>
     )

--- a/packages/react/src/patterns/OneDataCollection/exports.ts
+++ b/packages/react/src/patterns/OneDataCollection/exports.ts
@@ -13,6 +13,7 @@ export * from "./hooks/useDataCollectionItemNavigation"
 export * from "./hooks/useDataCollectionSource"
 export * from "./hooks/useInfiniteScrollPagination"
 export { useExportAction } from "./hooks/useExportAction"
+export * from "./visualizations/collection/Table/nested"
 export { downloadAsCSV, generateCSVContent } from "./utils/csvExport"
 export type { CSVExportOptions } from "./utils/csvExport"
 export type {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -115,6 +115,7 @@ export const TableCollection = <
   visualizationSettings,
   fromVisualization = "table",
   summaryPlaceholder = "-",
+  nested,
 }: CollectionProps<
   R,
   Filters,
@@ -392,11 +393,9 @@ export const TableCollection = <
       ? i18n.status.selected.singular
       : i18n.status.selected.plural
 
-  const TableWrapper = tableWithChildren ? NestedDataProvider : Fragment
-
   return (
     <div className="flex h-full min-h-0 flex-col gap-4">
-      <TableWrapper>
+      <NestedDataProvider nested={nested}>
         <div
           className={cn(
             bordered &&
@@ -994,7 +993,7 @@ export const TableCollection = <
           setPage={setPage}
           className="pb-4"
         />
-      </TableWrapper>
+      </NestedDataProvider>
     </div>
   )
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/NestedExpansionControl.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/NestedExpansionControl.test.tsx
@@ -1,0 +1,631 @@
+import { act, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { useMemo, useState } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import type { GroupingDefinition, SortingsDefinition } from "@/hooks/datasource"
+
+import { FiltersDefinition } from "@/hooks/datasource"
+import { ChildrenPaginationInfo } from "@/hooks/datasource/types/nested.typings"
+import { zeroRender as render } from "@/testing/test-utils"
+import { TextCell } from "@/ui/value-display/types/text"
+
+import { DataCollectionSource } from "../../../../hooks/useDataCollectionSource/types"
+import { ItemActionsDefinition } from "../../../../item-actions"
+import { NavigationFiltersDefinition } from "../../../../navigationFilters/types"
+import { SummariesDefinition } from "../../../../summary"
+import { TableCollection } from "../index"
+import { useNestedTable } from "../nested"
+import {
+  matchesExpansionCriteria,
+  NestedTableController,
+  NestedTableOptions,
+} from "../nested/types"
+
+vi.mock("../../property", () => ({
+  propertyRenderers: {
+    text: TextCell,
+  },
+}))
+
+class MockIntersectionObserver implements IntersectionObserver {
+  root: Document | Element | null = null
+  rootMargin = ""
+  thresholds: readonly number[] = []
+  disconnect = vi.fn()
+  observe = vi.fn()
+  takeRecords = vi.fn()
+  unobserve = vi.fn()
+}
+window.IntersectionObserver = MockIntersectionObserver
+
+type Person = { id: string; name: string; children?: Person[] }
+
+const tree: Person[] = [
+  {
+    id: "p1",
+    name: "Parent One",
+    children: [
+      {
+        id: "c1",
+        name: "Child One",
+        children: [
+          { id: "g1", name: "Grandchild One" },
+          { id: "g2", name: "Grandchild Two" },
+        ],
+      },
+      { id: "c2", name: "Child Two" },
+    ],
+  },
+  {
+    id: "p2",
+    name: "Parent Two",
+    children: [
+      { id: "c3", name: "Child Three" },
+      { id: "c4", name: "Child Four" },
+      { id: "c5", name: "Child Five" },
+      { id: "c6", name: "Child Six" },
+    ],
+  },
+]
+
+const CHILDREN_PER_PAGE = 2
+
+const columns = [{ label: "name", render: (item: Person) => item.name }]
+
+const createSource = (): DataCollectionSource<
+  Person,
+  FiltersDefinition,
+  SortingsDefinition,
+  SummariesDefinition,
+  ItemActionsDefinition<Person>,
+  NavigationFiltersDefinition,
+  GroupingDefinition<Person>
+> =>
+  ({
+    currentFilters: {},
+    setCurrentFilters: vi.fn(),
+    currentSortings: null,
+    setCurrentSortings: vi.fn(),
+    currentNavigationFilters: {},
+    setCurrentNavigationFilters: vi.fn(),
+    navigationFilters: undefined,
+    currentSearch: undefined,
+    debouncedCurrentSearch: undefined,
+    setCurrentSearch: vi.fn(),
+    isLoading: false,
+    setIsLoading: vi.fn(),
+    currentGrouping: undefined,
+    setCurrentGrouping: vi.fn(),
+    itemsWithChildren: (item: Person) => !!item.children?.length,
+    childrenCount: ({ item }: { item: Person }) => item.children?.length,
+    fetchChildren: ({
+      item,
+      pagination,
+    }: {
+      item: Person
+      pagination?: ChildrenPaginationInfo
+    }) => {
+      const all = item.children ?? []
+      const currentPage = (pagination?.currentPage ?? 0) + 1
+      const start = (currentPage - 1) * CHILDREN_PER_PAGE
+      return {
+        records: all.slice(start, start + CHILDREN_PER_PAGE),
+        paginationInfo: {
+          total: all.length,
+          perPage: CHILDREN_PER_PAGE,
+          currentPage,
+          pagesCount: Math.ceil(all.length / CHILDREN_PER_PAGE),
+          hasMore: currentPage * CHILDREN_PER_PAGE < all.length,
+        },
+      }
+    },
+    dataAdapter: {
+      fetchData: async () => ({ records: tree }),
+    },
+  }) as unknown as DataCollectionSource<
+    Person,
+    FiltersDefinition,
+    SortingsDefinition,
+    SummariesDefinition,
+    ItemActionsDefinition<Person>,
+    NavigationFiltersDefinition,
+    GroupingDefinition<Person>
+  >
+
+type TestSource = ReturnType<typeof createSource>
+
+const NestedTableHarness = ({
+  nested,
+  onControl,
+  sourceOverrides,
+}: {
+  nested?: Omit<NestedTableOptions<Person>, "control">
+  onControl?: (control: NestedTableController<Person>) => void
+  sourceOverrides?: Partial<TestSource>
+}) => {
+  const control = useNestedTable<Person>()
+  onControl?.(control)
+
+  return (
+    <TableCollection<
+      Person,
+      FiltersDefinition,
+      SortingsDefinition,
+      SummariesDefinition,
+      ItemActionsDefinition<Person>,
+      NavigationFiltersDefinition,
+      GroupingDefinition<Person>
+    >
+      columns={columns}
+      source={{ ...createSource(), ...sourceOverrides }}
+      onSelectItems={vi.fn()}
+      onLoadData={vi.fn()}
+      onLoadError={vi.fn()}
+      nested={{ ...nested, control }}
+    />
+  )
+}
+
+const renderNestedTable = (
+  nested?: Omit<NestedTableOptions<Person>, "control">,
+  sourceOverrides?: Partial<TestSource>
+) => {
+  let control!: NestedTableController<Person>
+  render(
+    <NestedTableHarness
+      nested={nested}
+      sourceOverrides={sourceOverrides}
+      onControl={(c) => {
+        control = c
+      }}
+    />
+  )
+  return {
+    get control() {
+      return control
+    },
+  }
+}
+
+/**
+ * Harness with mutable filters, to exercise the expansion reset that happens
+ * when the source filters change.
+ */
+const FilterableHarness = ({
+  nested,
+  onApi,
+}: {
+  nested?: Omit<NestedTableOptions<Person>, "control">
+  onApi: (api: {
+    control: NestedTableController<Person>
+    setFilters: (filters: Record<string, unknown>) => void
+  }) => void
+}) => {
+  const [filters, setFilters] = useState<Record<string, unknown>>({})
+  const control = useNestedTable<Person>()
+  const source = useMemo(
+    () => ({ ...createSource(), currentFilters: filters }),
+    [filters]
+  )
+  onApi({ control, setFilters })
+
+  return (
+    <TableCollection<
+      Person,
+      FiltersDefinition,
+      SortingsDefinition,
+      SummariesDefinition,
+      ItemActionsDefinition<Person>,
+      NavigationFiltersDefinition,
+      GroupingDefinition<Person>
+    >
+      columns={columns}
+      source={source}
+      onSelectItems={vi.fn()}
+      onLoadData={vi.fn()}
+      onLoadError={vi.fn()}
+      nested={{ ...nested, control }}
+    />
+  )
+}
+
+const waitForRootRows = async () => {
+  await waitFor(() => {
+    expect(screen.getByText("Parent One")).toBeInTheDocument()
+    expect(screen.getByText("Parent Two")).toBeInTheDocument()
+  })
+}
+
+const clickFirstChevron = async (user: ReturnType<typeof userEvent.setup>) => {
+  const chevron = document.querySelector(
+    ".lucide-chevron-right, .lucide-chevron-down"
+  )
+  expect(chevron).not.toBeNull()
+  await user.click(chevron as Element)
+}
+
+describe("matchesExpansionCriteria", () => {
+  const context = { item: { id: "x" }, depth: 1 }
+
+  it("resolves booleans, depth numbers and predicates", () => {
+    expect(matchesExpansionCriteria(undefined, context)).toBe(false)
+    expect(matchesExpansionCriteria(true, context)).toBe(true)
+    expect(matchesExpansionCriteria(false, context)).toBe(false)
+    expect(matchesExpansionCriteria(1, context)).toBe(false)
+    expect(matchesExpansionCriteria(2, context)).toBe(true)
+    expect(matchesExpansionCriteria((ctx) => ctx.depth === 1, context)).toBe(
+      true
+    )
+  })
+})
+
+describe("Nested table expansion control", () => {
+  describe("defaultExpanded policy", () => {
+    it("auto-expands every level with `true`, cascading through lazy loading", async () => {
+      renderNestedTable({ defaultExpanded: true })
+      await waitForRootRows()
+
+      await waitFor(() => {
+        expect(screen.getByText("Child One")).toBeInTheDocument()
+        expect(screen.getByText("Grandchild One")).toBeInTheDocument()
+      })
+    })
+
+    it("expands only up to the given depth with a number", async () => {
+      renderNestedTable({ defaultExpanded: 1 })
+      await waitForRootRows()
+
+      await waitFor(() => {
+        expect(screen.getByText("Child One")).toBeInTheDocument()
+      })
+      expect(screen.queryByText("Grandchild One")).not.toBeInTheDocument()
+    })
+
+    it("expands only rows matching a predicate", async () => {
+      renderNestedTable({
+        defaultExpanded: (ctx) => ctx.item.id === "p2",
+      })
+      await waitForRootRows()
+
+      await waitFor(() => {
+        expect(screen.getByText("Child Three")).toBeInTheDocument()
+      })
+      expect(screen.queryByText("Child One")).not.toBeInTheDocument()
+    })
+
+    it("leaves extra pages behind show-more by default, but loads them all with `defaultExpandedChildren: 'all'`", async () => {
+      renderNestedTable({
+        defaultExpanded: (ctx) => ctx.item.id === "p2",
+      })
+      await waitFor(() => {
+        expect(screen.getByText("Child Three")).toBeInTheDocument()
+      })
+      // Paginated: only the first page is visible
+      expect(screen.queryByText("Child Five")).not.toBeInTheDocument()
+    })
+
+    it("loads every page eagerly with `defaultExpandedChildren: 'all'`", async () => {
+      renderNestedTable({
+        defaultExpanded: (ctx) => ctx.item.id === "p2",
+        defaultExpandedChildren: "all",
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText("Child Five")).toBeInTheDocument()
+        expect(screen.getByText("Child Six")).toBeInTheDocument()
+      })
+    })
+  })
+
+  describe("useNestedTable controller", () => {
+    it("expandAll/collapseAll expand and collapse the whole tree", async () => {
+      const table = renderNestedTable()
+      await waitForRootRows()
+      expect(screen.queryByText("Child One")).not.toBeInTheDocument()
+
+      act(() => table.control.expandAll())
+      await waitFor(() => {
+        expect(screen.getByText("Child One")).toBeInTheDocument()
+        expect(screen.getByText("Grandchild One")).toBeInTheDocument()
+      })
+
+      act(() => table.control.collapseAll())
+      await waitFor(() => {
+        expect(screen.queryByText("Child One")).not.toBeInTheDocument()
+      })
+    })
+
+    it("expandAll honors depth and where criteria", async () => {
+      const table = renderNestedTable()
+      await waitForRootRows()
+
+      act(() =>
+        table.control.expandAll({
+          depth: 1,
+          where: (ctx) => ctx.item.id === "p1",
+        })
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText("Child One")).toBeInTheDocument()
+      })
+      expect(screen.queryByText("Grandchild One")).not.toBeInTheDocument()
+      expect(screen.queryByText("Child Three")).not.toBeInTheDocument()
+    })
+
+    it("expands a single row by id, optionally loading all its pages", async () => {
+      const table = renderNestedTable()
+      await waitForRootRows()
+
+      act(() => table.control.expand("p2", { children: "all" }))
+
+      await waitFor(() => {
+        expect(screen.getByText("Child Three")).toBeInTheDocument()
+        expect(screen.getByText("Child Six")).toBeInTheDocument()
+      })
+      expect(screen.queryByText("Child One")).not.toBeInTheDocument()
+      expect(table.control.isExpanded("p2")).toBe(true)
+      expect(table.control.isExpanded("p1")).toBe(false)
+    })
+
+    it("collapse overrides an active auto-expansion policy", async () => {
+      const table = renderNestedTable({ defaultExpanded: 1 })
+      await waitFor(() => {
+        expect(screen.getByText("Child One")).toBeInTheDocument()
+      })
+
+      act(() => table.control.collapse("p1"))
+
+      await waitFor(() => {
+        expect(screen.queryByText("Child One")).not.toBeInTheDocument()
+      })
+      // The policy still applies to the other root row
+      expect(screen.getByText("Child Three")).toBeInTheDocument()
+    })
+
+    it("queues operations invoked before the table has mounted", async () => {
+      const table = renderNestedTable()
+      // The table is still on its initial-loading skeleton at this point
+      act(() => table.control.expandAll({ depth: 1 }))
+
+      await waitFor(() => {
+        expect(screen.getByText("Child One")).toBeInTheDocument()
+        expect(screen.getByText("Child Three")).toBeInTheDocument()
+      })
+    })
+
+    it("toggle flips the state, including rows expanded by a policy", async () => {
+      const table = renderNestedTable({ defaultExpanded: 1 })
+      await waitFor(() => {
+        expect(screen.getByText("Child One")).toBeInTheDocument()
+      })
+
+      act(() => table.control.toggle("p1"))
+      await waitFor(() => {
+        expect(screen.queryByText("Child One")).not.toBeInTheDocument()
+      })
+
+      act(() => table.control.toggle("p1"))
+      await waitFor(() => {
+        expect(screen.getByText("Child One")).toBeInTheDocument()
+      })
+    })
+
+    it("targets multiple rows with a predicate", async () => {
+      const table = renderNestedTable()
+      await waitForRootRows()
+
+      act(() => table.control.expand((ctx) => ctx.depth === 0))
+      await waitFor(() => {
+        expect(screen.getByText("Child One")).toBeInTheDocument()
+        expect(screen.getByText("Child Three")).toBeInTheDocument()
+      })
+
+      act(() => table.control.collapse((ctx) => ctx.item.id === "p1"))
+      await waitFor(() => {
+        expect(screen.queryByText("Child One")).not.toBeInTheDocument()
+      })
+      expect(screen.getByText("Child Three")).toBeInTheDocument()
+    })
+
+    it("fires onExpandedChange for controller operations but not for policy auto-expansion", async () => {
+      const onExpandedChange = vi.fn()
+      const table = renderNestedTable({
+        defaultExpanded: 1,
+        onExpandedChange,
+      })
+      await waitFor(() => {
+        expect(screen.getByText("Child One")).toBeInTheDocument()
+      })
+      // Policy-based auto-expansion does not emit events
+      expect(onExpandedChange).not.toHaveBeenCalled()
+
+      act(() => table.control.collapse("p1"))
+      await waitFor(() => {
+        expect(screen.queryByText("Child One")).not.toBeInTheDocument()
+      })
+      expect(onExpandedChange).toHaveBeenCalledWith({
+        item: expect.objectContaining({ id: "p1" }),
+        depth: 0,
+        expanded: false,
+      })
+    })
+
+    it("expandTo reveals a deep node by expanding only its ancestor path", async () => {
+      const table = renderNestedTable()
+      await waitForRootRows()
+
+      // c1 is not rendered yet (p1 is collapsed): the path resolves
+      // progressively as lazy loading reveals each level.
+      act(() => table.control.expandTo(["p1", "c1"]))
+
+      await waitFor(() => {
+        expect(screen.getByText("Grandchild One")).toBeInTheDocument()
+      })
+      // The sibling tree is untouched
+      expect(screen.queryByText("Child Three")).not.toBeInTheDocument()
+      expect(table.control.isExpanded("p2")).toBe(false)
+    })
+
+    it("expandTo queues before mount and honors the children load mode", async () => {
+      const table = renderNestedTable()
+      // Invoked while the table is still on its initial-loading skeleton
+      act(() => table.control.expandTo(["p2"], { children: "all" }))
+
+      await waitFor(() => {
+        expect(screen.getByText("Child Three")).toBeInTheDocument()
+        expect(screen.getByText("Child Six")).toBeInTheDocument()
+      })
+      expect(screen.queryByText("Child One")).not.toBeInTheDocument()
+    })
+
+    it("getExpandedItems returns the expanded rendered items", async () => {
+      const table = renderNestedTable()
+      await waitForRootRows()
+
+      act(() => table.control.expand("p1"))
+      await waitFor(() => {
+        expect(screen.getByText("Child One")).toBeInTheDocument()
+      })
+
+      const expandedIds = table.control.getExpandedItems().map((i) => i.id)
+      expect(expandedIds).toEqual(["p1"])
+    })
+  })
+
+  describe("filters change reset", () => {
+    it("clears explicit overrides but keeps the auto-expansion policy", async () => {
+      let api!: {
+        control: NestedTableController<Person>
+        setFilters: (filters: Record<string, unknown>) => void
+      }
+      render(
+        <FilterableHarness
+          nested={{ defaultExpanded: 1 }}
+          onApi={(a) => {
+            api = a
+          }}
+        />
+      )
+      await waitFor(() => {
+        expect(screen.getByText("Child One")).toBeInTheDocument()
+      })
+
+      // Explicit collapse overrides the policy…
+      act(() => api.control.collapse("p1"))
+      await waitFor(() => {
+        expect(screen.queryByText("Child One")).not.toBeInTheDocument()
+      })
+
+      // …until the filters change: overrides reset, the policy re-applies
+      act(() => api.setFilters({ department: ["Engineering"] }))
+      await waitFor(() => {
+        expect(screen.getByText("Child One")).toBeInTheDocument()
+      })
+    })
+
+    it("reloads children of every policy-expanded row without firing onExpandedChange", async () => {
+      const onExpandedChange = vi.fn()
+      let api!: {
+        control: NestedTableController<Person>
+        setFilters: (filters: Record<string, unknown>) => void
+      }
+      render(
+        <FilterableHarness
+          nested={{ defaultExpanded: 1, onExpandedChange }}
+          onApi={(a) => {
+            api = a
+          }}
+        />
+      )
+      await waitFor(() => {
+        expect(screen.getByText("Child One")).toBeInTheDocument()
+        expect(screen.getByText("Child Three")).toBeInTheDocument()
+      })
+
+      act(() => api.setFilters({ department: ["Engineering"] }))
+
+      // Every policy-expanded row stays expanded and reloads its children —
+      // no row must be left with a residual explicit-collapse override.
+      await waitFor(() => {
+        expect(screen.getByText("Child One")).toBeInTheDocument()
+        expect(screen.getByText("Child Three")).toBeInTheDocument()
+      })
+      // The reset is not an explicit expansion change, so no events fire
+      expect(onExpandedChange).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("expand animations", () => {
+    it.each(["fade", "stagger", "slide", "pop"] as const)(
+      "still renders revealed children with the '%s' animation",
+      async (expandAnimation) => {
+        renderNestedTable({ defaultExpanded: true, expandAnimation })
+
+        await waitFor(() => {
+          expect(screen.getByText("Child One")).toBeInTheDocument()
+          expect(screen.getByText("Grandchild One")).toBeInTheDocument()
+        })
+      }
+    )
+  })
+
+  describe("eager loading safety guards", () => {
+    it("stops eager loading at `total` even if the adapter keeps reporting hasMore", async () => {
+      const fetchChildren = vi.fn(({ item }: { item: Person }) => ({
+        records: item.children ?? [],
+        paginationInfo: {
+          total: item.children?.length ?? 0,
+          perPage: 2,
+          currentPage: 1,
+          pagesCount: 1,
+          // Misbehaving adapter: always claims there is more
+          hasMore: true,
+        },
+      }))
+      const table = renderNestedTable(undefined, {
+        fetchChildren,
+      } as unknown as Partial<TestSource>)
+      await waitForRootRows()
+
+      act(() => table.control.expand("p2", { children: "all" }))
+      await waitFor(() => {
+        expect(screen.getByText("Child Six")).toBeInTheDocument()
+      })
+
+      // All records arrived in the first page; the total guard prevents
+      // further requests despite hasMore staying true.
+      expect(fetchChildren).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe("user interaction", () => {
+    it("chevron toggling still works and fires onExpandedChange", async () => {
+      const user = userEvent.setup()
+      const onExpandedChange = vi.fn()
+      renderNestedTable({ onExpandedChange })
+      await waitForRootRows()
+
+      await clickFirstChevron(user)
+      await waitFor(() => {
+        expect(screen.getByText("Child One")).toBeInTheDocument()
+      })
+      expect(onExpandedChange).toHaveBeenCalledWith({
+        item: expect.objectContaining({ id: "p1" }),
+        depth: 0,
+        expanded: true,
+      })
+
+      await clickFirstChevron(user)
+      await waitFor(() => {
+        expect(screen.queryByText("Child One")).not.toBeInTheDocument()
+      })
+      expect(onExpandedChange).toHaveBeenLastCalledWith({
+        item: expect.objectContaining({ id: "p1" }),
+        depth: 0,
+        expanded: false,
+      })
+    })
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -16,7 +16,8 @@
  *
  */
 
-import { forwardRef, useCallback, useRef } from "react"
+import { motion } from "motion/react"
+import { forwardRef, useCallback, useEffect, useRef, useState } from "react"
 
 import type { TableVisualizationType } from "@/patterns/OneDataCollection/types"
 
@@ -26,6 +27,7 @@ import {
   SelectionId,
   SortingsDefinition,
 } from "@/hooks/datasource"
+import { useReducedMotion } from "@/lib/a11y"
 import { DataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource/types"
 import { ItemActionsDefinition } from "@/patterns/OneDataCollection/item-actions"
 import { NavigationFiltersDefinition } from "@/patterns/OneDataCollection/navigationFilters/types"
@@ -40,6 +42,7 @@ import type {
 
 import { PrimaryActionItemDefinition } from "../../../../actions"
 import { useAddRow } from "../../EditableTable/context/AddRowContext"
+import { getExpandAnimationVariants } from "../nested/animations"
 import { useCalculateConectorHeight } from "../hooks/useCalculateConectorHeight"
 import { HeaderGroupEntry } from "../hooks/useHeaderGroups"
 import { useLoadChildren } from "../hooks/useLoadChildren"
@@ -61,6 +64,20 @@ const normalizeAddRowActions = (
     (item): item is PrimaryActionItemDefinition => item !== undefined
   )
 }
+
+/**
+ * Safety cap for eager children loading (`children: "all"`): stops fetching
+ * further pages even if the adapter keeps reporting `hasMore`.
+ */
+const MAX_EAGER_CHILDREN_PAGES = 100
+
+/**
+ * Stagger index for row mount animations. Depth contributes to the delay so
+ * that when a whole cached subtree mounts in a single commit (re-expansion
+ * without network waterfalls), the reveal still cascades level by level
+ * instead of appearing all at once.
+ */
+const mountStaggerIndex = (index: number, depth: number) => index + depth * 2
 
 export type RowProps<
   R extends RecordType,
@@ -132,8 +149,31 @@ const NestedRowContent = <
 
   const rowId = `${props.nestedRowProps?.depth ?? 0}-${"id" in props.item ? props.item.id + "-" + props.index : props.index}`
 
-  const { expandedRowIds, setRowExpanded } = useNestedDataContext()
-  const open = expandedRowIds[rowId] ?? false
+  const {
+    setRowExpanded,
+    resolveRowExpansion,
+    registerNestedRow,
+    expandAnimation,
+  } = useNestedDataContext()
+
+  const depth = props.nestedRowProps?.depth ?? 0
+
+  /**
+   * Expansion is resolved declaratively: an explicit override (user click or
+   * controller call) wins, otherwise the active auto-expansion policy is
+   * evaluated. This lets policies cascade to rows revealed by lazy loading.
+   */
+  const { expanded: open, eager } = resolveRowExpansion(
+    rowId,
+    props.item,
+    depth
+  )
+
+  // Register so imperative controller operations can target this row.
+  useEffect(
+    () => registerNestedRow(rowId, props.item, depth),
+    [registerNestedRow, rowId, props.item, depth]
+  )
 
   /**
    * useLoadChildren hook manages:
@@ -142,17 +182,80 @@ const NestedRowContent = <
    * - Pagination information
    * - Determining if children are "nested" (have their own children) or "flat"
    */
-  const { children, loadChildren, isLoading, childrenType, paginationInfo } =
-    useLoadChildren({
-      rowId: rowId,
-      item: props.item,
-      source: props.source,
-      onClearFetchedData: () => setRowExpanded(rowId, false),
-    })
+  const {
+    children,
+    loadChildren,
+    isLoading,
+    hasError,
+    childrenType,
+    paginationInfo,
+    hasFetched,
+  } = useLoadChildren({
+    rowId: rowId,
+    item: props.item,
+    source: props.source,
+  })
+
+  /**
+   * Lazy loading is driven by the resolved `open` state (not by the click
+   * handler) so rows opened programmatically or by a policy also fetch their
+   * children. The ref makes each open-session request the first page once,
+   * avoiding retry loops when a fetch errors.
+   */
+  const autoLoadRequestedRef = useRef(false)
+  const [eagerPagesRequested, setEagerPagesRequested] = useState(0)
+
+  // Re-arm the request guards when the children cache is invalidated (e.g. a
+  // filters change) so rows kept open by a policy reload their children.
+  const previousHasFetchedRef = useRef(hasFetched)
+  useEffect(() => {
+    if (previousHasFetchedRef.current && !hasFetched) {
+      autoLoadRequestedRef.current = false
+      setEagerPagesRequested(0)
+    }
+    previousHasFetchedRef.current = hasFetched
+  }, [hasFetched])
+
+  useEffect(() => {
+    if (!open) {
+      autoLoadRequestedRef.current = false
+      return
+    }
+    if (autoLoadRequestedRef.current || isLoading || hasFetched) return
+    autoLoadRequestedRef.current = true
+    loadChildren()
+  }, [open, isLoading, hasFetched, loadChildren])
+
+  /**
+   * Eager pagination (`children: "all"`): keeps fetching pages until the
+   * adapter reports no more. Guarded by `total`, a page cap and the error
+   * flag, so a misbehaving or failing adapter cannot cause a fetch loop —
+   * remaining pages fall back to the "show more" row.
+   */
+  const eagerLoadPending =
+    open &&
+    eager &&
+    hasFetched &&
+    !hasError &&
+    !!paginationInfo?.hasMore &&
+    (paginationInfo.total === undefined ||
+      children.length < paginationInfo.total) &&
+    eagerPagesRequested < MAX_EAGER_CHILDREN_PAGES
+
+  useEffect(() => {
+    if (!open || !eager) {
+      setEagerPagesRequested(0)
+      return
+    }
+    if (!eagerLoadPending || isLoading) return
+    setEagerPagesRequested((count) => count + 1)
+    loadChildren()
+  }, [open, eager, eagerLoadPending, isLoading, loadChildren])
 
   const shouldShowLoading = open && isLoading
   const shouldShowChildren = open
-  const shouldShowLoadMore = open && paginationInfo?.hasMore
+  const shouldShowLoadMore =
+    open && paginationInfo?.hasMore && !eagerLoadPending
 
   const addRowActions =
     open && !isLoading
@@ -201,22 +304,47 @@ const NestedRowContent = <
     [externalRef]
   )
 
+  // Children fetching reacts to the resolved `open` state (see effects above),
+  // so toggling only needs to record the explicit override.
   const handleExpand = () => {
-    const isExpanding = !open
-    setRowExpanded(rowId, isExpanding)
-
-    if (isExpanding && !children.length) {
-      loadChildren()
-    }
+    setRowExpanded(rowId, !open)
   }
 
   const sharedNestedRowProps = {
-    depth: props.nestedRowProps?.depth ?? 0,
+    depth,
     expanded: open,
     onExpand: handleExpand,
     nestedVariant: childrenType,
     connectorHeight: calculatedHeight,
   }
+
+  /**
+   * Optional mount animation for rows revealed on expansion (see
+   * `nested/animations.ts` for the variants); collapsing stays instant.
+   */
+  const shouldReduceMotion = useReducedMotion()
+  const animated = expandAnimation !== "none" && !shouldReduceMotion
+  const [MotionRow] = useState(() =>
+    motion.create(
+      Row<
+        R,
+        Filters,
+        Sortings,
+        Summaries,
+        ItemActions,
+        NavigationFilters,
+        Grouping
+      >
+    )
+  )
+  const mountAnimationProps =
+    expandAnimation !== "none"
+      ? {
+          variants: getExpandAnimationVariants(expandAnimation),
+          initial: "hidden" as const,
+          animate: "visible" as const,
+        }
+      : {}
 
   const isTableVisualization = props.fromVisualization === "table"
 
@@ -230,27 +358,37 @@ const NestedRowContent = <
   const isLastChild = (props.nestedRowProps?.isLastChild || firstRow) ?? false
   const shouldHideBorder = (open || !isLastChild) && isTableVisualization
 
+  const selfRowProps = {
+    ...props,
+    disableHover: !props.source.itemOnClick,
+    noBorder: shouldHideBorder,
+    nestedRowProps: {
+      ...sharedNestedRowProps,
+      // If nestedRowProps.parentHasChildren is not provided, we need to set it to true if the parent has children
+      // This nestedRowProps.parentHasChildren is provided on children iteration
+      parentHasChildren:
+        (props.nestedRowProps?.parentHasChildren ?? children.length > 0) ||
+        hasAddRowActions,
+      hasLoadedChildren: false,
+      isLastChild,
+      stickyRow: isSticky,
+    },
+    tableWithChildren: props.tableWithChildren,
+    fromVisualization: props.fromVisualization,
+  }
+
   return (
     <>
-      <Row
-        {...props}
-        disableHover={!props.source.itemOnClick}
-        noBorder={shouldHideBorder}
-        ref={combinedRowRef}
-        nestedRowProps={{
-          ...sharedNestedRowProps,
-          // If nestedRowProps.parentHasChildren is not provided, we need to set it to true if the parent has children
-          // This nestedRowProps.parentHasChildren is provided on children iteration
-          parentHasChildren:
-            (props.nestedRowProps?.parentHasChildren ?? children.length > 0) ||
-            hasAddRowActions,
-          hasLoadedChildren: false,
-          isLastChild,
-          stickyRow: isSticky,
-        }}
-        tableWithChildren={props.tableWithChildren}
-        fromVisualization={props.fromVisualization}
-      />
+      {animated && props.nestedRowProps?.animateMount ? (
+        <MotionRow
+          {...selfRowProps}
+          {...mountAnimationProps}
+          custom={mountStaggerIndex(props.index, depth)}
+          ref={combinedRowRef}
+        />
+      ) : (
+        <Row {...selfRowProps} ref={combinedRowRef} />
+      )}
 
       {shouldShowChildren &&
         children.map((child, childIndex) => {
@@ -259,7 +397,7 @@ const NestedRowContent = <
           const isFirstChild = childIndex === 0
           const isLastChildInLevel = childIndex === children.length - 1
 
-          const depth = (props.nestedRowProps?.depth ?? 0) + 1
+          const childDepth = depth + 1
 
           /**
            * Get the appropriate ref for connector height calculations
@@ -319,8 +457,9 @@ const NestedRowContent = <
                 nestedRowProps={{
                   ...props.nestedRowProps,
                   parentHasChildren: true,
-                  depth: depth,
+                  depth: childDepth,
                   isLastChild: childIsLastInTree,
+                  animateMount: animated,
                 }}
                 fromVisualization={props.fromVisualization}
               />
@@ -345,27 +484,39 @@ const NestedRowContent = <
             const leafShouldHideBorder =
               !childIsLastInTree && isTableVisualization
 
-            const leafChild = (
-              <Row
-                {...props}
+            const leafRowProps = {
+              ...props,
+              index: childIndex,
+              item: childItem,
+              onCheckedChange: (checked: boolean) => {
+                props.onItemCheckedChange?.(childItem, checked)
+              },
+              noBorder: leafShouldHideBorder,
+              nestedRowProps: {
+                ...props.nestedRowProps,
+                depth: childDepth,
+                parentHasChildren: true,
+                nestedVariant: childrenType,
+                onExpand: handleExpand,
+                isLastChild: childIsLastInTree,
+              },
+              fromVisualization: props.fromVisualization,
+              tableWithChildren: props.tableWithChildren,
+            }
+
+            const leafChild = animated ? (
+              <MotionRow
+                {...leafRowProps}
+                {...mountAnimationProps}
+                custom={mountStaggerIndex(childIndex, childDepth)}
                 key={`row-${props.groupIndex}-${props.index}-${childIndex}`}
-                index={childIndex}
-                item={childItem}
-                onCheckedChange={(checked) => {
-                  props.onItemCheckedChange?.(childItem, checked)
-                }}
-                noBorder={leafShouldHideBorder}
                 ref={getChildRef()}
-                nestedRowProps={{
-                  ...props.nestedRowProps,
-                  depth: (props.nestedRowProps?.depth ?? 0) + 1,
-                  parentHasChildren: true,
-                  nestedVariant: childrenType,
-                  onExpand: handleExpand,
-                  isLastChild: childIsLastInTree,
-                }}
-                fromVisualization={props.fromVisualization}
-                tableWithChildren={props.tableWithChildren}
+              />
+            ) : (
+              <Row
+                {...leafRowProps}
+                key={`row-${props.groupIndex}-${props.index}-${childIndex}`}
+                ref={getChildRef()}
               />
             )
 
@@ -476,9 +627,9 @@ const NestedRowComponentInner = <
     | React.RefObject<HTMLTableRowElement>
     | null
 ) => {
-  // Provider is mounted at Table level when tableWithChildren is true, so we
-  // never wrap here. This keeps expansion state and fetched data in a single
-  // context that survives parent re-renders (e.g. GraphQL refetch).
+  // Provider is mounted unconditionally at Table level, so we never wrap
+  // here. This keeps expansion state and fetched data in a single context
+  // that survives parent re-renders (e.g. GraphQL refetch).
   return <NestedRowContentWithRef {...props} ref={ref} />
 }
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -108,6 +108,8 @@ export type NestedRowProps = {
   onLoadMoreChildren?: () => void
   onAddRow?: OnAddRowConfig
   stickyRow?: boolean
+  /** Whether this row should animate its mount (set while revealing children with an expand animation). */
+  animateMount?: boolean
 }
 
 const referenceTypeClasses: Record<ReferenceType, string> = {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/useLoadChildren.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/useLoadChildren.ts
@@ -41,7 +41,6 @@ interface UseLoadChildrenProps<
     NavigationFilters,
     Grouping
   >
-  onClearFetchedData: () => void
 }
 
 const isDetailed = <R extends RecordType>(
@@ -80,7 +79,6 @@ export const useLoadChildren = <
   rowId,
   item,
   source,
-  onClearFetchedData,
 }: UseLoadChildrenProps<
   R,
   Filters,
@@ -102,6 +100,7 @@ export const useLoadChildren = <
     ChildrenPaginationInfo | undefined
   >(nestedFetchedData?.[rowId]?.paginationInfo)
   const [isLoading, setIsLoading] = useState(false)
+  const [hasError, setHasError] = useState(false)
   const [childrenType, setChildrenType] = useState<NestedVariant>(
     getChildrenType(nestedFetchedData?.[rowId])
   )
@@ -121,8 +120,10 @@ export const useLoadChildren = <
       setChildren([])
       setPaginationInfo(undefined)
       setChildrenType("basic")
+      setHasError(false)
+      // The provider also resets the expansion overrides here (keeping any
+      // active auto-expansion policy), so no per-row collapse is needed.
       clearFetchedData()
-      onClearFetchedData()
 
       previousFiltersRef.current = source.currentFilters
       previousSortingsRef.current = source.currentSortings
@@ -133,7 +134,6 @@ export const useLoadChildren = <
     source.currentSortings,
     source.currentNavigationFilters,
     clearFetchedData,
-    onClearFetchedData,
   ])
 
   const subscriptionRef = useRef<ZenObservable.Subscription | undefined>()
@@ -166,6 +166,7 @@ export const useLoadChildren = <
     subscriptionRef.current?.unsubscribe()
 
     setIsLoading(true)
+    setHasError(false)
 
     const result = source.fetchChildren?.({
       item,
@@ -197,6 +198,7 @@ export const useLoadChildren = <
           setIsLoading(true)
         } else if (state.error) {
           setIsLoading(false)
+          setHasError(true)
         } else if (state.data) {
           processChildrenData(state.data)
           setIsLoading(false)
@@ -204,6 +206,7 @@ export const useLoadChildren = <
       },
       error: (error) => {
         setIsLoading(false)
+        setHasError(true)
         console.error("Error loading children:", error)
       },
       complete: () => {
@@ -225,7 +228,11 @@ export const useLoadChildren = <
     children,
     loadChildren,
     isLoading,
+    /** Whether the last fetch failed. Cleared on the next fetch or on a filters/sortings reset. */
+    hasError,
     childrenType,
     paginationInfo,
+    /** Whether at least one page of children has been fetched (even if empty). */
+    hasFetched: nestedFetchedData?.[rowId] !== undefined,
   }
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/nested/animations.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/nested/animations.ts
@@ -1,0 +1,89 @@
+import { NestedExpandAnimation } from "./types"
+
+/**
+ * Mount variants for the rows revealed when a nested node expands.
+ *
+ * These are intentionally slower than the row variants used while data is
+ * loading (`getAnimationVariants` from the datasource, tuned for network
+ * waterfalls): expansion often reveals cached rows in a single commit, so
+ * the animation itself has to carry the reveal. All variants animate only
+ * `opacity` and `transform` (GPU-composited, safe on `<tr>` elements), never
+ * layout-affecting properties.
+ *
+ * The `custom` value is the row's stagger index (sibling index + depth
+ * contribution, see `mountStaggerIndex`), so sequenced variants cascade
+ * level by level even for fully cached subtrees.
+ */
+
+const STAGGER_STEP = 0.05
+const MAX_STAGGER_DELAY = 1.2
+
+const staggerDelay = (index: number) =>
+  Math.min(index * STAGGER_STEP, MAX_STAGGER_DELAY)
+
+/** Ease used across the design system for reveals (e.g. collapsible messages). */
+const REVEAL_EASE = [0.165, 0.84, 0.44, 1] as const
+
+export const getExpandAnimationVariants = (
+  animation: Exclude<NestedExpandAnimation, "none">
+) => {
+  switch (animation) {
+    // All revealed rows fade in at once
+    case "fade":
+      return {
+        hidden: { opacity: 0 },
+        visible: () => ({
+          opacity: 1,
+          transition: { duration: 0.3, ease: REVEAL_EASE },
+        }),
+      }
+
+    // Rows fade in and settle downwards one after another
+    case "stagger":
+      return {
+        hidden: { opacity: 0, y: -10 },
+        visible: (index: number) => ({
+          opacity: 1,
+          y: 0,
+          transition: {
+            delay: staggerDelay(index),
+            duration: 0.3,
+            ease: REVEAL_EASE,
+          },
+        }),
+      }
+
+    // Rows slide in from the left with a soft spring, one after another
+    case "slide":
+      return {
+        hidden: { opacity: 0, x: -24 },
+        visible: (index: number) => ({
+          opacity: 1,
+          x: 0,
+          transition: {
+            delay: staggerDelay(index),
+            type: "spring" as const,
+            stiffness: 260,
+            damping: 26,
+          },
+        }),
+      }
+
+    // Rows scale up into place with a springy pop, one after another
+    case "pop":
+      return {
+        hidden: { opacity: 0, scale: 0.94, y: -6 },
+        visible: (index: number) => ({
+          opacity: 1,
+          scale: 1,
+          y: 0,
+          transition: {
+            delay: staggerDelay(index),
+            type: "spring" as const,
+            stiffness: 320,
+            damping: 20,
+          },
+        }),
+      }
+  }
+}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/nested/index.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/nested/index.ts
@@ -1,0 +1,13 @@
+export { useNestedTable } from "./useNestedTable"
+export { nestedChildrenDisplayModes, nestedExpandAnimations } from "./types"
+export type {
+  NestedChildrenDisplayMode,
+  NestedExpandAllOptions,
+  NestedExpandAnimation,
+  NestedExpandOptions,
+  NestedExpansionContext,
+  NestedExpansionCriteria,
+  NestedRowTarget,
+  NestedTableController,
+  NestedTableOptions,
+} from "./types"

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/nested/internal-types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/nested/internal-types.ts
@@ -1,0 +1,69 @@
+import { RecordType } from "@/hooks/datasource"
+
+import {
+  NestedChildrenDisplayMode,
+  NestedExpansionCriteria,
+  NestedTableController,
+} from "./types"
+
+/**
+ * Active auto-expansion policy. Evaluated for every rendered expandable row
+ * that has no explicit override, so it cascades to rows revealed later by
+ * lazy loading.
+ */
+export type NestedExpansionPolicy<R extends RecordType> = {
+  criteria: NestedExpansionCriteria<R>
+  children: NestedChildrenDisplayMode
+}
+
+/**
+ * Expansion state held by the NestedDataProvider.
+ * Kept as a single object so imperative operations update it atomically.
+ */
+export type NestedExpansionState<R extends RecordType> = {
+  /**
+   * Explicit per-row overrides (user clicks or controller calls). `false`
+   * entries persist so a manual collapse wins over an active policy.
+   */
+  overrides: Record<string, boolean>
+  /** Rows whose children must be loaded eagerly (no "show more"). */
+  eager: Record<string, boolean>
+  policy: NestedExpansionPolicy<R> | null
+}
+
+/**
+ * Provider-side implementation of the controller operations. The controller
+ * created by `useNestedTable()` forwards its calls to the engine once the
+ * table (and therefore the provider) is mounted.
+ */
+export type NestedExpansionEngine<R extends RecordType> = Pick<
+  NestedTableController<R>,
+  | "expand"
+  | "collapse"
+  | "toggle"
+  | "expandAll"
+  | "collapseAll"
+  | "expandTo"
+  | "isExpanded"
+  | "getExpandedItems"
+>
+
+/**
+ * Internal shape of the controller returned by `useNestedTable()`. The
+ * binding method is private API between the hook and NestedDataProvider.
+ */
+export interface NestedTableControllerInternal<
+  R extends RecordType,
+> extends NestedTableController<R> {
+  /**
+   * @private Binds the controller to a mounted provider. Returns an unbind
+   * cleanup. Operations invoked while unbound are queued and replayed on bind.
+   */
+  __bindEngine: (engine: NestedExpansionEngine<R>) => () => void
+}
+
+/** Entry registered by every rendered expandable row. */
+export type NestedRowRegistryEntry<R extends RecordType> = {
+  item: R
+  depth: number
+}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/nested/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/nested/types.ts
@@ -1,0 +1,173 @@
+import { RecordType } from "@/hooks/datasource"
+
+/**
+ * How the children of an expanded row are loaded.
+ * - `"paginated"`: only the first page is loaded, remaining pages stay behind
+ *   a "show more" row (default).
+ * - `"all"`: pages are fetched eagerly until there are no more, so the subtree
+ *   is fully visible without a "show more" row.
+ */
+export const nestedChildrenDisplayModes = ["paginated", "all"] as const
+export type NestedChildrenDisplayMode =
+  (typeof nestedChildrenDisplayModes)[number]
+
+/**
+ * Context passed to nested-expansion predicates.
+ * `depth` is 0-based: root rows are depth 0, their children depth 1, etc.
+ */
+export type NestedExpansionContext<R extends RecordType> = {
+  item: R
+  depth: number
+}
+
+/**
+ * Declarative criteria describing which rows should be expanded.
+ * - `boolean`: expand every row (`true`) or none (`false`)
+ * - `number`: expand rows whose depth is lower than the given value, i.e.
+ *   `1` expands root rows (showing 2 levels), `2` also expands their children…
+ * - predicate: expand rows for which the function returns `true`
+ */
+export type NestedExpansionCriteria<R extends RecordType> =
+  | boolean
+  | number
+  | ((context: NestedExpansionContext<R>) => boolean)
+
+/**
+ * Identifies the row(s) an imperative operation applies to.
+ * - `string | number`: matched against the item's `id` property
+ * - predicate: matched against every currently rendered expandable row
+ *
+ * Only rows that are currently rendered can be targeted — a row hidden under
+ * a collapsed ancestor is not rendered yet. Use `expandAll` with `depth`/
+ * `where` for criteria that must also apply to rows revealed later.
+ */
+export type NestedRowTarget<R extends RecordType> =
+  | string
+  | number
+  | ((context: NestedExpansionContext<R>) => boolean)
+
+export type NestedExpandOptions = {
+  /**
+   * How the children of the expanded row(s) are loaded.
+   * @default "paginated"
+   */
+  children?: NestedChildrenDisplayMode
+}
+
+export type NestedExpandAllOptions<R extends RecordType> =
+  NestedExpandOptions & {
+    /**
+     * Maximum depth to auto-expand: rows with `depth < depth` are expanded.
+     * Omit to expand every level.
+     */
+    depth?: number
+    /** Additional predicate a row must satisfy to be auto-expanded. */
+    where?: (context: NestedExpansionContext<R>) => boolean
+  }
+
+/**
+ * Imperative controller for the nested rows of a table visualization.
+ * Create one with `useNestedTable()` and pass it via the table visualization
+ * options (`options.nested.control`).
+ */
+export interface NestedTableController<R extends RecordType> {
+  /** Expands the rows matching the target. */
+  expand: (target: NestedRowTarget<R>, options?: NestedExpandOptions) => void
+  /** Collapses the rows matching the target (overrides any active policy). */
+  collapse: (target: NestedRowTarget<R>) => void
+  /** Toggles the rows matching the target. */
+  toggle: (target: NestedRowTarget<R>, options?: NestedExpandOptions) => void
+  /**
+   * Auto-expands the whole tree (or a subset via `depth`/`where`). The
+   * criteria also applies to rows revealed later by lazy loading, so deep
+   * trees expand progressively as their children arrive.
+   */
+  expandAll: (options?: NestedExpandAllOptions<R>) => void
+  /** Collapses every row and clears any active auto-expansion policy. */
+  collapseAll: () => void
+  /**
+   * Expands the given path of item ids (ancestor → descendant) to reveal a
+   * specific node, without touching the rest of the tree. Ids not rendered
+   * yet stay pending and are expanded as soon as lazy loading reveals them,
+   * so a deep node can be reached with a single call:
+   *
+   * ```ts
+   * nestedTable.expandTo(["engineering", "engineering.platform"])
+   * ```
+   */
+  expandTo: (
+    path: Array<string | number>,
+    options?: NestedExpandOptions
+  ) => void
+  /** Whether the first row matching the target is currently expanded. */
+  isExpanded: (target: NestedRowTarget<R>) => boolean
+  /** Items of the currently rendered rows that are expanded. */
+  getExpandedItems: () => R[]
+}
+
+/**
+ * Mount animation applied to child rows when a node is expanded.
+ * - `"none"`: rows appear instantly (default, current behavior)
+ * - `"fade"`: all revealed rows fade in at once
+ * - `"stagger"`: rows fade in and settle downwards one after another
+ * - `"slide"`: rows slide in from the left with a soft spring, sequentially
+ * - `"pop"`: rows scale up into place with a springy pop, sequentially
+ *
+ * All animations are GPU-composited (`opacity`/`transform` only) and respect
+ * `prefers-reduced-motion`. Sequenced ones stagger by sibling index and
+ * depth, so cached subtrees still cascade level by level.
+ */
+export const nestedExpandAnimations = [
+  "none",
+  "fade",
+  "stagger",
+  "slide",
+  "pop",
+] as const
+export type NestedExpandAnimation = (typeof nestedExpandAnimations)[number]
+
+/**
+ * Nested-rows behavior for the table visualization.
+ */
+export type NestedTableOptions<R extends RecordType> = {
+  /**
+   * Rows matching this criteria start expanded, including rows revealed
+   * later by lazy loading. Evaluated when the table mounts; use `control`
+   * to change the expansion at runtime.
+   */
+  defaultExpanded?: NestedExpansionCriteria<R>
+  /**
+   * How children of rows auto-expanded by `defaultExpanded` are loaded.
+   * @default "paginated"
+   */
+  defaultExpandedChildren?: NestedChildrenDisplayMode
+  /** Controller created with `useNestedTable()` for programmatic control. */
+  control?: NestedTableController<R>
+  /**
+   * Mount animation for child rows revealed on expansion.
+   * @default "none"
+   */
+  expandAnimation?: NestedExpandAnimation
+  /**
+   * Called when a row's expansion changes explicitly — via user interaction
+   * or a targeted controller operation (`expand`, `collapse`, `toggle`).
+   * Not called for policy-based auto-expansion (`defaultExpanded`,
+   * `expandAll`, `collapseAll`).
+   */
+  onExpandedChange?: (
+    event: NestedExpansionContext<R> & { expanded: boolean }
+  ) => void
+}
+
+/**
+ * Resolves a declarative expansion criteria against a row.
+ */
+export const matchesExpansionCriteria = <R extends RecordType>(
+  criteria: NestedExpansionCriteria<R> | undefined,
+  context: NestedExpansionContext<R>
+): boolean => {
+  if (criteria === undefined) return false
+  if (typeof criteria === "boolean") return criteria
+  if (typeof criteria === "number") return context.depth < criteria
+  return criteria(context)
+}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/nested/useNestedTable.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/nested/useNestedTable.ts
@@ -1,0 +1,87 @@
+import { useState } from "react"
+
+import { RecordType } from "@/hooks/datasource"
+
+import {
+  NestedExpansionEngine,
+  NestedTableControllerInternal,
+} from "./internal-types"
+import {
+  NestedExpandAllOptions,
+  NestedExpandOptions,
+  NestedRowTarget,
+  NestedTableController,
+} from "./types"
+
+const createNestedTableController = <
+  R extends RecordType,
+>(): NestedTableControllerInternal<R> => {
+  let engine: NestedExpansionEngine<R> | null = null
+  const pendingOperations: Array<(engine: NestedExpansionEngine<R>) => void> =
+    []
+
+  // Mutating operations queue until the table mounts so calls made while the
+  // table is still loading (or before it renders) are not lost.
+  const run = (operation: (engine: NestedExpansionEngine<R>) => void) => {
+    if (engine) {
+      operation(engine)
+    } else {
+      pendingOperations.push(operation)
+    }
+  }
+
+  return {
+    expand: (target: NestedRowTarget<R>, options?: NestedExpandOptions) =>
+      run((e) => e.expand(target, options)),
+    collapse: (target: NestedRowTarget<R>) => run((e) => e.collapse(target)),
+    toggle: (target: NestedRowTarget<R>, options?: NestedExpandOptions) =>
+      run((e) => e.toggle(target, options)),
+    expandAll: (options?: NestedExpandAllOptions<R>) =>
+      run((e) => e.expandAll(options)),
+    collapseAll: () => run((e) => e.collapseAll()),
+    expandTo: (path: Array<string | number>, options?: NestedExpandOptions) =>
+      run((e) => e.expandTo(path, options)),
+    isExpanded: (target: NestedRowTarget<R>) =>
+      engine?.isExpanded(target) ?? false,
+    getExpandedItems: () => engine?.getExpandedItems() ?? [],
+    __bindEngine: (nextEngine: NestedExpansionEngine<R>) => {
+      engine = nextEngine
+      pendingOperations.splice(0).forEach((operation) => operation(nextEngine))
+      return () => {
+        if (engine === nextEngine) engine = null
+      }
+    },
+  }
+}
+
+/**
+ * Creates a stable controller to programmatically expand/collapse the nested
+ * rows of a table visualization. Pass it through the visualization options:
+ *
+ * ```tsx
+ * const nestedTable = useNestedTable<User>()
+ *
+ * <OneDataCollection
+ *   source={source}
+ *   visualizations={[
+ *     { type: "table", options: { columns, nested: { control: nestedTable } } },
+ *   ]}
+ * />
+ *
+ * nestedTable.expandAll({ depth: 2 })
+ * nestedTable.expand("user-1", { children: "all" })
+ * nestedTable.collapse((ctx) => ctx.depth > 0)
+ * ```
+ *
+ * Operations invoked before the table mounts are queued and applied on
+ * mount. Note that targeted operations (`expand`, `collapse`, `toggle`) only
+ * match rows rendered at the time they run — to reach a node hidden under
+ * collapsed ancestors use `expandTo` with its id path, or `expandAll` with
+ * `depth`/`where` for criteria that must apply to rows not yet loaded.
+ */
+export const useNestedTable = <
+  R extends RecordType,
+>(): NestedTableController<R> => {
+  const [controller] = useState(() => createNestedTableController<R>())
+  return controller
+}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/providers/NestedProvider.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/providers/NestedProvider.tsx
@@ -3,29 +3,104 @@ import {
   ReactNode,
   useCallback,
   useContext,
+  useEffect,
+  useMemo,
+  useRef,
   useState,
 } from "react"
 
 import { RecordType } from "@/hooks/datasource"
 import { ChildrenResponse } from "@/hooks/datasource/types/nested.typings"
 
+import {
+  NestedExpansionEngine,
+  NestedExpansionState,
+  NestedRowRegistryEntry,
+  NestedTableControllerInternal,
+} from "../nested/internal-types"
+import {
+  matchesExpansionCriteria,
+  NestedExpandAllOptions,
+  NestedExpandAnimation,
+  NestedExpandOptions,
+  NestedExpansionContext,
+  NestedExpansionCriteria,
+  NestedRowTarget,
+  NestedTableOptions,
+} from "../nested/types"
+
+/** Result of resolving a row's expansion against overrides + active policy. */
+type ResolvedRowExpansion = {
+  expanded: boolean
+  /** Whether the row's children must be loaded eagerly (no "show more"). */
+  eager: boolean
+}
+
 interface NestedDataContextValue<R extends RecordType> {
   fetchedData: Record<string, ChildrenResponse<R>>
   updateFetchedData: (rowId: string, data: ChildrenResponse<R>) => void
   clearFetchedData: () => void
-  /** Persisted expansion state so rows stay open across parent re-renders (e.g. GraphQL refetch) */
-  expandedRowIds: Record<string, boolean>
+  /** Records an explicit expansion override for a row (user click or controller call). */
   setRowExpanded: (rowId: string, expanded: boolean) => void
+  /** Resolves a row's expansion: explicit override → active policy → closed. */
+  resolveRowExpansion: (
+    rowId: string,
+    item: R,
+    depth: number
+  ) => ResolvedRowExpansion
+  /** Registers a rendered expandable row so imperative operations can target it. Returns an unregister cleanup. */
+  registerNestedRow: (rowId: string, item: R, depth: number) => () => void
+  expandAnimation: NestedExpandAnimation
 }
 
 const NestedDataContext = createContext<
   NestedDataContextValue<RecordType> | undefined
 >(undefined)
 
+const resolveExpansion = <R extends RecordType>(
+  state: NestedExpansionState<R>,
+  rowId: string,
+  context: NestedExpansionContext<R>
+): ResolvedRowExpansion => {
+  const explicit = state.overrides[rowId]
+  const policyMatch =
+    explicit === undefined && state.policy !== null
+      ? matchesExpansionCriteria(state.policy.criteria, context)
+      : false
+  const expanded = explicit ?? policyMatch
+
+  const eager =
+    expanded &&
+    (state.eager[rowId] ?? (policyMatch && state.policy?.children === "all"))
+
+  return { expanded, eager }
+}
+
+const matchesTarget = <R extends RecordType>(
+  target: NestedRowTarget<R>,
+  entry: NestedRowRegistryEntry<R>
+): boolean => {
+  if (typeof target === "function") {
+    return target({ item: entry.item, depth: entry.depth })
+  }
+  return "id" in entry.item && entry.item.id === target
+}
+
+const buildExpandAllCriteria = <R extends RecordType>(
+  options?: NestedExpandAllOptions<R>
+): NestedExpansionCriteria<R> => {
+  const { depth, where } = options ?? {}
+  if (depth === undefined && !where) return true
+  return (context) =>
+    (depth === undefined || context.depth < depth) && (where?.(context) ?? true)
+}
+
 export const NestedDataProvider = <R extends RecordType>({
   children,
+  nested,
 }: {
   children: ReactNode
+  nested?: NestedTableOptions<R>
 }) => {
   const [fetchedData, setFetchedData] = useState<
     Record<string, ChildrenResponse<R>>
@@ -41,23 +116,231 @@ export const NestedDataProvider = <R extends RecordType>({
     []
   )
 
-  const [expandedRowIds, setExpandedRowIdsState] = useState<
-    Record<string, boolean>
-  >({})
+  const [expansionState, setExpansionState] = useState<NestedExpansionState<R>>(
+    () => ({
+      overrides: {},
+      eager: {},
+      policy:
+        nested?.defaultExpanded !== undefined
+          ? {
+              criteria: nested.defaultExpanded,
+              children: nested.defaultExpandedChildren ?? "paginated",
+            }
+          : null,
+    })
+  )
+
+  // Latest-value refs so the engine callbacks stay stable while reading fresh
+  // state synchronously (controller calls can happen back-to-back in one tick).
+  const expansionStateRef = useRef(expansionState)
+  const nestedOptionsRef = useRef(nested)
+  nestedOptionsRef.current = nested
+  const registryRef = useRef(new Map<string, NestedRowRegistryEntry<R>>())
+
+  /**
+   * Item ids requested via `expandTo` whose rows are not rendered yet. They
+   * are consumed as rows register, so a deep path expands progressively as
+   * lazy loading reveals each level.
+   */
+  const pendingExpandRef = useRef(
+    new Map<string | number, NestedExpandOptions>()
+  )
+
+  const commitExpansionState = useCallback((next: NestedExpansionState<R>) => {
+    expansionStateRef.current = next
+    setExpansionState(next)
+  }, [])
 
   const clearFetchedData = useCallback(() => {
     setFetchedData({})
-    setExpandedRowIdsState({})
-  }, [])
+    // Explicit overrides are positional (depth-id-index) so they cannot be
+    // trusted after a refetch; the declarative policy still applies. Pending
+    // expandTo paths are dropped too, as the new data may not contain them.
+    pendingExpandRef.current.clear()
+    commitExpansionState({
+      ...expansionStateRef.current,
+      overrides: {},
+      eager: {},
+    })
+  }, [commitExpansionState])
 
-  const setRowExpanded = useCallback((rowId: string, expanded: boolean) => {
-    setExpandedRowIdsState((prev) => {
-      if (expanded) return { ...prev, [rowId]: true }
-      const next = { ...prev }
-      delete next[rowId]
-      return next
+  const emitExpandedChange = useCallback((rowId: string, expanded: boolean) => {
+    const entry = registryRef.current.get(rowId)
+    if (!entry) return
+    nestedOptionsRef.current?.onExpandedChange?.({
+      item: entry.item,
+      depth: entry.depth,
+      expanded,
     })
   }, [])
+
+  const setRowExpanded = useCallback(
+    (rowId: string, expanded: boolean) => {
+      const current = expansionStateRef.current
+      if (current.overrides[rowId] === expanded) return
+      commitExpansionState({
+        ...current,
+        overrides: { ...current.overrides, [rowId]: expanded },
+        eager: expanded ? current.eager : { ...current.eager, [rowId]: false },
+      })
+      emitExpandedChange(rowId, expanded)
+    },
+    [commitExpansionState, emitExpandedChange]
+  )
+
+  /**
+   * Consumes a pending `expandTo` entry for the given row, expanding it (and
+   * flagging eager loading when requested). No-op when the row's item id has
+   * no pending request.
+   */
+  const applyPendingExpansion = useCallback(
+    (rowId: string, item: R, depth: number) => {
+      if (!("id" in item)) return
+      const itemId = item.id as string | number
+      const pendingOptions = pendingExpandRef.current.get(itemId)
+      if (pendingOptions === undefined) return
+      pendingExpandRef.current.delete(itemId)
+
+      const current = expansionStateRef.current
+      const resolved = resolveExpansion(current, rowId, { item, depth })
+      const eager = pendingOptions.children === "all"
+      if (resolved.expanded && (!eager || resolved.eager)) return
+
+      commitExpansionState({
+        ...current,
+        overrides: { ...current.overrides, [rowId]: true },
+        eager: eager ? { ...current.eager, [rowId]: true } : current.eager,
+      })
+      if (!resolved.expanded) emitExpandedChange(rowId, true)
+    },
+    [commitExpansionState, emitExpandedChange]
+  )
+
+  const registerNestedRow = useCallback(
+    (rowId: string, item: R, depth: number) => {
+      registryRef.current.set(rowId, { item, depth })
+      applyPendingExpansion(rowId, item, depth)
+      return () => {
+        registryRef.current.delete(rowId)
+      }
+    },
+    [applyPendingExpansion]
+  )
+
+  const resolveRowExpansion = useCallback(
+    (rowId: string, item: R, depth: number) =>
+      resolveExpansion(expansionState, rowId, { item, depth }),
+    [expansionState]
+  )
+
+  const engine = useMemo<NestedExpansionEngine<R>>(() => {
+    const resolveTargets = (target: NestedRowTarget<R>) => {
+      const matches: Array<{ rowId: string } & NestedRowRegistryEntry<R>> = []
+      registryRef.current.forEach((entry, rowId) => {
+        if (matchesTarget(target, entry)) matches.push({ rowId, ...entry })
+      })
+      return matches
+    }
+
+    const applyToTargets = (
+      target: NestedRowTarget<R>,
+      resolveNext: (current: ResolvedRowExpansion) => boolean,
+      options?: NestedExpandOptions
+    ) => {
+      const matches = resolveTargets(target)
+      if (matches.length === 0) return
+
+      const current = expansionStateRef.current
+      const overrides = { ...current.overrides }
+      const eager = { ...current.eager }
+      const changes: Array<{ rowId: string; expanded: boolean }> = []
+
+      for (const match of matches) {
+        const resolved = resolveExpansion(current, match.rowId, {
+          item: match.item,
+          depth: match.depth,
+        })
+        const nextExpanded = resolveNext(resolved)
+        overrides[match.rowId] = nextExpanded
+        if (nextExpanded && options?.children === "all") {
+          eager[match.rowId] = true
+        } else if (!nextExpanded) {
+          eager[match.rowId] = false
+        }
+        if (resolved.expanded !== nextExpanded) {
+          changes.push({ rowId: match.rowId, expanded: nextExpanded })
+        }
+      }
+
+      commitExpansionState({ ...current, overrides, eager })
+      changes.forEach(({ rowId, expanded }) =>
+        emitExpandedChange(rowId, expanded)
+      )
+    }
+
+    return {
+      expand: (target, options) => applyToTargets(target, () => true, options),
+      collapse: (target) => applyToTargets(target, () => false),
+      toggle: (target, options) =>
+        applyToTargets(target, (current) => !current.expanded, options),
+      expandAll: (options) => {
+        pendingExpandRef.current.clear()
+        commitExpansionState({
+          overrides: {},
+          eager: {},
+          policy: {
+            criteria: buildExpandAllCriteria(options),
+            children: options?.children ?? "paginated",
+          },
+        })
+      },
+      collapseAll: () => {
+        pendingExpandRef.current.clear()
+        commitExpansionState({ overrides: {}, eager: {}, policy: null })
+      },
+      expandTo: (path, options) => {
+        if (path.length === 0) return
+        const normalizedOptions = options ?? {}
+        path.forEach((id) =>
+          pendingExpandRef.current.set(id, normalizedOptions)
+        )
+        // Apply immediately to the rows already rendered; the rest of the
+        // path is consumed as lazy loading registers each revealed level.
+        registryRef.current.forEach((entry, rowId) =>
+          applyPendingExpansion(rowId, entry.item, entry.depth)
+        )
+      },
+      isExpanded: (target) => {
+        const [first] = resolveTargets(target)
+        if (!first) return false
+        return resolveExpansion(expansionStateRef.current, first.rowId, {
+          item: first.item,
+          depth: first.depth,
+        }).expanded
+      },
+      getExpandedItems: () => {
+        const items: R[] = []
+        registryRef.current.forEach((entry, rowId) => {
+          const { expanded } = resolveExpansion(
+            expansionStateRef.current,
+            rowId,
+            { item: entry.item, depth: entry.depth }
+          )
+          if (expanded) items.push(entry.item)
+        })
+        return items
+      },
+    }
+  }, [applyPendingExpansion, commitExpansionState, emitExpandedChange])
+
+  const control = nested?.control
+  useEffect(() => {
+    const internalControl = control as
+      | NestedTableControllerInternal<R>
+      | undefined
+    if (!internalControl?.__bindEngine) return
+    return internalControl.__bindEngine(engine)
+  }, [control, engine])
 
   return (
     <NestedDataContext.Provider
@@ -66,8 +349,10 @@ export const NestedDataProvider = <R extends RecordType>({
           fetchedData,
           updateFetchedData,
           clearFetchedData,
-          expandedRowIds,
           setRowExpanded,
+          resolveRowExpansion,
+          registerNestedRow,
+          expandAnimation: nested?.expandAnimation ?? "none",
         } as NestedDataContextValue<RecordType>
       }
     >

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
@@ -14,6 +14,7 @@ import { NavigationFiltersDefinition } from "../../../navigationFilters/types"
 import { PropertyDefinition } from "../../../property-render"
 import { SummariesDefinition, SummaryKey } from "../../../summary"
 import { CollectionProps } from "../../../types"
+import { NestedTableOptions } from "./nested/types"
 
 export type TableVisualizationSettings = {
   order?: ColId[]
@@ -165,6 +166,13 @@ export type TableVisualizationOptions<
    * Useful for embedding the table inside panels or detail views.
    */
   bordered?: boolean
+
+  /**
+   * Behavior of nested rows (sources with `fetchChildren`): default expansion
+   * criteria, programmatic control via `useNestedTable()`, children load mode
+   * and expand animation.
+   */
+  nested?: NestedTableOptions<R>
 }
 
 export type TableCollectionProps<


### PR DESCRIPTION
## Stack

This PR is part of a 5-PR stack that splits the original nested-expansion work into reviewable units. Each PR targets the previous one; review and merge top to bottom.

1. #4784 **(this PR)** — programmatic nested-table expansion control
2. #4785 — search/filter alignment
3. #4786 — controlled expansion via `nested.expanded` + adapter-driven eager loading
4. #4787 — policy/load-mode hardening
5. #4611 — identity keying + final review fixes

> ⚠️ The repo squash-merges: after each PR merges, GitHub retargets the next one to `main` automatically, but its branch must be rebased (`git rebase --onto main <merged-branch> <next-branch>` + force-push) so the already-squashed commits don't show up in its diff.

## Description

Nested tables in the Data Collection pattern could only be expanded by clicking each chevron, with no way to control expansion from code. This PR adds a programmatic expansion system to the table visualization: a declarative auto-expansion policy, an imperative controller hook (`useNestedTable`), control over how children pages load (keep the "show more" row vs eager-load every page), targeted deep-node reveal, expand animations, and an `onExpandedChange` callback.

## Storybook

📖 **Docs — [Programmatic Expansion Control](https://ds.factorial.dev/?path=/docs/patterns-data-collection-visualizations-table--documentation#programmatic-expansion-control)** (`Table` docs page, new section — link resolves once this branch's Storybook is deployed)

Interactive stories:

- [`TableNestedProgrammaticControl`](https://ds.factorial.dev/?path=/story/patterns-data-collection-visualizations-table--table-nested-programmatic-control) — full playground: bulk expansion, targeted operations (`expand`/`toggle`/`expandTo`), children load mode, animation switcher and reset
- [`TableNestedAutoExpandFirstLevel`](https://ds.factorial.dev/?path=/story/patterns-data-collection-visualizations-table--table-nested-auto-expand-first-level) — declarative `defaultExpanded: 1` (with play assertion)
- [`TableNestedAutoExpandCriteria`](https://ds.factorial.dev/?path=/story/patterns-data-collection-visualizations-table--table-nested-auto-expand-criteria) — predicate-based policy + eager children loading, with reset
- [`TableNestedExpandAnimation`](https://ds.factorial.dev/?path=/story/patterns-data-collection-visualizations-table--table-nested-expand-animation) — animation modes with expand/collapse/reset controls

## Implementation details

- feat: add `nested` option to `TableVisualizationOptions` — `defaultExpanded` (boolean | depth number | `({ item, depth }) => boolean`), `defaultExpandedChildren` (`"paginated"` | `"all"`), `control`, `expandAnimation`, `onExpandedChange`
- feat: add `useNestedTable()` controller hook — `expand`/`collapse`/`toggle` by item id or predicate, `expandAll({ depth, where, children })`, `collapseAll`, `expandTo(idPath)`, `isExpanded`, `getExpandedItems`; operations invoked before the table mounts are queued and applied on mount

  <details>
  <summary>How expansion is resolved</summary>

  Each rendered expandable row resolves its state as *explicit override → active policy → collapsed*. Policies (`defaultExpanded`, `expandAll`) are re-evaluated for rows revealed later by lazy loading, so auto-expansion cascades naturally through a tree that loads on demand, while a manual collapse always wins over an active policy. `expandTo` keeps not-yet-rendered ids pending and consumes them as each level registers, so a single call reveals a node buried under collapsed, unloaded ancestors.
  </details>

- feat: children fetching is now driven by the resolved open state (effect-based) instead of the click handler, so policy/controller-opened rows lazy-load their children too; eager mode (`children: "all"`) chains pages with a defensive page cap (made fully adapter-driven later in the stack)
- feat: add expand animations (`fade`, `stagger`, `slide`, `pop`) — GPU-composited (`opacity`/`transform` only), staggered by sibling index and depth so cached subtrees still cascade level by level, disabled under `prefers-reduced-motion`
- fix: filters/sortings changes now reset expansion in the provider only (overrides cleared, policy preserved) — the previous per-row collapse callback left a residual explicit-collapse override on an arbitrary row and emitted spurious `onExpandedChange` events
- docs: new "Programmatic Expansion Control" section in the Table MDX + 4 interactive stories
- test: 25 new unit tests (`NestedExpansionControl.test.tsx`) covering policies, controller operations, predicate targets, `expandTo` path resolution, pre-mount queueing and controller unbind/rebind, filters reset and eager-loading guards

https://github.com/user-attachments/assets/3e9df238-ec52-44df-9a46-256b38255a79

## Testing

- `pnpm vitest run` on `src/patterns/OneDataCollection/visualizations/collection/Table` at this commit: 114 tests passing (9 files) — no regressions in `NestedSelection` / `Table` / `EditableTable`
- `pnpm tsc` and `pnpm format:check` green at this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)