### PR TITLE
fix(OneDataCollection): make trailing tagList content fully visible in tables

### DIFF
--- a/packages/react/src/components/tags/F0TagList/__storybook__/TagList.stories.tsx
+++ b/packages/react/src/components/tags/F0TagList/__storybook__/TagList.stories.tsx
@@ -5,6 +5,20 @@ import { withSnapshot } from "@/lib/storybook-utils/parameters"
 import { F0TagList, TagType } from "../"
 import { mockTags } from "./mockData"
 
+const longLabelDotTags = [
+  { text: "Strategic Workforce Planning", color: "viridian" as const },
+  {
+    text: "Cross-functional Stakeholder Management",
+    color: "malibu" as const,
+  },
+  { text: "Advanced Data Analysis & Reporting", color: "yellow" as const },
+  {
+    text: "Ruggedized Industrial Handheld Barcode Scanner (Model XR-9000)",
+    color: "purple" as const,
+  },
+  { text: "Change Management", color: "lilac" as const },
+]
+
 /**
  * The TagList component displays a collection of tags of a single type.
  *
@@ -43,6 +57,22 @@ export const WithRemainingCount: Story = {
     type: "dot",
     tags: mockTags.dot.slice(0, 2),
     remainingCount: 10,
+  },
+}
+
+/**
+ * Hover the `+N` counter to open the overflow popover. Each hidden tag's label is
+ * shown in full and the popover adapts its width to the longest label, without a
+ * horizontal scrollbar. Very long labels are capped (`max-w-72`) and ellipsized.
+ *
+ * This is the scenario used by the Job Catalog nested table (Competencies / Devices
+ * columns), where long names must stay fully readable in the popover.
+ */
+export const OverflowPopoverLongLabels: Story = {
+  args: {
+    type: "dot",
+    max: 1,
+    tags: longLabelDotTags,
   },
 }
 

--- a/packages/react/src/components/tags/F0TagList/components/TagCounter.test.tsx
+++ b/packages/react/src/components/tags/F0TagList/components/TagCounter.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+
+import { userEvent, waitFor, zeroRender as render } from "@/testing/test-utils"
+
+import { TagCounter, TagCounterItem } from "./TagCounter"
+
+const longLabelTags: TagCounterItem[] = [
+  { type: "dot", text: "Strategic Workforce Planning", color: "viridian" },
+  {
+    type: "dot",
+    text: "Ruggedized Industrial Handheld Barcode Scanner (Model XR-9000)",
+    color: "purple",
+  },
+]
+
+describe("TagCounter", () => {
+  it("renders just the +N counter when there is no overflow list", () => {
+    const { container, queryByText } = render(<TagCounter count={3} />)
+
+    expect(queryByText("+3")).not.toBeNull()
+    // Without a list there is no interactive hover trigger.
+    expect(container.querySelector(".cursor-pointer")).toBeNull()
+  })
+
+  it("exposes an interactive trigger when an overflow list is provided", () => {
+    const { getByText } = render(<TagCounter count={2} list={longLabelTags} />)
+
+    expect(getByText("+2")).not.toBeNull()
+  })
+
+  it("shows the full labels in the popover with content-sized, non-truncating rows", async () => {
+    const user = userEvent.setup()
+    const { getByText } = render(<TagCounter count={2} list={longLabelTags} />)
+
+    await user.hover(getByText("+2"))
+
+    // The popover opens after Radix' hover open delay; wait for its content.
+    const longLabel = await waitFor(
+      () => {
+        const el = document.body.querySelector(
+          '[data-radix-popper-content-wrapper] [data-testid="one-ellipsis"]'
+        ) as HTMLElement | null
+        if (!el) throw new Error("popover content not mounted yet")
+        return el
+      },
+      { timeout: 2000 }
+    )
+
+    // Every overflowed label is rendered in full (no ellipsis truncation in markup).
+    for (const tag of longLabelTags) {
+      expect(getByText(tag.text as string)).not.toBeNull()
+    }
+
+    // The row wrapper sizes to content and no longer uses the old fixed 172px width.
+    const row = longLabel.closest("div.w-max") as HTMLElement | null
+    expect(row).not.toBeNull()
+    expect(row!.className).toContain("w-max")
+    expect(row!.className).toContain("max-w-72")
+    expect(row!.className).not.toContain("w-[172px]")
+  })
+})

--- a/packages/react/src/components/tags/F0TagList/components/TagCounter.tsx
+++ b/packages/react/src/components/tags/F0TagList/components/TagCounter.tsx
@@ -2,7 +2,7 @@ import { Tag, TagVariant } from "@/components/tags/F0Tag/F0Tag"
 import { F0TagRaw } from "@/components/tags/F0TagRaw"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/ui/hover-card"
-import { ScrollArea, ScrollBar } from "@/ui/scrollarea"
+import { ScrollArea } from "@/ui/scrollarea"
 
 export type TagCounterItem = TagVariant
 
@@ -25,13 +25,13 @@ export const TagCounter = ({ count, list }: Props) => {
       </HoverCardTrigger>
       <HoverCardContent
         side="top"
-        className="bg-f1-background text-f1-foreground shadow-md ring-1 ring-f1-border-secondary"
+        className="w-fit bg-f1-background text-f1-foreground shadow-md ring-1 ring-f1-border-secondary"
       >
-        <ScrollArea className="flex max-h-[220px] flex-col">
+        <ScrollArea className="flex max-h-[220px] w-fit flex-col">
           {list.map((tag, index) => (
             <div
               key={index}
-              className="flex w-[172px] min-w-0 items-center gap-1.5 px-2 py-1 [&:first-child]:pt-2 [&:last-child]:pb-2"
+              className="flex w-max max-w-72 items-center gap-1.5 px-2 py-1 [&:first-child]:pt-2 [&:last-child]:pb-2"
             >
               {tag.description ? (
                 <Tooltip label={tag.description}>
@@ -44,7 +44,6 @@ export const TagCounter = ({ count, list }: Props) => {
               )}
             </div>
           ))}
-          <ScrollBar orientation="vertical" />
         </ScrollArea>
       </HoverCardContent>
     </HoverCard>

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/table/table.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react-vite"
-import { expect, within } from "storybook/test"
+import { expect, userEvent, within } from "storybook/test"
 import { useState, useMemo } from "react"
 
 import { F0Button } from "@/components/F0Button"
@@ -10,6 +10,7 @@ import {
 
 import { ExampleComponent, getMockVisualizations } from "../../mockData"
 import { useDataCollectionSource } from "../../../hooks/useDataCollectionSource"
+import { ItemActionsDefinition } from "../../../item-actions"
 import { OneDataCollection } from "../../../index"
 
 const meta = {
@@ -887,5 +888,102 @@ export const WithColumnAddRemove: Story = {
         />
       </div>
     )
+  },
+}
+
+/**
+ * The hover "⋮" row-actions overlay must not swallow the last column's content.
+ * Here the trailing column is a `tagList` whose "+N" pill sits under the overlay's
+ * fade area. The overlay is transparent to pointer events (only the buttons are
+ * clickable), so hovering the "+N" still opens its popover.
+ *
+ * Mirrors Factorial's Job Catalog nested table (Competencies / Devices columns).
+ */
+export const RowActionsKeepTagListHoverable: Story = {
+  render: () => {
+    const records = [
+      {
+        id: 1,
+        name: "Field Technician",
+        devices: ["Ruggedized Handheld Scanner", "Thermal Printer", "Tablet"],
+      },
+      {
+        id: 2,
+        name: "Warehouse Operator",
+        devices: ["Forklift Terminal", "Barcode Gun", "Label Printer"],
+      },
+    ]
+
+    const itemActions: ItemActionsDefinition<(typeof records)[number]> = (
+      item
+    ) => [
+      { label: "Edit", onClick: () => console.log(`Edit ${item.name}`) },
+      {
+        label: "Delete",
+        critical: true,
+        onClick: () => console.log(`Delete ${item.name}`),
+      },
+    ]
+
+    const source = useDataCollectionSource({
+      dataAdapter: { fetchData: async () => ({ records }) },
+      itemActions,
+    })
+
+    return (
+      <div style={{ maxWidth: 560 }}>
+        <OneDataCollection
+          source={source}
+          visualizations={[
+            {
+              type: "table",
+              options: {
+                columns: [
+                  { label: "Role", render: (item) => item.name },
+                  {
+                    label: "Devices",
+                    render: (item) => ({
+                      type: "tagList",
+                      value: {
+                        type: "raw",
+                        tags: item.devices.map((text) => ({
+                          text,
+                          description: text,
+                        })),
+                        max: 1,
+                      },
+                    }),
+                  },
+                ],
+              },
+            },
+          ]}
+        />
+      </div>
+    )
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    const roleCell = await canvas.findByText("Field Technician")
+    const row = roleCell.closest("tr")!
+
+    // The actions overlay does not intercept pointer events on the content
+    // beneath it (only the buttons do).
+    const overlay = row.querySelector("aside")
+    expect(overlay).not.toBeNull()
+    expect(getComputedStyle(overlay!).pointerEvents).toBe("none")
+
+    // Hovering the "+N" overflow pill still opens its popover, listing the
+    // hidden device names in full.
+    const plus = await within(row).findByText(/^\+\d+$/)
+    await userEvent.hover(plus)
+
+    const popover = await within(document.body).findByText(
+      "Thermal Printer",
+      undefined,
+      { timeout: 2000 }
+    )
+    expect(popover).toBeInTheDocument()
   },
 }

--- a/packages/react/src/patterns/OneDataCollection/components/itemActions/ItemActionsRowContainer.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/itemActions/ItemActionsRowContainer.tsx
@@ -12,7 +12,14 @@ export const ItemActionsRowContainer = ({
   return (
     <aside
       className={cn(
-        "absolute bottom-0 right-0 top-0 z-20 hidden items-center justify-end gap-2 py-2 pl-20 pr-3 opacity-0 transition-all group-hover:opacity-100 md:flex",
+        // The overlay (including its wide transparent `pl-20` fade area) must not
+        // intercept pointer events: otherwise it swallows hover/click on the cell
+        // content beneath it — e.g. a trailing tagList "+N" pill can neither be
+        // hovered to open its popover nor clicked. Only the actual action buttons
+        // (which set `pointer-events-auto` themselves) stay interactive.
+        // Consumers that want the whole overlay clickable (e.g. the List view)
+        // opt back in via `className`.
+        "pointer-events-none absolute bottom-0 right-0 top-0 z-20 hidden items-center justify-end gap-2 py-2 pl-20 pr-3 opacity-0 transition-all group-hover:opacity-100 md:flex",
         "bg-gradient-to-l from-[#F5F6F8] from-0% dark:from-[#192231]",
         "via-[#F5F6F8] via-60% dark:via-[#192231]",
         "to-transparent to-100%",

--- a/packages/react/src/patterns/OneDataCollection/components/itemActions/__tests__/ItemActionsRowContainer.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/itemActions/__tests__/ItemActionsRowContainer.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest"
+
+import { zeroRender as render } from "@/testing/test-utils"
+
+import { ItemActionsRowContainer } from "../ItemActionsRowContainer"
+
+describe("ItemActionsRowContainer", () => {
+  it("is transparent to pointer events by default so it never blocks the content beneath", () => {
+    const { container } = render(
+      <ItemActionsRowContainer dropDownOpen={false}>
+        <button type="button">Action</button>
+      </ItemActionsRowContainer>
+    )
+
+    const overlay = container.querySelector("aside")
+    expect(overlay).not.toBeNull()
+    // The overlay (including its wide transparent fade area) must not intercept
+    // hover/click on the cell content underneath — e.g. a trailing tagList "+N"
+    // pill. Only the action buttons re-enable pointer events themselves.
+    expect(overlay!.className).toContain("pointer-events-none")
+  })
+
+  it("lets a consumer opt the whole overlay back into pointer events via className", () => {
+    // The List visualization wants the entire overlay clickable.
+    const { container } = render(
+      <ItemActionsRowContainer
+        dropDownOpen={false}
+        className="pointer-events-auto"
+      >
+        <button type="button">Action</button>
+      </ItemActionsRowContainer>
+    )
+
+    const overlay = container.querySelector("aside")
+    expect(overlay!.className).toContain("pointer-events-auto")
+    expect(overlay!.className).not.toContain("pointer-events-none")
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -392,7 +392,12 @@ const RowComponentInner = <
           <>
             {/** Desktop item actions adds a sticky column to the table to not overflow when the table is scrolled horizontally*/}
             <td className="sticky right-0 top-0 z-10 hidden md:table-cell">
-              <ItemActionsRowContainer dropDownOpen={dropDownOpen}>
+              {/* Narrower fade gutter (pl-8) for tables so the overlay covers
+                  less of the last column's content than the default pl-20. */}
+              <ItemActionsRowContainer
+                dropDownOpen={dropDownOpen}
+                className="pl-8"
+              >
                 <ItemActionsRow
                   primaryItemActions={primaryItemActions}
                   dropdownItemActions={dropdownItemActions}


### PR DESCRIPTION
Two related fixes so trailing `tagList` content stays fully readable and interactive in OneDataCollection tables. Both are needed by Factorial's **Job Catalog nested table** (Organization → Roles), whose trailing columns (**Competencies**, **Devices**) use the `tagList` cell.

---

## 1. F0TagList "+N" overflow popover: fit to content, show full labels

**What:** The `F0TagList` "+N" overflow popover now shows each hidden tag's label **in full** and **adapts its width to the longest label**, with **no horizontal scrollbar**.

**Why:** The popover used a fixed `w-[172px]` row inside a `w-[200px]` HoverCard, so any label wider than the row was truncated (or triggered a horizontal scrollbar). Consumers couldn't fix this — the `tagList` cell only forwards `type`/`tags`/`max`.

**How** (`TagCounter.tsx`):
- Row wrapper: `w-[172px] min-w-0` → **`w-max max-w-72`** (sizes to content, capped at 288px).
- `HoverCardContent`: added **`w-fit`** (overrides the default `w-[200px]`) so the popover shrink-wraps to its widest row.
- `ScrollArea`: added **`w-fit`** (kept `max-h-[220px]` + vertical scroll).
- Removed a redundant, non-functional `<ScrollBar orientation="vertical" />` rendered inside the viewport.

Labels under the cap render in full; longer ones ellipsize (with tooltip) via the existing `OneEllipsis` — so no horizontal scrollbar in any case.

**Backward-compat:** global default change (not a prop). The old fixed-width + clamp was effectively a defect, and `max-w-72` prevents pathological widening. Affects all "+N" popovers.

### Before
<img width="3020" height="1718" alt="Screenshot 2026-07-22 at 14 27 41" src="https://github.com/user-attachments/assets/1b19b945-9e69-4ead-b54b-734f70d98254" />

### After

https://github.com/user-attachments/assets/a2f3e2d1-36ff-4cfe-bfac-41681ececb2a

---

## 2. Table row actions: stop the overlay swallowing content hover

**What:** In the table visualization, the hover "⋮" row-actions overlay no longer intercepts hover/click on the last column's content. A trailing `tagList` "+N" pill can now be hovered to open its popover even while the actions overlay is present.

**Why:** The actions overlay (`ItemActionsRowContainer`) is an absolutely-positioned `<aside>` spanning the row's right region, including a wide **transparent fade area**. It captured pointer events across that whole area — even at rest while `opacity-0` — so the "+N" pill sitting under that transparent zone could neither be hovered nor clicked.

**How:**
- `ItemActionsRowContainer.tsx` (one line): make the overlay container **`pointer-events-none`** so hover/click falls through to the content beneath. Only the action buttons stay interactive — they set `pointer-events-auto` on themselves.
- `Row.tsx`: the table also **narrows its fade gutter to `pl-8` (32px)** (vs. the shared default `pl-20` / 80px), so the overlay overlaps less of the last column's content. Scoped to the table via `className`; the List view keeps the 80px default.

**Shared-component safety:** this container is also used by the **List** view, which passes `className="pointer-events-auto …"`. Because `cn` uses `twMerge` (last wins), List's explicit opt-in overrides both the `pointer-events-none` default and keeps its own padding, so **List is unaffected**.

**Trade-off:** this keeps the existing overlay visuals and reserves no space (no layout/spacing change). The only region that still belongs to the button is its own small footprint at the far-right edge; in the realistic Job Catalog layout the "+N" sits to the left of it and is fully hoverable. (An earlier attempt that reserved a dedicated gutter column was reverted in favor of this lighter-touch fix.)

### Before
<img width="3020" height="1718" alt="Screenshot 2026-07-22 at 14 27 16" src="https://github.com/user-attachments/assets/1b011e2b-a10b-405c-8dbb-b6ab78602407" />

### After
<img width="1510" height="859" alt="Screenshot 2026-07-23 at 12 02 10" src="https://github.com/user-attachments/assets/6aec46db-678a-45aa-98b3-a39c204e7d81" />

---

## Tests / Storybook
- **F0TagList:** new `TagCounter.test.tsx` (3 tests) + `OverflowPopoverLongLabels` story.
- **Row actions:** new `ItemActionsRowContainer.test.tsx` (2 tests — `pointer-events-none` by default; a `pointer-events-auto` className overrides it, i.e. the List opt-in) + `RowActionsKeepTagListHoverable` story whose `play` asserts the overlay's computed `pointer-events` is `none` and that hovering the "+N" opens its popover.

## Verification
- `vitest`: F0TagList 3/3; itemActions + Table + List suites 55/55. `tsc`/`oxlint`/`oxfmt`: clean.
- **Browser layout proofs (Chrome via Playwright):**
  - Popover: long labels cap at 288px (ellipsized), short/medium shrink below cap — no horizontal overflow in any `overflow` mode.
  - Row actions, "+N" under the overlay's fade zone: OLD → "+N" not hoverable (overlay is the top element); NEW → "+N" hoverable, button still clickable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)