### PR TITLE
feat(F0Text): add ai gradient text variant

### DIFF
--- a/packages/react/src/components/F0Text/F0Text.tsx
+++ b/packages/react/src/components/F0Text/F0Text.tsx
@@ -10,6 +10,7 @@ const _allowedVariants = [
   "inverse",
   "code",
   "label",
+  "ai",
 ] as const
 
 export type F0TextProps = Omit<TextProps, "className" | "variant" | "as"> & {

--- a/packages/react/src/components/F0Text/__stories__/Text.mdx
+++ b/packages/react/src/components/F0Text/__stories__/Text.mdx
@@ -85,6 +85,13 @@ Renders body copy, descriptions, code snippets, and labels across the interface.
           toasts)
         </td>
       </tr>
+      <tr>
+        <td>
+          <code>ai</code>
+        </td>
+        <td>AI gradient fill</td>
+        <td>Hints and messaging produced by or referring to AI features</td>
+      </tr>
     </tbody>
   </table>
 </Unstyled>
@@ -103,6 +110,7 @@ Renders body copy, descriptions, code snippets, and labels across the interface.
 - Use `code` for technical strings, identifiers, or short inline snippets
 - Use `label` for any UI label: form fields, stat labels, filter labels, column headers in compact layouts
 - Use `inverse` only when text appears on a dark or strongly colored background
+- Use `ai` for short AI-related hints or messaging — the gradient is a brand accent, not a reading style for long copy
 
 #### When NOT to use
 
@@ -124,6 +132,7 @@ Renders body copy, descriptions, code snippets, and labels across the interface.
 
 - The `label` variant should use `as="label"` when associated with a form input — wrap the input inside the label for correct HTML semantics, since `F0Text` does not accept a `htmlFor` prop
 - The `inverse` variant does not change contrast automatically — ensure the background provides sufficient contrast (WCAG AA: 4.5:1 for normal text)
+- The `ai` variant renders text as a gradient fill — use it on light backgrounds and keep it to short strings; parts of the gradient have lower contrast than solid foreground colors
 - Use `ellipsis` only when the full text is accessible through another means (tooltip, expanded view) — truncated text without a disclosure is an accessibility gap
 
 ---

--- a/packages/react/src/components/F0Text/__stories__/Text.stories.tsx
+++ b/packages/react/src/components/F0Text/__stories__/Text.stories.tsx
@@ -13,7 +13,15 @@ const meta = {
   tags: ["!autodocs", "experimental"],
   argTypes: {
     variant: {
-      options: ["body", "description", "small", "inverse", "code", "label"],
+      options: [
+        "body",
+        "description",
+        "small",
+        "inverse",
+        "code",
+        "label",
+        "ai",
+      ],
       control: "select",
       description: "The variant of the text",
       table: {
@@ -96,6 +104,7 @@ export const Variants: Story = {
       <F0Text variant="small" content="This is a small text." />
       <F0Text variant="code" content="const example = 'code text';" />
       <F0Text variant="label" content="Label text" />
+      <F0Text variant="ai" content="This is an AI gradient text." />
       <div className="rounded bg-f1-background-inverse p-2">
         <F0Text variant="inverse" content="Inverse text on dark background" />
       </div>
@@ -184,6 +193,7 @@ export const Snapshot: Story = {
           <F0Text variant="small" content="Small variant text" />
           <F0Text variant="code" content="const code = 'Code variant text';" />
           <F0Text variant="label" content="Label variant text" />
+          <F0Text variant="ai" content="Ai variant text" />
           <F0Text variant="inverse" content="Inverse variant text" />
         </div>
       </section>

--- a/packages/react/src/components/F0Text/__tests__/Text.test.tsx
+++ b/packages/react/src/components/F0Text/__tests__/Text.test.tsx
@@ -35,6 +35,12 @@ describe("F0Text Component", () => {
       render(<F0Text variant="label" content="Label" />)
       expect(screen.getByText("Label")).toBeInTheDocument()
     })
+
+    it("renders ai variant", () => {
+      render(<F0Text variant="ai" content="Ai" />)
+      expect(screen.getByText("Ai")).toBeInTheDocument()
+      expect(screen.getByText("Ai")).toHaveClass("bg-ai-text-gradient")
+    })
   })
 
   describe("Allowed HTML Tags", () => {

--- a/packages/react/src/ui/Text/variants.ts
+++ b/packages/react/src/ui/Text/variants.ts
@@ -28,6 +28,7 @@ export const textVariants = cva({
       "label-input": "font-medium text-f1-foreground-secondary",
 
       // Semantic text
+      ai: "bg-ai-text-gradient bg-clip-text text-transparent",
       selected: "font-medium text-f1-foreground-selected",
       warning: "text-f1-foreground-warning",
       critical: "text-f1-foreground-critical",
@@ -61,6 +62,7 @@ export const defaultTag: Record<TextVariant, AsAllowedList> = {
   label: "p",
   "label-input": "label",
   small: "p",
+  ai: "p",
   selected: "p",
   inverse: "p",
   warning: "p",

--- a/packages/react/tailwind.config.ts
+++ b/packages/react/tailwind.config.ts
@@ -20,6 +20,11 @@ export default {
         ...baseConfig.theme?.extend?.maxWidth,
         content: "712px",
       },
+      backgroundImage: {
+        ...baseConfig.theme?.extend?.backgroundImage,
+        "ai-text-gradient":
+          "linear-gradient(270deg, #E55619 0%, #E51943 50%, #A1ADE5 100%)",
+      },
       keyframes: {
         ...baseConfig.theme?.extend?.keyframes,
         "rotate-gradient": {


### PR DESCRIPTION
## Description

Adds an `ai` variant to `F0Text` that renders text with the AI brand gradient. Until now the gradient only existed as raw hex utility classes copied across `sds/ai` components, and consumers had no way to render gradient text since `F0Text` strips `className`.

## Implementation details

- feat: add `ai-text-gradient` background-image token to the Tailwind theme (`linear-gradient(270deg, #E55619 0%, #E51943 50%, #A1ADE5 100%)`, per design)
- feat: add `ai` semantic text variant (`bg-ai-text-gradient bg-clip-text text-transparent`) and expose it in `F0Text`'s allowed variants
- docs: document the variant in the Storybook stories (Variants + Snapshot) and `Text.mdx`, including a contrast/accessibility note
- test: cover the new variant in the F0Text unit tests

<img width="428" height="65" alt="Screenshot 2026-07-22 at 12 32 12" src="https://github.com/user-attachments/assets/0fbc0810-81ef-4d46-b144-8e28e3a86303" />
