### PR TITLE
feat(OneDataCollection): control nested expansion via nested.expanded

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.mdx
@@ -833,9 +833,10 @@ nested: {
 
 By default expanded rows keep their children paginated behind a "show more"
 row. Set `defaultExpandedChildren: "all"` (or `children: "all"` on controller
-operations) to fetch every page eagerly so the subtree is fully visible. Eager
-loading is guarded by the reported `total` and a page cap, so a misbehaving
-adapter cannot cause an infinite fetch loop.
+operations) to fetch every page eagerly so the subtree is fully visible. The
+adapter fully drives when eager loading stops: on `hasMore: false`, on
+reaching the reported `total`, or on a fetch error — make sure your adapter
+reports these signals accurately.
 
 #### Controlled expansion: `expanded`
 

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.mdx
@@ -837,6 +837,29 @@ operations) to fetch every page eagerly so the subtree is fully visible. Eager
 loading is guarded by the reported `total` and a page cap, so a misbehaving
 adapter cannot cause an infinite fetch loop.
 
+#### Controlled expansion: `expanded`
+
+`expanded` accepts the same criteria shape as `defaultExpanded`, but unlike
+it, the provider re-applies it every time its reference changes — a
+controlled counterpart, mirroring `revealNodeId`/`focusOnEntry` on the Graph
+visualization. Precedence is `expanded` (controlled) > `control`
+(imperative) > `defaultExpanded` (uncontrolled, mount-only): calling
+`control` while `expanded` is set still works immediately, but the
+controlled criteria takes over again on the next `expanded` change. Pass a
+stable/memoized predicate (or a primitive) to avoid re-applying it every
+render.
+
+```tsx
+const [depth, setDepth] = useState(1)
+
+nested: {
+  expanded: depth, // re-applied whenever `depth` changes
+  control: nestedTable, // still usable, but overridden on the next `expanded` change
+}
+```
+
+<Canvas of={TableStories.TableNestedControlledExpansion} meta={TableStories} />
+
 #### Imperative controller: `useNestedTable`
 
 Create a controller with `useNestedTable()` and pass it via

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -1271,6 +1271,58 @@ export const TableNestedProgrammaticControl: Story = {
 }
 
 /**
+ * Controlled declarative expansion via `nested.expanded` (mirrors
+ * `revealNodeId`/`focusOnEntry` on the Graph visualization): unlike
+ * `defaultExpanded` (read once at mount), the criteria passed here is
+ * re-applied every time its reference changes, taking over from whatever the
+ * imperative controller may have done in between — a click on "Toggle
+ * Platform team" collapses/expands it immediately, but the next depth change
+ * below reimposes the controlled criteria over the whole tree.
+ */
+export const TableNestedControlledExpansion: Story = {
+  render: function Render() {
+    const nestedTable = useNestedTable<OrgNode>()
+    const [depth, setDepth] = useState(1)
+
+    return (
+      <div className="flex flex-col gap-4">
+        <NestedDemoSection title="Controlled depth (nested.expanded)">
+          {[0, 1, 2].map((value) => (
+            <F0Button
+              key={value}
+              size="sm"
+              variant={depth === value ? "default" : "outline"}
+              label={`Depth ${value}`}
+              onClick={() => setDepth(value)}
+            />
+          ))}
+        </NestedDemoSection>
+        <NestedDemoSection title="Imperative controller (overridden on next depth change)">
+          <F0Button
+            size="sm"
+            variant="outline"
+            label="Toggle Platform team"
+            onClick={() => nestedTable.toggle("engineering.platform")}
+          />
+        </NestedDemoSection>
+        <OrgNestedTable
+          nested={{
+            control: nestedTable,
+            expanded: depth,
+          }}
+        />
+      </div>
+    )
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    // depth: 1 expands root rows only
+    await canvas.findByText("Platform")
+    expect(canvas.queryByText("Core Squad")).toBeNull()
+  },
+}
+
+/**
  * Declarative auto-expansion: `defaultExpanded: 1` opens every root row on
  * mount (2 visible levels). Children keep their "show more" pagination.
  */

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -29,6 +29,7 @@ import {
 import { Add } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
+import { getActiveFilterKeys } from "@/patterns/OneFilterPicker/internal/getActiveFilterKeys"
 import { PagesPagination } from "@/patterns/OneDataCollection/components/PagesPagination"
 import { useDataCollectionSettings } from "@/patterns/OneDataCollection/Settings/SettingsProvider"
 import { GroupHeader } from "@/ui/GroupHeader/index"
@@ -128,7 +129,8 @@ export const TableCollection = <
   TableVisualizationOptions<R, Filters, Sortings, Summaries>
 > &
   TableCustomizationProps<R, Sortings, Summaries>) => {
-  const { t, ...i18n } = useI18n()
+  const i18nContext = useI18n()
+  const { t, ...i18n } = i18nContext
   const addRow = useAddRow()
   // Created a motion component for the row
   const [MotionRow] = useState(() =>
@@ -342,12 +344,23 @@ export const TableCollection = <
     // keystroke would flip `hasActiveFilters` ~200ms before the nested-rows
     // cache is actually invalidated.
     if (normalizeSearch(source.debouncedCurrentSearch)) return true
-    return Object.values(source.currentFilters ?? {}).some((value) =>
-      Array.isArray(value)
-        ? value.length > 0
-        : value !== undefined && value !== null
+    // Delegate to the per-filter-type `isEmpty` semantics (same check the
+    // collection itself uses), so a cleared filter left at its empty value
+    // (e.g. a search filter set to "") does not count as active.
+    if (!source.filters) return false
+    return (
+      getActiveFilterKeys(
+        source.filters,
+        source.currentFilters ?? {},
+        i18nContext
+      ).length > 0
     )
-  }, [source.debouncedCurrentSearch, source.currentFilters])
+  }, [
+    source.debouncedCurrentSearch,
+    source.filters,
+    source.currentFilters,
+    i18nContext,
+  ])
 
   /*
    * Initial loading

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/NestedExpansionControl.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/NestedExpansionControl.test.tsx
@@ -18,6 +18,7 @@ import { TableCollection } from "../index"
 import { useNestedTable } from "../nested"
 import {
   matchesExpansionCriteria,
+  NestedExpansionCriteria,
   NestedTableController,
   NestedTableOptions,
 } from "../nested/types"
@@ -213,6 +214,100 @@ const MutableSourceHarness = ({
     [initialOverrides, overrides]
   )
   onApi({ control, setOverrides })
+
+  return (
+    <TableCollection<
+      Person,
+      FiltersDefinition,
+      SortingsDefinition,
+      SummariesDefinition,
+      ItemActionsDefinition<Person>,
+      NavigationFiltersDefinition,
+      GroupingDefinition<Person>
+    >
+      columns={columns}
+      source={source}
+      onSelectItems={vi.fn()}
+      onLoadData={vi.fn()}
+      onLoadError={vi.fn()}
+      nested={{ ...nested, control }}
+    />
+  )
+}
+
+/**
+ * Harness for the controlled `nested.expanded` option: lets a test change
+ * the criteria at runtime and observe the imperative controller alongside
+ * it (to exercise the documented precedence between the two).
+ */
+const ControlledExpansionHarness = ({
+  initialExpanded,
+  onApi,
+}: {
+  initialExpanded?: NestedExpansionCriteria<Person>
+  onApi: (api: {
+    control: NestedTableController<Person>
+    setExpanded: (value: NestedExpansionCriteria<Person> | undefined) => void
+  }) => void
+}) => {
+  const [expanded, setExpanded] = useState<
+    NestedExpansionCriteria<Person> | undefined
+  >(initialExpanded)
+  const control = useNestedTable<Person>()
+  onApi({ control, setExpanded })
+
+  return (
+    <TableCollection<
+      Person,
+      FiltersDefinition,
+      SortingsDefinition,
+      SummariesDefinition,
+      ItemActionsDefinition<Person>,
+      NavigationFiltersDefinition,
+      GroupingDefinition<Person>
+    >
+      columns={columns}
+      source={createSource()}
+      onSelectItems={vi.fn()}
+      onLoadData={vi.fn()}
+      onLoadError={vi.fn()}
+      nested={{ control, expanded }}
+    />
+  )
+}
+
+/**
+ * Harness that only varies `debouncedCurrentSearch`, keeping every other
+ * source reference (filters, sortings, navigation filters) stable across
+ * updates. Needed to isolate the search-normalization fix from the
+ * `filtersChanged`/`sortingsChanged` identity checks in `useLoadChildren`,
+ * which — unlike search — compare by reference and would otherwise mask a
+ * spurious invalidation behind a legitimate one.
+ */
+const SearchOnlyMutableSourceHarness = ({
+  nested,
+  fetchChildren,
+  onApi,
+}: {
+  nested?: Omit<NestedTableOptions<Person>, "control">
+  fetchChildren: TestSource["fetchChildren"]
+  onApi: (api: {
+    control: NestedTableController<Person>
+    setSearch: (search: string | undefined) => void
+  }) => void
+}) => {
+  const [search, setSearch] = useState<string | undefined>(undefined)
+  const control = useNestedTable<Person>()
+  const baseSource = useMemo(() => createSource(), [])
+  const source = useMemo(
+    () => ({
+      ...baseSource,
+      fetchChildren,
+      debouncedCurrentSearch: search,
+    }),
+    [baseSource, fetchChildren, search]
+  )
+  onApi({ control, setSearch })
 
   return (
     <TableCollection<
@@ -699,6 +794,123 @@ describe("Nested table expansion control", () => {
         depth: 0,
         hasActiveFilters: false,
         expanded: false,
+      })
+    })
+  })
+
+  describe("search normalization (undefined vs empty string)", () => {
+    it('does not clear the children cache or refetch on an undefined→"" search transition', async () => {
+      const fetchChildren = vi.fn(({ item }: { item: Person }) => ({
+        records: item.children ?? [],
+      }))
+      let api!: {
+        control: NestedTableController<Person>
+        setSearch: (search: string | undefined) => void
+      }
+      render(
+        <SearchOnlyMutableSourceHarness
+          fetchChildren={
+            fetchChildren as unknown as TestSource["fetchChildren"]
+          }
+          nested={{ defaultExpanded: 1 }}
+          onApi={(a) => {
+            api = a
+          }}
+        />
+      )
+      await waitFor(() => {
+        expect(screen.getByText("Child One")).toBeInTheDocument()
+      })
+      const callsBeforeTransition = fetchChildren.mock.calls.length
+
+      // A consumer initializing a controlled search input commonly calls
+      // `setSearch("")` on mount, producing this exact transition.
+      act(() => api.setSearch(""))
+
+      // The row stays expanded with its cached children, and no refetch was
+      // triggered by the (spurious) cache invalidation this used to cause.
+      await waitFor(() => {
+        expect(screen.getByText("Child One")).toBeInTheDocument()
+      })
+      expect(fetchChildren).toHaveBeenCalledTimes(callsBeforeTransition)
+    })
+  })
+
+  describe("re-expanding rows with empty cached children", () => {
+    it("refetches when a row whose children resolved to an empty list is re-expanded", async () => {
+      const fetchChildren = vi.fn(() => ({ records: [] }))
+      const table = renderNestedTable(undefined, {
+        fetchChildren,
+      } as unknown as Partial<TestSource>)
+      await waitForRootRows()
+
+      act(() => table.control.expand("p1"))
+      await waitFor(() => {
+        expect(fetchChildren).toHaveBeenCalledTimes(1)
+      })
+
+      act(() => table.control.collapse("p1"))
+      act(() => table.control.expand("p1"))
+
+      await waitFor(() => {
+        expect(fetchChildren).toHaveBeenCalledTimes(2)
+      })
+    })
+
+    it("does not refetch on every render while the row stays expanded (no fetch loop)", async () => {
+      const fetchChildren = vi.fn(() => ({ records: [] }))
+      const table = renderNestedTable(undefined, {
+        fetchChildren,
+      } as unknown as Partial<TestSource>)
+      await waitForRootRows()
+
+      act(() => table.control.expand("p1"))
+      await waitFor(() => {
+        expect(fetchChildren).toHaveBeenCalledTimes(1)
+      })
+
+      // Re-render without collapsing/re-expanding: still just one call.
+      act(() => table.control.expand("p1"))
+      await waitFor(() => {
+        expect(fetchChildren).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  describe("controlled expansion (`nested.expanded`)", () => {
+    it("reactively applies the criteria on change, taking precedence over the imperative controller", async () => {
+      let api!: {
+        control: NestedTableController<Person>
+        setExpanded: (
+          value: NestedExpansionCriteria<Person> | undefined
+        ) => void
+      }
+      render(
+        <ControlledExpansionHarness
+          initialExpanded={1}
+          onApi={(a) => {
+            api = a
+          }}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText("Child One")).toBeInTheDocument()
+      })
+      expect(screen.queryByText("Grandchild One")).not.toBeInTheDocument()
+
+      // The imperative controller still works immediately…
+      act(() => api.control.collapse("p1"))
+      await waitFor(() => {
+        expect(screen.queryByText("Child One")).not.toBeInTheDocument()
+      })
+
+      // …but changing the controlled criteria reimposes it, overriding the
+      // controller's explicit collapse.
+      act(() => api.setExpanded(2))
+      await waitFor(() => {
+        expect(screen.getByText("Child One")).toBeInTheDocument()
+        expect(screen.getByText("Grandchild One")).toBeInTheDocument()
       })
     })
   })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -16,8 +16,8 @@
  *
  */
 
-import { motion } from "motion/react"
-import { forwardRef, useCallback, useEffect, useMemo, useRef } from "react"
+import { motion, MotionProps } from "motion/react"
+import { forwardRef, useCallback, useEffect, useRef } from "react"
 
 import type { TableVisualizationType } from "@/patterns/OneDataCollection/types"
 
@@ -72,6 +72,27 @@ const normalizeAddRowActions = (
  * instead of appearing all at once.
  */
 const mountStaggerIndex = (index: number, depth: number) => index + depth * 2
+
+/**
+ * Motion-wrapped Row shared by every animated nested row, created lazily on
+ * first use. motion's proxy does not cache custom components, so creating
+ * this inside the row component would allocate one distinct wrapper type per
+ * rendered row. Generics are type-level only, so a single runtime wrapper
+ * serves every table; prop safety is preserved by the parallel plain-`Row`
+ * branch at each call site, which receives the same props fully typed.
+ */
+type SharedMotionRow = React.ForwardRefExoticComponent<
+  MotionProps &
+    Record<string, unknown> &
+    React.RefAttributes<HTMLTableRowElement>
+>
+let sharedMotionRow: SharedMotionRow | undefined
+const getMotionRow = (): SharedMotionRow => {
+  sharedMotionRow ??= motion.create(
+    Row as unknown as React.ComponentType<Record<string, unknown>>
+  ) as unknown as SharedMotionRow
+  return sharedMotionRow
+}
 
 export type RowProps<
   R extends RecordType,
@@ -164,14 +185,13 @@ const NestedRowContent = <
   )
 
   // Register so imperative controller operations can target this row.
-  // Keyed by `rowId` (stable per row) rather than `props.item` identity —
-  // data sources commonly recreate item objects on every render/refetch, and
-  // `rowId` already embeds the item's id, so this avoids an unregister +
-  // re-register cycle on every render.
+  // `props.item` is included so the registry entry stays fresh after a
+  // refetch recreates item objects: controller predicates, getExpandedItems
+  // and onExpandedChange must see current field values, not the first-render
+  // snapshot. Re-registering on item identity change is two cheap Map ops.
   useEffect(
     () => registerNestedRow(rowId, props.item, depth),
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally keyed by rowId, not props.item identity (see comment above)
-    [registerNestedRow, rowId, depth]
+    [registerNestedRow, rowId, props.item, depth]
   )
 
   /**
@@ -230,9 +250,12 @@ const NestedRowContent = <
    * legitimate empty result from ever being retried. Only refetch on a fresh
    * collapsed→expanded transition (tracked via `previousOpenRef`), not on
    * every render while the row stays open, so a genuinely empty result
-   * cannot cause a fetch loop.
+   * cannot cause a fetch loop. The ref starts as `false` so a row that
+   * remounts already-open (e.g. revealed by re-expanding a collapsed
+   * ancestor) with cached empty children also counts as a transition and
+   * retries once, matching the behavior of toggling the row itself.
    */
-  const previousOpenRef = useRef(open)
+  const previousOpenRef = useRef(false)
   useEffect(() => {
     const wasOpen = previousOpenRef.current
     previousOpenRef.current = open
@@ -340,40 +363,19 @@ const NestedRowContent = <
    * `nested/animations.ts` for the variants); collapsing stays instant.
    */
   const shouldReduceMotion = useReducedMotion()
-  const animated = expandAnimation !== "none" && !shouldReduceMotion
-  // Lazy: only pay for a motion-wrapped component when an animation is
-  // actually configured — rows using the default "none" animation render the
-  // plain `Row` instead (see usages below). Keyed by whether animation is
-  // enabled (not by the specific mode) so switching between animated modes
-  // at runtime reuses the same wrapped component, while flipping from
-  // "none" to an animated mode still creates it on demand.
   const hasAnimation = expandAnimation !== "none"
-  const MotionRow = useMemo(
-    () =>
-      hasAnimation
-        ? motion.create(
-            Row<
-              R,
-              Filters,
-              Sortings,
-              Summaries,
-              ItemActions,
-              NavigationFilters,
-              Grouping
-            >
-          )
-        : undefined,
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- keyed by hasAnimation only, see comment above
-    [hasAnimation]
-  )
-  const mountAnimationProps =
-    expandAnimation !== "none"
-      ? {
-          variants: getExpandAnimationVariants(expandAnimation),
-          initial: "hidden" as const,
-          animate: "visible" as const,
-        }
-      : {}
+  const animated = hasAnimation && !shouldReduceMotion
+  // Lazy: only pay for the motion-wrapped component when an animation is
+  // actually configured — rows using the default "none" animation render the
+  // plain `Row` instead (see usages below).
+  const MotionRow = hasAnimation ? getMotionRow() : undefined
+  const mountAnimationProps = hasAnimation
+    ? {
+        variants: getExpandAnimationVariants(expandAnimation),
+        initial: "hidden" as const,
+        animate: "visible" as const,
+      }
+    : {}
 
   const isTableVisualization = props.fromVisualization === "table"
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -17,14 +17,7 @@
  */
 
 import { motion } from "motion/react"
-import {
-  forwardRef,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react"
+import { forwardRef, useCallback, useEffect, useMemo, useRef } from "react"
 
 import type { TableVisualizationType } from "@/patterns/OneDataCollection/types"
 
@@ -71,12 +64,6 @@ const normalizeAddRowActions = (
     (item): item is PrimaryActionItemDefinition => item !== undefined
   )
 }
-
-/**
- * Safety cap for eager children loading (`children: "all"`): stops fetching
- * further pages even if the adapter keeps reporting `hasMore`.
- */
-const MAX_EAGER_CHILDREN_PAGES = 100
 
 /**
  * Stagger index for row mount animations. Depth contributes to the delay so
@@ -215,15 +202,13 @@ const NestedRowContent = <
    * avoiding retry loops when a fetch errors.
    */
   const autoLoadRequestedRef = useRef(false)
-  const [eagerPagesRequested, setEagerPagesRequested] = useState(0)
 
-  // Re-arm the request guards when the children cache is invalidated (e.g. a
+  // Re-arm the request guard when the children cache is invalidated (e.g. a
   // filters change) so rows kept open by a policy reload their children.
   const previousHasFetchedRef = useRef(hasFetched)
   useEffect(() => {
     if (previousHasFetchedRef.current && !hasFetched) {
       autoLoadRequestedRef.current = false
-      setEagerPagesRequested(0)
     }
     previousHasFetchedRef.current = hasFetched
   }, [hasFetched])
@@ -265,9 +250,10 @@ const NestedRowContent = <
 
   /**
    * Eager pagination (`children: "all"`): keeps fetching pages until the
-   * adapter reports no more. Guarded by `total`, a page cap and the error
-   * flag, so a misbehaving or failing adapter cannot cause a fetch loop —
-   * remaining pages fall back to the "show more" row.
+   * adapter reports no more. The adapter fully drives when to stop — loading
+   * halts on `hasMore: false`, on reaching `total`, or on a fetch error, so a
+   * failing adapter cannot cause a retry loop and remaining pages fall back
+   * to the "show more" row.
    */
   const eagerLoadPending =
     open &&
@@ -276,18 +262,12 @@ const NestedRowContent = <
     !hasError &&
     !!paginationInfo?.hasMore &&
     (paginationInfo.total === undefined ||
-      children.length < paginationInfo.total) &&
-    eagerPagesRequested < MAX_EAGER_CHILDREN_PAGES
+      children.length < paginationInfo.total)
 
   useEffect(() => {
-    if (!open || !eager) {
-      setEagerPagesRequested(0)
-      return
-    }
     if (!eagerLoadPending || isLoading) return
-    setEagerPagesRequested((count) => count + 1)
     loadChildren()
-  }, [open, eager, eagerLoadPending, isLoading, loadChildren])
+  }, [eagerLoadPending, isLoading, loadChildren])
 
   const shouldShowLoading = open && isLoading
   const shouldShowChildren = open

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/nested/animations.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/nested/animations.ts
@@ -24,66 +24,64 @@ const staggerDelay = (index: number) =>
 /** Ease used across the design system for reveals (e.g. collapsible messages). */
 const REVEAL_EASE = [0.165, 0.84, 0.44, 1] as const
 
+// Precomputed at module scope: the variants are pure of their inputs, so
+// building them once avoids a fresh allocation per animated row per render.
+const expandAnimationVariants = {
+  // All revealed rows fade in at once
+  fade: {
+    hidden: { opacity: 0 },
+    visible: () => ({
+      opacity: 1,
+      transition: { duration: 0.3, ease: REVEAL_EASE },
+    }),
+  },
+
+  // Rows fade in and settle downwards one after another
+  stagger: {
+    hidden: { opacity: 0, y: -10 },
+    visible: (index: number) => ({
+      opacity: 1,
+      y: 0,
+      transition: {
+        delay: staggerDelay(index),
+        duration: 0.3,
+        ease: REVEAL_EASE,
+      },
+    }),
+  },
+
+  // Rows slide in from the left with a soft spring, one after another
+  slide: {
+    hidden: { opacity: 0, x: -24 },
+    visible: (index: number) => ({
+      opacity: 1,
+      x: 0,
+      transition: {
+        delay: staggerDelay(index),
+        type: "spring" as const,
+        stiffness: 260,
+        damping: 26,
+      },
+    }),
+  },
+
+  // Rows scale up into place with a springy pop, one after another
+  pop: {
+    hidden: { opacity: 0, scale: 0.94, y: -6 },
+    visible: (index: number) => ({
+      opacity: 1,
+      scale: 1,
+      y: 0,
+      transition: {
+        delay: staggerDelay(index),
+        type: "spring" as const,
+        stiffness: 320,
+        damping: 20,
+      },
+    }),
+  },
+} as const
+
 export const getExpandAnimationVariants = (
   animation: Exclude<NestedExpandAnimation, "none">
-) => {
-  switch (animation) {
-    // All revealed rows fade in at once
-    case "fade":
-      return {
-        hidden: { opacity: 0 },
-        visible: () => ({
-          opacity: 1,
-          transition: { duration: 0.3, ease: REVEAL_EASE },
-        }),
-      }
-
-    // Rows fade in and settle downwards one after another
-    case "stagger":
-      return {
-        hidden: { opacity: 0, y: -10 },
-        visible: (index: number) => ({
-          opacity: 1,
-          y: 0,
-          transition: {
-            delay: staggerDelay(index),
-            duration: 0.3,
-            ease: REVEAL_EASE,
-          },
-        }),
-      }
-
-    // Rows slide in from the left with a soft spring, one after another
-    case "slide":
-      return {
-        hidden: { opacity: 0, x: -24 },
-        visible: (index: number) => ({
-          opacity: 1,
-          x: 0,
-          transition: {
-            delay: staggerDelay(index),
-            type: "spring" as const,
-            stiffness: 260,
-            damping: 26,
-          },
-        }),
-      }
-
-    // Rows scale up into place with a springy pop, one after another
-    case "pop":
-      return {
-        hidden: { opacity: 0, scale: 0.94, y: -6 },
-        visible: (index: number) => ({
-          opacity: 1,
-          scale: 1,
-          y: 0,
-          transition: {
-            delay: staggerDelay(index),
-            type: "spring" as const,
-            stiffness: 320,
-            damping: 20,
-          },
-        }),
-      }
-  }
-}
+) => expandAnimationVariants[animation]

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/nested/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/nested/types.ts
@@ -148,6 +148,25 @@ export type NestedTableOptions<R extends RecordType> = {
    * @default "paginated"
    */
   defaultExpandedChildren?: NestedChildrenDisplayMode
+  /**
+   * Declarative, **controlled** expansion criteria (mirrors `revealNodeId`/
+   * `focusOnEntry` on the Graph visualization): while defined, the provider
+   * reactively re-applies it every time its reference changes, clearing any
+   * explicit override left by a user click or a `control` call — the same
+   * way a controlled input value reasserts itself on the next render where
+   * the value prop changes.
+   *
+   * Precedence: `expanded` (controlled) > `control` (imperative) >
+   * `defaultExpanded` (uncontrolled, mount-only). Calling `control` while
+   * `expanded` is set still works immediately (it is not blocked), but the
+   * controlled criteria takes over again on the next change of `expanded` —
+   * so mixing both on the same table only makes sense transiently.
+   *
+   * Uses reference equality, like any other prop-driven effect: pass a
+   * stable/memoized predicate, or a primitive (`boolean`/`number`), to avoid
+   * re-applying it on every render.
+   */
+  expanded?: NestedExpansionCriteria<R>
   /** Controller created with `useNestedTable()` for programmatic control. */
   control?: NestedTableController<R>
   /**

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/providers/NestedProvider.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/providers/NestedProvider.tsx
@@ -356,6 +356,34 @@ export const NestedDataProvider = <R extends RecordType>({
     }
   }, [applyPendingExpansion, commitExpansionState, emitExpandedChange])
 
+  /**
+   * Controlled expansion (`nested.expanded`): reactively re-applies the
+   * criteria every time its reference changes, taking over from whatever
+   * explicit overrides a user click or a `control` call may have set in the
+   * meantime — see the precedence note on `NestedTableOptions.expanded`.
+   * Unlike `defaultExpanded` (read once, at mount, via the initial state
+   * above), this runs on every `expanded` reference change, including the
+   * first one, so it also covers the initial render when `expanded` is
+   * defined from the start.
+   */
+  const controlledExpanded = nested?.expanded
+  useEffect(() => {
+    if (controlledExpanded === undefined) return
+    pendingExpandRef.current.clear()
+    commitExpansionState({
+      overrides: {},
+      eager: {},
+      policy: {
+        criteria: controlledExpanded,
+        children:
+          nestedOptionsRef.current?.defaultExpandedChildren ?? "paginated",
+      },
+    })
+    // Controlled re-application is not an explicit expansion change (same as
+    // defaultExpanded/expandAll), so onExpandedChange is intentionally not
+    // fired here.
+  }, [controlledExpanded, commitExpansionState])
+
   const control = nested?.control
   useEffect(() => {
     const internalControl = control as

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/providers/NestedProvider.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/providers/NestedProvider.tsx
@@ -393,20 +393,34 @@ export const NestedDataProvider = <R extends RecordType>({
     return internalControl.__bindEngine(engine)
   }, [control, engine])
 
+  // Memoized so parent re-renders with unchanged expansion state don't force
+  // every consuming row to re-render: all callbacks are stable useCallbacks,
+  // so the identity only changes on real state updates.
+  const expandAnimation = nested?.expandAnimation ?? "none"
+  const contextValue = useMemo(
+    () =>
+      ({
+        fetchedData,
+        updateFetchedData,
+        clearFetchedData,
+        setRowExpanded,
+        resolveRowExpansion,
+        registerNestedRow,
+        expandAnimation,
+      }) as NestedDataContextValue<RecordType>,
+    [
+      fetchedData,
+      updateFetchedData,
+      clearFetchedData,
+      setRowExpanded,
+      resolveRowExpansion,
+      registerNestedRow,
+      expandAnimation,
+    ]
+  )
+
   return (
-    <NestedDataContext.Provider
-      value={
-        {
-          fetchedData,
-          updateFetchedData,
-          clearFetchedData,
-          setRowExpanded,
-          resolveRowExpansion,
-          registerNestedRow,
-          expandAnimation: nested?.expandAnimation ?? "none",
-        } as NestedDataContextValue<RecordType>
-      }
-    >
+    <NestedDataContext.Provider value={contextValue}>
       {children}
     </NestedDataContext.Provider>
   )


### PR DESCRIPTION
## Stack

This PR is part of a 5-PR stack that splits the original nested-expansion work into reviewable units. Each PR targets the previous one; review and merge top to bottom.

1. #4784 — programmatic nested-table expansion control
2. #4785 — search/filter alignment
3. #4786 **(this PR)** — controlled expansion via `nested.expanded` + adapter-driven eager loading
4. #4787 — policy/load-mode hardening
5. #4611 — identity keying + final review fixes

> ⚠️ The repo squash-merges: after each PR merges, GitHub retargets the next one to `main` automatically, but its branch must be rebased (`git rebase --onto main <merged-branch> <next-branch>` + force-push) so the already-squashed commits don't show up in its diff.

## Description

Adds declarative, controlled expansion for nested tables via `nested.expanded` (mirrors the Graph's `revealNodeId`/`focusOnEntry` pattern): while defined, the provider re-applies the criteria whenever its reference changes, taking over from user clicks or imperative controller calls. It also removes the artificial page cap so the adapter fully drives eager children loading, and applies the findings of an adversarially-verified review pass over the branch.

## Storybook

- [`TableNestedControlledExpansion`](https://ds.factorial.dev/?path=/story/patterns-data-collection-visualizations-table--table-nested-controlled-expansion) — controlled `nested.expanded` reasserting itself over imperative controller calls (with play assertion)

## Implementation details

- feat: controlled declarative expansion via `nested.expanded` — precedence: `expanded` (controlled) > `control` (imperative) > `defaultExpanded` (mount-only); new story, MDX section and tests
- refactor: remove the hardcoded `MAX_EAGER_CHILDREN_PAGES` backstop — eager loading (`children: "all"`) now stops solely on the adapter-reported signals: `hasMore: false`, reaching `total`, or a fetch error
- fix: `hasActiveFilters` delegates to `getActiveFilterKeys` (per-filter-type `isEmpty` semantics), so a filter cleared to its empty value (e.g. a search filter left as `""`) no longer counts as active and no longer keeps `hasActiveFilters`-driven expansion policies engaged
- fix: the nested-row registry re-registers when the item identity changes, so controller predicates, `getExpandedItems` and `onExpandedChange` see current field values after a refetch instead of the first-render snapshot
- fix: a row that remounts already-open with cached empty children retries the fetch once, matching the behavior of toggling the row itself
- perf: the `NestedDataContext` value is memoized (all its callbacks were already stable), so unrelated parent re-renders no longer re-render every row; the motion-wrapped `Row` is a lazy module-scope singleton and the expand-animation variants are precomputed instead of rebuilt per row render
- docs: `table.mdx` no longer claims a page cap on eager children loading
- test: controlled-mode coverage added to `NestedExpansionControl.test.tsx`

## Testing

- `pnpm vitest run` on `src/patterns/OneDataCollection/visualizations/collection/Table` at this commit: 120 tests passing (9 files)
- `pnpm tsc` green at this commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)