### PR TITLE
fix(F0AnalyticsDashboard): stop resize handle from jumping dashboard scroll

### DIFF
--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardGrid.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/DashboardGrid.test.tsx
@@ -251,6 +251,80 @@ describe("DashboardGrid", () => {
     })
   })
 
+  describe("resize handle scroll preservation", () => {
+    function getResizeHandle(container: HTMLElement): HTMLElement {
+      const handle = container.querySelector(".group\\/resize")
+      if (!(handle instanceof HTMLElement)) {
+        throw new Error("Expected a resize handle to be rendered")
+      }
+      return handle
+    }
+
+    // The resize clamp momentarily collapses the row to `height: 0` to measure
+    // its content floor. In a real browser that synchronous shrink makes any
+    // scrollable ancestor clamp its `scrollTop` to the reduced range; jsdom has
+    // no layout, so we model that clamp at its exact trigger point — the read
+    // of a card's `scrollHeight` while its row is collapsed — by nudging the
+    // target's scroll offset to 0. Without the fix that clamp would stick; the
+    // fix snapshots the offset before the collapse and restores it after.
+    function mockScrollHeightThatClampsOnCollapse(
+      cardId: string,
+      contentHeight: number,
+      clampTarget: () => void
+    ) {
+      vi.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockImplementation(
+        function getScrollHeight(this: HTMLElement) {
+          if (this.dataset.cardId !== cardId) return 0
+          const row = this.closest("[data-dashboard-row]")
+          if (row instanceof HTMLElement && row.style.height === "0px") {
+            clampTarget()
+          }
+          return contentHeight
+        }
+      )
+    }
+
+    it("keeps a scrollable ancestor's offset when a resize handle is grabbed while scrolled down", () => {
+      const scroller = document.createElement("div")
+      // jsdom reports clientHeight 0, so any non-zero scrollHeight makes the
+      // scroller qualify as a scrollable ancestor. Instance property shadows
+      // the prototype `scrollHeight` spy set below.
+      Object.defineProperty(scroller, "scrollHeight", {
+        configurable: true,
+        get: () => 2000,
+      })
+      scroller.scrollTop = 480
+
+      mockScrollHeightThatClampsOnCollapse("headcount", 160, () => {
+        scroller.scrollTop = 0
+      })
+
+      const { container } = render(
+        <DashboardGrid items={makeMetricItems(200)} filters={{}} editMode />,
+        { container: scroller }
+      )
+
+      const handle = getResizeHandle(container)
+      fireEvent.mouseDown(handle, { clientY: 500 })
+      fireEvent.mouseUp(document, { clientY: 500 })
+
+      expect(scroller.scrollTop).toBe(480)
+    })
+
+    it("still resizes the row normally with the scroll guard in place", () => {
+      const { container } = render(
+        <DashboardGrid items={makeMetricItems(200)} filters={{}} editMode />
+      )
+
+      const handle = getResizeHandle(container)
+      fireEvent.mouseDown(handle, { clientY: 500 })
+      fireEvent.mouseMove(document, { clientY: 560 })
+      fireEvent.mouseUp(document, { clientY: 560 })
+
+      expect(getDashboardRowHeight(container)).toBe("260px")
+    })
+  })
+
   describe("content overflow containment", () => {
     it("clips vertical overflow on collection rows so a too-short row can never paint over the next one", () => {
       const { container } = render(

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardGrid/DashboardGrid.tsx
@@ -890,7 +890,9 @@ function getMinRowHeight<Filters extends FiltersDefinition>(
  * wrapper height. Content height can itself depend on the container height
  * (horizontal scrollbars appear, toolbars wrap), so a second pass re-reads
  * at the height found by the first pass and keeps the larger value. Styles
- * are restored synchronously in the same task, so nothing paints in between.
+ * are restored synchronously in the same task, so nothing paints in between —
+ * and scrollable ancestors are snapshotted/restored around the collapse so the
+ * transient shrink can't leave their scroll offset clamped (see below).
  */
 function getRowContentMinHeight(
   rowEl: HTMLElement | null | undefined,
@@ -913,6 +915,16 @@ function getRowContentMinHeight(
     return min
   }
 
+  // Collapsing the row to 0 shrinks the scrollable content. `measure()` reads
+  // `scrollHeight`, forcing a synchronous layout while the row is collapsed —
+  // and any scrollable ancestor whose `scrollTop` now exceeds its reduced
+  // scroll range gets clamped by the browser *at that layout*. Restoring the
+  // height afterwards does NOT un-clamp it (the clamp already happened, and it
+  // is a scroll mutation, not a paint), so grabbing a resize handle would jump
+  // the dashboard's scroll position. Snapshot every scrollable ancestor's
+  // offsets and restore them in the same task so the clamp is never observed.
+  const scrollSnapshot = snapshotScrollAncestors(rowEl)
+
   rowEl.style.minHeight = "0px"
   rowEl.style.height = "0px"
   const collapsed = measure()
@@ -921,7 +933,42 @@ function getRowContentMinHeight(
 
   rowEl.style.height = prevHeight
   rowEl.style.minHeight = prevMinHeight
+  restoreScrollAncestors(scrollSnapshot)
   return settled
+}
+
+/**
+ * Record the scroll offsets of every scrollable ancestor of `el` (plus the
+ * document scrolling element). Used to restore them after a synchronous
+ * layout measurement that temporarily shrinks scrollable content — see
+ * `getRowContentMinHeight`.
+ */
+function snapshotScrollAncestors(
+  el: HTMLElement
+): Array<{ el: Element; top: number; left: number }> {
+  const snapshot: Array<{ el: Element; top: number; left: number }> = []
+  let node: HTMLElement | null = el.parentElement
+  while (node) {
+    if (
+      node.scrollHeight > node.clientHeight ||
+      node.scrollWidth > node.clientWidth
+    ) {
+      snapshot.push({ el: node, top: node.scrollTop, left: node.scrollLeft })
+    }
+    node = node.parentElement
+  }
+  const doc = typeof document !== "undefined" ? document.scrollingElement : null
+  if (doc) snapshot.push({ el: doc, top: doc.scrollTop, left: doc.scrollLeft })
+  return snapshot
+}
+
+function restoreScrollAncestors(
+  snapshot: Array<{ el: Element; top: number; left: number }>
+): void {
+  for (const { el, top, left } of snapshot) {
+    if (el.scrollTop !== top) el.scrollTop = top
+    if (el.scrollLeft !== left) el.scrollLeft = left
+  }
 }
 
 function getSlotWeight<Filters extends FiltersDefinition>(


### PR DESCRIPTION
## Problem

Grabbing a dashboard row's **resize handle** jumps the whole dashboard scroll position when you're scrolled down. Repro: resize a row → scroll down → click another row's resize handle → the page jumps up (by roughly the grabbed row's height).

## Root cause

The resize-clamp measurement `getRowContentMinHeight` (added in #4740) finds a row's content floor by momentarily collapsing the row to `height: 0` and reading `card.scrollHeight`. That read forces a **synchronous layout while the row is collapsed**. If the transient shrink drops a scrollable ancestor's `scrollHeight` below its current `scrollTop`, the browser **clamps `scrollTop` at that layout**.

Scroll clamping is a layout-time mutation, not a paint — so restoring the height in the same task (which correctly kept anything from *painting*) does **not** un-clamp the scroll offset. The clamp sticks, and the dashboard jumps.

## Fix

Snapshot every scrollable ancestor's scroll offsets (plus `document.scrollingElement`) **before** the collapse, and restore them **after** the height is restored — all synchronously, so the clamp is never observed.

## Verification

- Real-browser repro with the exact collapse logic: scrolled to bottom, the measurement jumped `scrollTop` by **298px** (≈ the 300px row) before the fix, **0px** after.
- Confirmed end-to-end in the product (local f0 build swapped into factorial): resize → scroll → resize another row no longer jumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)