### PR TITLE
fix(SectionHeader): use 1px dashed separator aligned with border tokens

### DIFF
--- a/packages/react/src/patterns/SectionHeader/index.tsx
+++ b/packages/react/src/patterns/SectionHeader/index.tsx
@@ -40,7 +40,7 @@ const _SectionHeader = ({
   return (
     <div
       className={cn(
-        "border-1 flex flex-col justify-between gap-4 border-dashed border-transparent px-6 pb-5 pt-5 first:pb-0 first:pt-0 md:flex-row md:gap-2",
+        "flex flex-col justify-between gap-4 border border-dashed border-transparent px-6 pb-5 pt-5 first:pb-0 first:pt-0 md:flex-row md:gap-2",
         layout === "standard" && "-mx-[23px]",
         separator === "top" && "border-t-f1-border first:pt-5",
         separator === "bottom" && "border-b-f1-border first:pb-5"


### PR DESCRIPTION
## Description

The `SectionHeader` bottom (and top) dashed separator rendered as an unexpectedly **thick ~3px line**. This PR makes it a **1px hairline** aligned with the design-system border tokens.

## Root cause

The separator used the class `border-1`, which **does not exist in Tailwind v3** (valid widths are `border`, `border-2`, `border-4`, `border-8`). No `border-width` rule was emitted, but `border-dashed` still applied `border-style: dashed`, so the width fell back to the CSS initial value `border-width: medium` (~3px) — hence the thick line.

## Implementation details

- Replaced `border-1` → `border` (1px) in `packages/react/src/patterns/SectionHeader/index.tsx`.
- Color tokens are **unchanged**: `border-t-f1-border` / `border-b-f1-border` (the `f1-border` token family), plus `border-transparent` as the base.
- This matches the hairline separator convention already used across the library (`pagination`, `tooltip`, `dropdown-menu`, `F0Wizard`).

## Screenshots (if applicable)

Before (`border-1` → ~3px)
<img width="1800" height="340" alt="image" src="https://github.com/user-attachments/assets/1d788ea2-d917-40f8-843b-90033a1a3610" /> 
After (`border` → 1px)
<img width="1800" height="340" alt="image" src="https://github.com/user-attachments/assets/7c71d052-4316-48cc-aff4-b250b3d85318" />

<!-- Before: thick dashed line. After: fine 1px dashed hairline, same f1-border color token. -->