### PR TITLE
feat(OneDataCollection): auto page size for full-height collections

### DIFF
--- a/packages/react/src/hooks/datasource/__test__/useData.spec.tsx
+++ b/packages/react/src/hooks/datasource/__test__/useData.spec.tsx
@@ -610,8 +610,12 @@ describe("mergeFiltersWithIntersection", () => {
       expect(result.current.data.records.map((r) => r.id)).toEqual([
         1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
       ])
-      expect(result.current.paginationInfo?.perPage).toBe(10)
-      expect(result.current.paginationInfo?.pagesCount).toBe(3)
+      const pagination = result.current.paginationInfo
+      expect(pagination?.type).toBe("pages")
+      if (pagination?.type === "pages") {
+        expect(pagination.perPage).toBe(10)
+        expect(pagination.pagesCount).toBe(3)
+      }
     })
 
     it("does fetch when the page size grows beyond the loaded records", async () => {

--- a/packages/react/src/hooks/datasource/__test__/useData.spec.tsx
+++ b/packages/react/src/hooks/datasource/__test__/useData.spec.tsx
@@ -525,4 +525,124 @@ describe("mergeFiltersWithIntersection", () => {
     // Verify that fetchData was called (lanes functionality is working)
     expect(mockAdapter.fetchData).toHaveBeenCalled()
   })
+
+  describe("page size reuse", () => {
+    // Backs the `perPage: "auto"` flow: it over-fetches a first page, then
+    // shrinks the page size to what fits. Shrinking must reuse the already
+    // loaded records — never fetch again.
+    const buildPagedSource = (records: TestRecord[], perPage: number) => {
+      const fetchData = vi.fn(
+        async (options: PaginatedFetchOptions<TestFilters>) => {
+          const pp = options.pagination?.perPage ?? 10
+          const page =
+            "currentPage" in options.pagination
+              ? (options.pagination.currentPage ?? 1)
+              : 1
+          const start = (page - 1) * pp
+          return {
+            records: records.slice(start, start + pp),
+            total: records.length,
+            currentPage: page,
+            perPage: pp,
+            pagesCount: Math.ceil(records.length / pp),
+            type: "pages" as const,
+          }
+        }
+      )
+      const adapter: PaginatedDataAdapter<
+        TestRecord,
+        TestFilters,
+        PaginatedFetchOptions<TestFilters>,
+        PageBasedPaginatedResponse<TestRecord>
+      > = { fetchData, paginationType: "pages", perPage }
+      const source: TestSource = {
+        dataAdapter: adapter,
+        currentFilters: {},
+        setCurrentFilters: vi.fn(),
+        currentSortings: null,
+        setCurrentSortings: vi.fn(),
+        currentSearch: undefined,
+        debouncedCurrentSearch: undefined,
+        setCurrentSearch: vi.fn(),
+        isLoading: false,
+        setIsLoading: vi.fn(),
+        currentGrouping: undefined,
+        setCurrentGrouping: vi.fn(),
+      }
+      return { source, fetchData }
+    }
+
+    it("reuses loaded records when the page size shrinks (no refetch)", async () => {
+      const records: TestRecord[] = Array.from({ length: 30 }, (_, i) => ({
+        id: i + 1,
+        name: `Test ${i + 1}`,
+      }))
+      // Stable sources per page size; only the adapter reference changes when
+      // the page size does (mirrors OneDataCollection's memoized adapter).
+      const big = buildPagedSource(records, 20)
+      const small = buildPagedSource(records, 10)
+      small.fetchData = big.fetchData // share the spy; shrink must not call it
+      small.source.dataAdapter.fetchData = big.source.dataAdapter.fetchData
+
+      const { result, rerender } = renderHook(({ source }) => useData(source), {
+        initialProps: { source: big.source },
+      })
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+
+      expect(big.fetchData).toHaveBeenCalledTimes(1)
+      expect(result.current.data.records).toHaveLength(20)
+      expect(result.current.paginationInfo?.perPage).toBe(20)
+
+      // Shrink the page size (auto measured that fewer rows fit).
+      rerender({ source: small.source })
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+
+      // No extra loading: fetchData is still called exactly once, and the
+      // already-loaded records are simply trimmed to the new page size.
+      expect(big.fetchData).toHaveBeenCalledTimes(1)
+      expect(result.current.isLoading).toBe(false)
+      expect(result.current.data.records).toHaveLength(10)
+      expect(result.current.data.records.map((r) => r.id)).toEqual([
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+      ])
+      expect(result.current.paginationInfo?.perPage).toBe(10)
+      expect(result.current.paginationInfo?.pagesCount).toBe(3)
+    })
+
+    it("does fetch when the page size grows beyond the loaded records", async () => {
+      const records: TestRecord[] = Array.from({ length: 30 }, (_, i) => ({
+        id: i + 1,
+        name: `Test ${i + 1}`,
+      }))
+      const small = buildPagedSource(records, 10)
+      const big = buildPagedSource(records, 20)
+      big.fetchData = small.fetchData
+      big.source.dataAdapter.fetchData = small.source.dataAdapter.fetchData
+
+      const { result, rerender } = renderHook(({ source }) => useData(source), {
+        initialProps: { source: small.source },
+      })
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+
+      expect(small.fetchData).toHaveBeenCalledTimes(1)
+      expect(result.current.data.records).toHaveLength(10)
+
+      // Growing needs records we don't have yet, so a fetch is expected.
+      rerender({ source: big.source })
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+
+      expect(small.fetchData).toHaveBeenCalledTimes(2)
+      expect(result.current.data.records).toHaveLength(20)
+    })
+  })
 })

--- a/packages/react/src/hooks/datasource/types/fetch.typings.ts
+++ b/packages/react/src/hooks/datasource/types/fetch.typings.ts
@@ -233,9 +233,12 @@ export type PaginatedDataAdapter<
   /** Indicates this adapter uses page-based pagination */
   paginationType: PaginationType
   /**
-   * Default number of records per page. Pass `"auto"` (page-based pagination
-   * inside a `fullHeight` collection only) to derive the page size from the
-   * available vertical space, clamped between 10 and 30 items.
+   * Number of records per page. Pass `"auto"` to derive the page size from the
+   * available vertical space (page-based pagination inside a `fullHeight`
+   * collection only), sized to exactly the rows that fit (capped at 30). In a
+   * `fullHeight` collection, leaving this unset behaves like `"auto"` — an
+   * unspecified page size means "fill the height". Outside `fullHeight`, an
+   * unset value falls back to the default page size.
    */
   perPage?: number | "auto"
   /**

--- a/packages/react/src/hooks/datasource/types/fetch.typings.ts
+++ b/packages/react/src/hooks/datasource/types/fetch.typings.ts
@@ -232,8 +232,12 @@ export type PaginatedDataAdapter<
 > = {
   /** Indicates this adapter uses page-based pagination */
   paginationType: PaginationType
-  /** Default number of records per page */
-  perPage?: number
+  /**
+   * Default number of records per page. Pass `"auto"` (page-based pagination
+   * inside a `fullHeight` collection only) to derive the page size from the
+   * available vertical space, clamped between 10 and 30 items.
+   */
+  perPage?: number | "auto"
   /**
    * Function to fetch paginated data based on filter and pagination options
    * @param options - The filter and pagination options to apply when fetching data

--- a/packages/react/src/hooks/datasource/useData.ts
+++ b/packages/react/src/hooks/datasource/useData.ts
@@ -317,6 +317,14 @@ export function useData<
 
   const isLoadingMoreRef = useRef(false)
 
+  // Latest loaded records + the query/pageSize that produced them, so a
+  // shrinking page size can reuse the already-loaded records instead of
+  // refetching (see the initial fetch effect below).
+  const rawDataRef = useRef(rawData)
+  rawDataRef.current = rawData
+  const lastFetchSignatureRef = useRef<string | undefined>(undefined)
+  const lastFetchedPerPageRef = useRef<number | undefined>(undefined)
+
   // The provided `currentPage` only seeds the very first page-based fetch
   // (e.g. restoring a page from the URL); later fetches reset to page 1 as
   // before — notably when filters/search/sortings change.
@@ -609,9 +617,11 @@ export function useData<
 
           const defaultPerPage = 20
 
-          // Safely access perPage, defaulting to 20 if not available
+          // Safely access perPage, defaulting to 20 if not available.
+          // "auto" is resolved to a number by OneDataCollection before it
+          // reaches this hook; fall back to the default if it wasn't.
           const perPageValue =
-            "perPage" in dataAdapter && dataAdapter.perPage !== undefined
+            "perPage" in dataAdapter && typeof dataAdapter.perPage === "number"
               ? dataAdapter.perPage
               : defaultPerPage
 
@@ -758,6 +768,51 @@ export function useData<
     () => {
       if (!enabled) return
       if (!isLoadingMoreRef.current) {
+        // Page-based reuse: when only the page size shrank (same filters /
+        // sortings / search) and page 1 already holds at least that many
+        // records, trim the loaded records instead of refetching — no extra
+        // network round-trip. This is what makes the auto page size hide items
+        // it over-fetched without loading again.
+        const perPageValue =
+          "perPage" in dataAdapter && typeof dataAdapter.perPage === "number"
+            ? dataAdapter.perPage
+            : undefined
+        const currentPagination = paginationInfoRef.current
+        const fetchSignature = JSON.stringify({
+          filters: mergedFilters,
+          sortings: currentSortings,
+          grouping: currentGrouping,
+          search: searchValue.current,
+          paginationType: dataAdapter.paginationType,
+        })
+        const canReuseLoadedData =
+          dataAdapter.paginationType === "pages" &&
+          perPageValue !== undefined &&
+          fetchSignature === lastFetchSignatureRef.current &&
+          lastFetchedPerPageRef.current !== undefined &&
+          perPageValue < lastFetchedPerPageRef.current &&
+          isPageBasedPagination(currentPagination) &&
+          currentPagination.currentPage === 1 &&
+          rawDataRef.current.length >= perPageValue
+
+        if (canReuseLoadedData) {
+          lastFetchedPerPageRef.current = perPageValue
+          setRawData((prev) => prev.slice(0, perPageValue))
+          setPaginationInfo((info) =>
+            info && info.type === "pages"
+              ? {
+                  ...info,
+                  perPage: perPageValue,
+                  pagesCount: Math.max(1, Math.ceil(info.total / perPageValue)),
+                }
+              : info
+          )
+          return
+        }
+
+        lastFetchSignatureRef.current = fetchSignature
+        lastFetchedPerPageRef.current = perPageValue
+
         setIsLoading(true)
         // Seed the first page-based fetch from `currentPage` (if provided), then
         // fall back to page 1 for every subsequent fetch (filter/search/sorting

--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -74,6 +74,7 @@ import { DataCollectionSource } from "./hooks/useDataCollectionSource"
 import {
   ESTIMATED_LIST_ROW_HEIGHT,
   ESTIMATED_ROW_HEIGHT,
+  shouldAutoSizePerPage,
   useAutoPerPage,
 } from "./hooks/useAutoPerPage"
 import { CustomEmptyStates, useEmptyState } from "./hooks/useEmptyState"
@@ -390,11 +391,20 @@ const OneDataCollectionComp = <
   // Flips true once the first page of data has rendered, so the auto page size
   // can measure the real content (see useAutoPerPage). Set from onLoadData.
   const [firstDataLoaded, setFirstDataLoaded] = useState(false)
-  const autoPerPageRequested =
+  // Auto page size is on when a page-based full-height collection either asks
+  // for `perPage: "auto"` or leaves `perPage` unset (in a full-height layout an
+  // unspecified page size means "fill the height").
+  const autoPerPageEnabled = shouldAutoSizePerPage(
+    source.dataAdapter,
+    fullHeight
+  )
+  // Explicit `perPage: "auto"` without fullHeight is a misconfiguration worth
+  // warning about; an unset perPage without fullHeight just uses the default.
+  const autoPerPageMisconfigured =
     "perPage" in source.dataAdapter &&
     source.dataAdapter.perPage === "auto" &&
-    source.dataAdapter.paginationType === "pages"
-  const autoPerPageEnabled = autoPerPageRequested && !!fullHeight
+    source.dataAdapter.paginationType === "pages" &&
+    !fullHeight
   // The auto page size seeds the first page with a per-visualization row-height
   // estimate, then measures the real content. The estimate must be a LOWER
   // bound of the real row height so the seed over-fetches (or matches) and the
@@ -426,26 +436,23 @@ const OneDataCollectionComp = <
   }, [currentVisualization])
 
   useEffect(() => {
-    if (autoPerPageRequested && !fullHeight) {
+    if (autoPerPageMisconfigured) {
       console.warn(
         '[OneDataCollection] perPage: "auto" requires the fullHeight prop — falling back to the default page size.'
       )
     }
-  }, [autoPerPageRequested, fullHeight])
+  }, [autoPerPageMisconfigured])
 
   // Resolve `perPage: "auto"` to the measured page size. Memoized narrowly on
   // the source adapter and the resolved size so its reference only changes when
   // one of those changes — otherwise a fresh adapter object on every render of
   // effectiveSource would retrigger useData's fetch in an infinite loop.
   const resolvedDataAdapter = useMemo(() => {
-    if (
-      "perPage" in source.dataAdapter &&
-      source.dataAdapter.perPage === "auto"
-    ) {
+    if (autoPerPageEnabled) {
       return { ...source.dataAdapter, perPage: autoPerPage }
     }
     return source.dataAdapter
-  }, [source.dataAdapter, autoPerPage])
+  }, [source.dataAdapter, autoPerPageEnabled, autoPerPage])
 
   // Patched source with per-viz currentFilters to avoid stale filters during
   // transitions, and with `perPage: "auto"` resolved to the measured value

--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -71,6 +71,11 @@ import {
 } from "./hooks/useDataColectionStorage/types"
 import { useDataCollectionStorage } from "./hooks/useDataColectionStorage/useDataCollectionStorage"
 import { DataCollectionSource } from "./hooks/useDataCollectionSource"
+import {
+  ESTIMATED_LIST_ROW_HEIGHT,
+  ESTIMATED_ROW_HEIGHT,
+  useAutoPerPage,
+} from "./hooks/useAutoPerPage"
 import { CustomEmptyStates, useEmptyState } from "./hooks/useEmptyState"
 import { useExportAction } from "./hooks/useExportAction"
 import { useDataCollectionUrlSync } from "./hooks/useDataCollectionUrlSync"
@@ -375,19 +380,94 @@ const OneDataCollectionComp = <
     storageKey: id,
   })
 
-  // Patched source with per-viz currentFilters to avoid stale filters during transitions
-  const effectiveSource = useMemo(() => {
-    if (!hasPerVisualizationFilters) return source
-    return {
-      ...source,
-      currentFilters: activeCurrentFilters,
-      setCurrentFilters: activeSetCurrentFilters,
+  /**
+   * Auto page size: `perPage: "auto"` derives the page size from the measured
+   * height of the visualization container. Only meaningful with `fullHeight`,
+   * where the container is height-bounded — otherwise its height would derive
+   * from the content itself (feedback loop), so we fall back to the default.
+   */
+  const vizContainerRef = useRef<HTMLDivElement>(null)
+  // Flips true once the first page of data has rendered, so the auto page size
+  // can measure the real content (see useAutoPerPage). Set from onLoadData.
+  const [firstDataLoaded, setFirstDataLoaded] = useState(false)
+  const autoPerPageRequested =
+    "perPage" in source.dataAdapter &&
+    source.dataAdapter.perPage === "auto" &&
+    source.dataAdapter.paginationType === "pages"
+  const autoPerPageEnabled = autoPerPageRequested && !!fullHeight
+  // The auto page size seeds the first page with a per-visualization row-height
+  // estimate, then measures the real content. The estimate must be a LOWER
+  // bound of the real row height so the seed over-fetches (or matches) and the
+  // measurement trims down to what fits — an estimate above the real height
+  // would under-fetch and leave the collection short, since the measurement
+  // only trims, never grows. List rows are a fixed height (no reflow); the
+  // table and editable table depend on their content, so they seed at the
+  // baseline and rely on the measurement to trim.
+  const autoPerPageRowHeight = (() => {
+    switch (visualizations[currentVisualization]?.type) {
+      case "list":
+        return ESTIMATED_LIST_ROW_HEIGHT
+      default:
+        return ESTIMATED_ROW_HEIGHT
     }
+  })()
+  const autoPerPage = useAutoPerPage(vizContainerRef, autoPerPageEnabled, {
+    rowHeight: autoPerPageRowHeight,
+    ready: firstDataLoaded,
+    measureKey: currentVisualization,
+  })
+
+  // Each visualization has its own row layout, so the auto page size is
+  // re-measured when the visualization switches: clear the ready flag so the
+  // measurement waits for the new visualization's first page to load.
+  useEffect(() => {
+    if (autoPerPageEnabled) setFirstDataLoaded(false)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only on visualization change
+  }, [currentVisualization])
+
+  useEffect(() => {
+    if (autoPerPageRequested && !fullHeight) {
+      console.warn(
+        '[OneDataCollection] perPage: "auto" requires the fullHeight prop — falling back to the default page size.'
+      )
+    }
+  }, [autoPerPageRequested, fullHeight])
+
+  // Resolve `perPage: "auto"` to the measured page size. Memoized narrowly on
+  // the source adapter and the resolved size so its reference only changes when
+  // one of those changes — otherwise a fresh adapter object on every render of
+  // effectiveSource would retrigger useData's fetch in an infinite loop.
+  const resolvedDataAdapter = useMemo(() => {
+    if (
+      "perPage" in source.dataAdapter &&
+      source.dataAdapter.perPage === "auto"
+    ) {
+      return { ...source.dataAdapter, perPage: autoPerPage }
+    }
+    return source.dataAdapter
+  }, [source.dataAdapter, autoPerPage])
+
+  // Patched source with per-viz currentFilters to avoid stale filters during
+  // transitions, and with `perPage: "auto"` resolved to the measured value
+  const effectiveSource = useMemo(() => {
+    let patched = source
+    if (hasPerVisualizationFilters) {
+      patched = {
+        ...patched,
+        currentFilters: activeCurrentFilters,
+        setCurrentFilters: activeSetCurrentFilters,
+      }
+    }
+    if (patched.dataAdapter !== resolvedDataAdapter) {
+      patched = { ...patched, dataAdapter: resolvedDataAdapter }
+    }
+    return patched
   }, [
     source,
     hasPerVisualizationFilters,
     activeCurrentFilters,
     activeSetCurrentFilters,
+    resolvedDataAdapter,
   ])
 
   const defaultSortings = useRef(currentSortings)
@@ -851,6 +931,7 @@ const OneDataCollectionComp = <
 
     setIsInitialLoading(isInitialLoadingFromCallback)
     setTotalItems(totalItems)
+    setFirstDataLoaded(true)
     setEmptyStateType(getEmptyStateType(totalItems, filters, search))
   }
 
@@ -1663,20 +1744,25 @@ const OneDataCollectionComp = <
       )}
       {/* Visualization renderer must be always mounted to react (load data) even if empty state is shown */}
       <div
+        ref={vizContainerRef}
         className={cn(
           emptyState && "hidden",
           fullHeight && "h-full min-h-0 flex-1"
         )}
       >
-        <VisualizationRenderer
-          visualization={visualizations[currentVisualization]}
-          source={effectiveSource}
-          onSelectItems={onSelectItemsLocal}
-          onLoadData={onLoadData}
-          onLoadError={onLoadError}
-          tmpFullWidth={tmpFullWidth}
-          searchSelectionNonce={searchPreview.selectionNonce}
-        />
+        {/* With perPage "auto", defer mounting one frame until the container
+            is measured, so the first fetch already uses the resolved size */}
+        {(!autoPerPageEnabled || autoPerPage !== undefined) && (
+          <VisualizationRenderer
+            visualization={visualizations[currentVisualization]}
+            source={effectiveSource}
+            onSelectItems={onSelectItemsLocal}
+            onLoadData={onLoadData}
+            onLoadError={onLoadError}
+            tmpFullWidth={tmpFullWidth}
+            searchSelectionNonce={searchPreview.selectionNonce}
+          />
+        )}
       </div>
       {emptyState ? (
         <div className="flex flex-1 flex-col items-center justify-center">

--- a/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/overview.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/crud-patterns/overview.mdx
@@ -18,6 +18,19 @@ interactions with records from a Data Collection. Use them to decide whether an
 interaction should stay in the current surface, open a dialog, guide the user
 through a wizard, or navigate to a dedicated page.
 
+## Page layout
+
+A page fully focused on CRUD is built around a single Data Collection that is
+the main thing the user consumes there. For these surfaces, render the
+collection in
+[`fullHeight`](/?path=/docs/patterns-data-collection-full-height--documentation)
+mode: the toolbar and pagination stay pinned in view while only the rows
+scroll, so users never lose the filters or page controls and the collection
+uses all the vertical space the page has. With page-based pagination, pair it
+with `perPage: "auto"` so the page size fits the available height. Reserve the
+default content-height mode for collections that are just one section among many
+on a page.
+
 ## CRUD by view
 
 Open a fullscreen scenario that shows create, read, update, and delete

--- a/packages/react/src/patterns/OneDataCollection/__stories__/full-height.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/full-height.mdx
@@ -26,6 +26,25 @@ maximum height possible.
 > to limit the height of the data collection you must set the correct height to
 > the parent container.
 
+### When to use it
+
+**Reach for `fullHeight` whenever the data collection is the main thing users
+consume on the page** — list pages, index pages, and any surface fully focused
+on CRUD over one collection. There, keeping the toolbar and pagination pinned
+in view while only the rows scroll is almost always the right experience: users
+never lose the filters or the page controls, and the collection uses all the
+vertical space it has instead of leaving it empty or pushing the pagination
+below the fold.
+
+Keep the default (content-height) mode for collections that are one section
+among many on a page — a small table inside a detail view, a preview embedded in
+a dashboard card — where the collection should grow with its content and the
+page as a whole scrolls.
+
+When you do use `fullHeight` with page-based pagination, pair it with
+[`perPage: "auto"`](#auto-page-size) so the page size matches the available
+height instead of a hardcoded guess.
+
 ### Example
 
 ```tsx
@@ -52,3 +71,87 @@ OneDataCollection component will use the 100% of that wrapper.
 #### With pagination
 
 <Canvas of={FullHeightStories.WithPagination} />
+
+## Auto page size
+
+With page-based pagination, a fixed `perPage` rarely matches the space the
+collection actually has: on tall screens rows stop short of the pagination
+footer, and on short ones the page scrolls internally. Setting
+`perPage: "auto"` on the data adapter derives the page size from the measured
+content so a page shows **exactly the rows that fit** — never a partial,
+overflowing row — up to a maximum of **30** items.
+
+```tsx
+const dataAdapter = {
+  paginationType: "pages",
+  perPage: "auto",
+  fetchData: ...,
+}
+```
+
+Requirements and behavior:
+
+- Requires `fullHeight` (the container must be height-bounded — otherwise its
+  height would derive from the content itself and there is nothing to measure).
+  Without it, the collection warns in development and falls back to the default
+  page size.
+- The height is measured **once on mount** and kept stable afterwards, so
+  resizing the window doesn't shift items between pages or trigger refetches.
+- Each collection measures its own container, so multiple collections on the
+  same page resolve their page sizes independently.
+
+> **Reserve room for the minimum page.** When other collections could squeeze
+> an auto-sized one down to nothing, give its flex slot a `min-height` equal to
+> the minimum page height so it stays visible and the page scrolls instead. Use
+> the exported `getAutoPerPageMinHeight()` helper for the value:
+>
+> ```tsx
+> import { getAutoPerPageMinHeight } from "@factorialco/f0-react"
+>
+> <div className="flex-1" style={{ minHeight: getAutoPerPageMinHeight() }}>
+>   <OneDataCollection source={autoSource} visualizations={...} fullHeight />
+> </div>
+> ```
+>
+> Keep `flex-1` (not `min-h-0 flex-1`) so the slot floors at the minimum page
+> height while the collection still scrolls internally above it.
+
+#### With content on top
+
+Other content above the collection (here a horizontal `F0Box` with summary
+cards) takes its natural height; the collection sizes its page to the space
+that remains below it.
+
+<Canvas of={FullHeightStories.AutoPageSizeWithContentOnTop} />
+
+#### With content below
+
+The collection fills the space above the other content, which keeps its natural
+height at the bottom.
+
+<Canvas of={FullHeightStories.AutoPageSizeWithContentBelow} />
+
+#### Collections around other content
+
+An auto-sized collection on top, other content in the middle, and another
+auto-sized collection at the bottom. Each collection measures its own slot, so
+they split the remaining space independently.
+
+<Canvas of={FullHeightStories.AutoPageSizeAroundContent} />
+
+#### Auto page size next to a fixed one
+
+<Canvas of={FullHeightStories.AutoPageSizeWithFixedSibling} />
+
+#### Two auto-sized collections splitting the viewport
+
+<Canvas of={FullHeightStories.AutoPageSizeBoth} />
+
+#### Squeezed: reserving the minimum height
+
+When the auto-sized collection has (almost) no vertical space left, its flex
+slot still reserves the minimum height (see the note above), so it stays
+visible showing the rows that fit that reserved space while the page scrolls —
+it never disappears.
+
+<Canvas of={FullHeightStories.AutoPageSizeWithNoSpaceLeft} />

--- a/packages/react/src/patterns/OneDataCollection/__stories__/full-height.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/full-height.mdx
@@ -76,15 +76,18 @@ OneDataCollection component will use the 100% of that wrapper.
 
 With page-based pagination, a fixed `perPage` rarely matches the space the
 collection actually has: on tall screens rows stop short of the pagination
-footer, and on short ones the page scrolls internally. Setting
-`perPage: "auto"` on the data adapter derives the page size from the measured
-content so a page shows **exactly the rows that fit** — never a partial,
-overflowing row — up to a maximum of **30** items.
+footer, and on short ones the page scrolls internally. Deriving the page size
+from the measured content instead makes a page show **exactly the rows that
+fit** — never a partial, overflowing row — up to a maximum of **30** items.
+
+In a `fullHeight` collection this is the **default**: just leave `perPage`
+unset and the page fills the height. Set `perPage: "auto"` explicitly if you
+prefer to be verbose, or a number to force a fixed page size.
 
 ```tsx
+// full-height + page-based → auto by default (no perPage needed)
 const dataAdapter = {
   paginationType: "pages",
-  perPage: "auto",
   fetchData: ...,
 }
 ```

--- a/packages/react/src/patterns/OneDataCollection/__stories__/full-height.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/full-height.stories.tsx
@@ -1,11 +1,59 @@
 import { Meta, StoryObj } from "@storybook/react-vite"
 
+import { F0Box } from "@/lib/F0Box"
+
+import { getAutoPerPageMinHeight } from "../hooks/useAutoPerPage"
 import {
   buildSecondaryActions,
   createDataAdapter,
   ExampleComponent,
   generateMockUsers,
 } from "./mockData"
+
+// A `perPage: "auto"` collection reserves the height of its minimum page so
+// siblings can't squeeze it out of view: it keeps its minimum page (scrolling
+// internally) and the page scrolls instead of the collection disappearing.
+const autoCollectionSlot = {
+  className: "flex-1",
+  style: { minHeight: getAutoPerPageMinHeight() },
+}
+
+// A row of summary cards standing in for "other content" around a collection.
+const SummaryCards = () => {
+  const cards = [
+    { label: "Total employees", value: "300" },
+    { label: "Departments", value: "4" },
+    { label: "New this month", value: "12" },
+    { label: "Turnover", value: "2.1%" },
+  ]
+  return (
+    <F0Box display="flex" flexDirection="row" gap="xl">
+      {cards.map((card) => (
+        <F0Box
+          key={card.label}
+          display="flex"
+          flexDirection="column"
+          gap="sm"
+          padding="lg"
+          background="secondary"
+          borderRadius="md"
+          grow
+        >
+          <span className="text-f1-foreground-secondary">{card.label}</span>
+          <span className="text-2xl font-semibold">{card.value}</span>
+        </F0Box>
+      ))}
+    </F0Box>
+  )
+}
+
+const makeAutoAdapter = () =>
+  createDataAdapter({
+    data: generateMockUsers(300),
+    delay: 500,
+    paginationType: "pages",
+    perPage: "auto",
+  })
 
 const meta = {
   title: "Data Collection/Full height",
@@ -18,7 +66,7 @@ const meta = {
     (Story) => (
       <div
         style={{
-          height: "470px",
+          height: "calc(100vh - 2rem)",
           width: "100%",
           display: "flex",
           overflow: "auto",
@@ -34,23 +82,37 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 export const Basic: Story = {
-  render: () => (
-    <ExampleComponent
-      frozenColumns={2}
-      fullHeight
-      totalItemSummary={(totalItems) => `Total items: ${totalItems}`}
-      secondaryActions={{
-        expanded: 0,
-        actions: buildSecondaryActions,
-      }}
-    />
-  ),
+  render: () => {
+    // Page-based with perPage "auto" is the recommended default for a
+    // full-height collection: the page size fits the available height and it
+    // paginates properly across every visualization (including editable table),
+    // while never rendering all 300 rows at once (the table doesn't virtualize).
+    const dataAdapter = createDataAdapter({
+      data: generateMockUsers(300),
+      delay: 500,
+      paginationType: "pages",
+      perPage: "auto",
+    })
+
+    return (
+      <ExampleComponent
+        frozenColumns={2}
+        fullHeight
+        dataAdapter={dataAdapter}
+        totalItemSummary={(totalItems) => `Total items: ${totalItems}`}
+        secondaryActions={{
+          expanded: 0,
+          actions: buildSecondaryActions,
+        }}
+      />
+    )
+  },
 }
 
 export const WithPagination: Story = {
   ...Basic,
   render: () => {
-    const paginatedMockUsers = generateMockUsers(50)
+    const paginatedMockUsers = generateMockUsers(300)
     const dataAdapter = createDataAdapter({
       data: paginatedMockUsers,
       delay: 500,
@@ -67,13 +129,161 @@ export const WithPagination: Story = {
   },
 }
 
+/**
+ * `perPage: "auto"` derives the page size from the available vertical space
+ * (exactly the rows that fit, up to 30). The top collection fills the remaining
+ * viewport height and sizes its page to it; the bottom one keeps a fixed page
+ * size of 5 and takes its natural height.
+ */
+export const AutoPageSizeWithFixedSibling: Story = {
+  ...Basic,
+  render: () => {
+    const autoAdapter = createDataAdapter({
+      data: generateMockUsers(300),
+      delay: 500,
+      paginationType: "pages",
+      perPage: "auto",
+    })
+    const fixedAdapter = createDataAdapter({
+      data: generateMockUsers(300),
+      delay: 500,
+      paginationType: "pages",
+      perPage: 5,
+    })
+
+    return (
+      <div className="flex h-full w-full flex-col gap-4">
+        <div {...autoCollectionSlot}>
+          <ExampleComponent fullHeight dataAdapter={autoAdapter} />
+        </div>
+        <div>
+          <ExampleComponent dataAdapter={fixedAdapter} />
+        </div>
+      </div>
+    )
+  },
+}
+
+/**
+ * Auto page size with other content on top: a horizontal F0Box with summary
+ * cards takes its natural height, and the collection derives its page size
+ * from whatever vertical space remains below it.
+ */
+export const AutoPageSizeWithContentOnTop: Story = {
+  ...Basic,
+  render: () => (
+    <div className="flex h-full w-full flex-col gap-4">
+      <SummaryCards />
+      <div {...autoCollectionSlot}>
+        <ExampleComponent fullHeight dataAdapter={makeAutoAdapter()} />
+      </div>
+    </div>
+  ),
+}
+
+/**
+ * Auto page size with other content below it: the collection fills the space
+ * above the summary cards, which keep their natural height pinned at the
+ * bottom.
+ */
+export const AutoPageSizeWithContentBelow: Story = {
+  ...Basic,
+  render: () => (
+    <div className="flex h-full w-full flex-col gap-4">
+      <div {...autoCollectionSlot}>
+        <ExampleComponent fullHeight dataAdapter={makeAutoAdapter()} />
+      </div>
+      <SummaryCards />
+    </div>
+  ),
+}
+
+/**
+ * Two auto-sized collections wrapping other content: one on top, a row of
+ * summary cards in the middle, and another at the bottom. Each collection
+ * measures its own slot, so they split the remaining space independently.
+ */
+export const AutoPageSizeAroundContent: Story = {
+  ...Basic,
+  render: () => (
+    <div className="flex h-full w-full flex-col gap-4">
+      <div {...autoCollectionSlot}>
+        <ExampleComponent fullHeight dataAdapter={makeAutoAdapter()} />
+      </div>
+      <SummaryCards />
+      <div {...autoCollectionSlot}>
+        <ExampleComponent fullHeight dataAdapter={makeAutoAdapter()} />
+      </div>
+    </div>
+  ),
+}
+
+/**
+ * Two collections with `perPage: "auto"` splitting the viewport. Each one
+ * measures only its own container, so they resolve their page sizes
+ * independently — no coordination between collections is needed.
+ */
+export const AutoPageSizeBoth: Story = {
+  ...Basic,
+  render: () => (
+    <div className="flex h-full w-full flex-col gap-4">
+      <div {...autoCollectionSlot}>
+        <ExampleComponent fullHeight dataAdapter={makeAutoAdapter()} />
+      </div>
+      <div {...autoCollectionSlot}>
+        <ExampleComponent fullHeight dataAdapter={makeAutoAdapter()} />
+      </div>
+    </div>
+  ),
+}
+
+/**
+ * When the auto-sized collection is squeezed by its siblings and there is
+ * (almost) no vertical space left, its flex slot still reserves the minimum
+ * height, so it stays visible showing the rows that fit that reserved space
+ * while the page scrolls — it never disappears. On very tall containers the
+ * page size caps at 30.
+ */
+export const AutoPageSizeWithNoSpaceLeft: Story = {
+  ...Basic,
+  render: () => {
+    const makeFixedAdapter = () =>
+      createDataAdapter({
+        data: generateMockUsers(300),
+        delay: 500,
+        paginationType: "pages",
+        perPage: 5,
+      })
+    const autoAdapter = createDataAdapter({
+      data: generateMockUsers(300),
+      delay: 500,
+      paginationType: "pages",
+      perPage: "auto",
+    })
+
+    return (
+      <div className="flex h-full w-full flex-col gap-4">
+        <div>
+          <ExampleComponent dataAdapter={makeFixedAdapter()} />
+        </div>
+        <div>
+          <ExampleComponent dataAdapter={makeFixedAdapter()} />
+        </div>
+        <div {...autoCollectionSlot}>
+          <ExampleComponent fullHeight dataAdapter={autoAdapter} />
+        </div>
+      </div>
+    )
+  },
+}
+
 export const WithPaginationAndGrouping: Story = {
   ...WithPagination,
   parameters: {
     chromatic: { disableSnapshot: false },
   },
   render: () => {
-    const paginatedMockUsers = generateMockUsers(50)
+    const paginatedMockUsers = generateMockUsers(300)
     const dataAdapter = createDataAdapter({
       data: paginatedMockUsers,
       delay: 500,

--- a/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/mockData.tsx
@@ -1579,7 +1579,10 @@ export const ExampleComponent = ({
 
   return (
     <div
-      className={cn("space-y-4", fullHeight && "max-h-full w-full bg-[#fff]")}
+      className={cn(
+        "space-y-4",
+        fullHeight && "flex h-full min-h-0 w-full flex-col bg-[#fff]"
+      )}
     >
       <OneDataCollection
         dataTestId={`one-data-collection-${id ?? "example"}`}
@@ -1719,7 +1722,7 @@ interface DataAdapterOptions<TRecord> {
   delay?: number
   useObservable?: boolean
   paginationType?: PaginationType
-  perPage?: number
+  perPage?: number | "auto"
   search?: string
 }
 
@@ -1853,7 +1856,8 @@ export function createDataAdapter<
     // Apply pagination if needed
     if (pagination && paginationType === "pages") {
       const { currentPage = 1 } = pagination
-      const pageSize = pagination.perPage || perPage
+      const pageSize =
+        pagination.perPage || (typeof perPage === "number" ? perPage : 20)
       const startIndex = (currentPage - 1) * pageSize
       const paginatedRecords = filteredRecords.slice(
         startIndex,
@@ -1870,7 +1874,8 @@ export function createDataAdapter<
         summaries: summaries as TRecord, // Include summaries
       }
     } else if (pagination && paginationType === "infinite-scroll") {
-      const pageSize = pagination.perPage || perPage
+      const pageSize =
+        pagination.perPage || (typeof perPage === "number" ? perPage : 20)
 
       const cursor = "cursor" in pagination ? pagination.cursor : null
 

--- a/packages/react/src/patterns/OneDataCollection/exports.ts
+++ b/packages/react/src/patterns/OneDataCollection/exports.ts
@@ -12,6 +12,11 @@ export * from "./hooks/useDataCollectionData"
 export * from "./hooks/useDataCollectionItemNavigation"
 export * from "./hooks/useDataCollectionSource"
 export * from "./hooks/useInfiniteScrollPagination"
+export {
+  AUTO_PER_PAGE_MAX,
+  AUTO_PER_PAGE_MIN_RESERVED_ROWS,
+  getAutoPerPageMinHeight,
+} from "./hooks/useAutoPerPage"
 export { useExportAction } from "./hooks/useExportAction"
 export { downloadAsCSV, generateCSVContent } from "./utils/csvExport"
 export type { CSVExportOptions } from "./utils/csvExport"

--- a/packages/react/src/patterns/OneDataCollection/hooks/__tests__/useAutoPerPage.spec.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/__tests__/useAutoPerPage.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest"
+
+import { shouldAutoSizePerPage } from "../useAutoPerPage"
+
+describe("shouldAutoSizePerPage", () => {
+  const pages = { paginationType: "pages" as const }
+
+  it("auto-sizes a full-height page-based collection with perPage unset", () => {
+    // The case the API should just handle: fullHeight + no perPage → auto.
+    expect(shouldAutoSizePerPage({ ...pages }, true)).toBe(true)
+    expect(shouldAutoSizePerPage({ ...pages, perPage: undefined }, true)).toBe(
+      true
+    )
+  })
+
+  it("auto-sizes when perPage is explicitly 'auto' and fullHeight", () => {
+    expect(shouldAutoSizePerPage({ ...pages, perPage: "auto" }, true)).toBe(
+      true
+    )
+  })
+
+  it("respects a numeric perPage (never auto-sizes)", () => {
+    expect(shouldAutoSizePerPage({ ...pages, perPage: 20 }, true)).toBe(false)
+  })
+
+  it("does not auto-size without fullHeight, even if perPage is unset", () => {
+    expect(shouldAutoSizePerPage({ ...pages }, false)).toBe(false)
+    expect(shouldAutoSizePerPage({ ...pages }, undefined)).toBe(false)
+    // Explicit "auto" without fullHeight also can't be measured → no auto.
+    expect(shouldAutoSizePerPage({ ...pages, perPage: "auto" }, false)).toBe(
+      false
+    )
+  })
+
+  it("only applies to page-based pagination", () => {
+    expect(
+      shouldAutoSizePerPage({ paginationType: "infinite-scroll" }, true)
+    ).toBe(false)
+    // A non-paginated adapter has no paginationType.
+    expect(shouldAutoSizePerPage({}, true)).toBe(false)
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/hooks/useAutoPerPage.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useAutoPerPage.ts
@@ -1,6 +1,26 @@
 import { RefObject, useEffect, useLayoutEffect, useRef, useState } from "react"
 
 /**
+ * Whether a collection should derive its page size from the available height.
+ *
+ * It applies to page-based, `fullHeight` collections that either opt in
+ * explicitly with `perPage: "auto"` or simply leave `perPage` unset — in a
+ * full-height layout an unspecified page size means "fill the height", so it
+ * defaults to auto instead of a hardcoded fallback. A numeric `perPage` is
+ * always respected as-is, and without `fullHeight` there is no bounded height
+ * to measure so it never applies.
+ */
+export function shouldAutoSizePerPage(
+  dataAdapter: { paginationType?: string; perPage?: number | "auto" },
+  fullHeight: boolean | undefined
+): boolean {
+  if (!fullHeight) return false
+  if (dataAdapter.paginationType !== "pages") return false
+  const perPage = dataAdapter.perPage
+  return perPage === "auto" || perPage === undefined
+}
+
+/**
  * Upper bound for the resolved page size, so a very tall container never
  * fetches an unreasonably large page.
  */

--- a/packages/react/src/patterns/OneDataCollection/hooks/useAutoPerPage.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useAutoPerPage.ts
@@ -1,0 +1,184 @@
+import { RefObject, useEffect, useLayoutEffect, useRef, useState } from "react"
+
+/**
+ * Upper bound for the resolved page size, so a very tall container never
+ * fetches an unreasonably large page.
+ */
+export const AUTO_PER_PAGE_MAX = 30
+
+/**
+ * Number of rows the min-height reservation keeps space for (see
+ * `getAutoPerPageMinHeight`). This is NOT a lower bound on the page size — the
+ * page size always matches what actually fits, so it never overflows. It only
+ * sizes the space a squeezed collection reserves to stay usable.
+ */
+export const AUTO_PER_PAGE_MIN_RESERVED_ROWS = 10
+
+/**
+ * Row-height estimates used to seed the FIRST page in `perPage: "auto"` mode.
+ * The real page size is then derived by measuring the rendered content (see
+ * `useAutoPerPage`).
+ *
+ * These MUST be a lower bound of the real row height: the measurement only
+ * trims the seeded page down to what fits, never grows it, so an estimate above
+ * the real height would under-fetch and leave the collection short. A view with
+ * a fixed row height can seed with that exact height (first page is already
+ * right, nothing reflows); content-variable views seed at the baseline and let
+ * the measurement trim.
+ *
+ * - `default` (table, editable table) — the baseline min row height. Their real
+ *   height depends on column content (wrapping text, inline controls), so they
+ *   seed low and rely on the measurement to trim.
+ * - `list` — list rows are a fixed height (`min-h-[64px]`, ~68px rendered).
+ */
+export const ESTIMATED_ROW_HEIGHT = 48
+export const ESTIMATED_LIST_ROW_HEIGHT = 68
+
+/**
+ * Vertical space inside the visualization container that is not available for
+ * rows: the sticky table header (~40px), the pagination footer (~52px) and the
+ * gap between them (16px).
+ */
+const RESERVED_CHROME_HEIGHT = 108
+
+// The page size is whatever fits, never forced up (which would overflow), only
+// bounded to at least 1 row and at most AUTO_PER_PAGE_MAX.
+const clampPerPage = (value: number): number =>
+  Math.min(AUTO_PER_PAGE_MAX, Math.max(1, value))
+
+/**
+ * Minimum height a `perPage: "auto"` collection reserves so it stays usable
+ * (space for AUTO_PER_PAGE_MIN_RESERVED_ROWS rows plus chrome). Applied as a
+ * `min-height` so the collection stays visible when its siblings would
+ * otherwise squeeze it to nothing — the whole page scrolls instead of the
+ * collection disappearing.
+ */
+export function getAutoPerPageMinHeight(
+  rowHeight: number = ESTIMATED_ROW_HEIGHT
+): number {
+  return RESERVED_CHROME_HEIGHT + AUTO_PER_PAGE_MIN_RESERVED_ROWS * rowHeight
+}
+
+/**
+ * Finds the scrollable element inside the visualization container (the table /
+ * list / card scroll area), preferring the one holding the most content.
+ */
+function findScrollContainer(container: HTMLElement): HTMLElement | null {
+  const candidates = Array.from(
+    container.querySelectorAll<HTMLElement>("*")
+  ).filter((el) => {
+    const overflowY = getComputedStyle(el).overflowY
+    return overflowY === "auto" || overflowY === "scroll"
+  })
+  if (candidates.length === 0) return null
+  return candidates.reduce((tallest, el) =>
+    el.scrollHeight > tallest.scrollHeight ? el : tallest
+  )
+}
+
+/**
+ * Resolves `perPage: "auto"` so a page fills the available vertical space
+ * without overflowing.
+ *
+ * How it works: an estimate seeds the first page so the visualization renders,
+ * then — once `ready` (the first fetch has resolved) — the real page size is
+ * derived by measuring the rendered content. Comparing the scroll container's
+ * visible height to its total content height yields the exact number of items
+ * that fit, independent of the visualization's row height or column count:
+ *
+ *   itemsThatFit = seedPerPage × clientHeight / scrollHeight
+ *
+ * This works for tables, lists and (multi-column) card grids alike, because a
+ * grid's total height already reflects its columns. The result is exactly what
+ * fits (never forced higher, so a page never overflows), bounded to at most
+ * AUTO_PER_PAGE_MAX. A squeezed collection stays usable via the min-height
+ * reservation (see `getAutoPerPageMinHeight`), not by inflating the page size.
+ *
+ * The size is measured once per visualization and kept stable across resizes:
+ * resizing must not shift page boundaries under the user (an item would jump
+ * between pages) nor trigger refetch churn while dragging a window edge. It is
+ * re-derived when `rowHeight` changes, i.e. when the active visualization
+ * switches to one with a different row height.
+ *
+ * Requires a height-bounded container (the collection's `fullHeight` mode).
+ * In an unbounded container the measured height would derive from the content
+ * itself, creating a feedback loop — callers must not enable the hook there.
+ *
+ * @param containerRef the visualization container to measure
+ * @param enabled whether `perPage: "auto"` is active
+ * @param options.rowHeight per-visualization seed estimate
+ * @param options.ready `true` once the first page of data has rendered and can
+ *   be measured
+ * @param options.measureKey re-seeds and re-measures whenever it changes (e.g.
+ *   the active visualization), since each visualization has its own row layout
+ * @returns the resolved page size, or `undefined` until seeded (or disabled)
+ */
+export function useAutoPerPage(
+  containerRef: RefObject<HTMLElement | null>,
+  enabled: boolean,
+  {
+    rowHeight = ESTIMATED_ROW_HEIGHT,
+    ready = true,
+    measureKey,
+  }: {
+    rowHeight?: number
+    ready?: boolean
+    measureKey?: unknown
+  } = {}
+): number | undefined {
+  const [perPage, setPerPage] = useState<number | undefined>(undefined)
+  const seedRef = useRef<number | undefined>(undefined)
+  const measuredRef = useRef(false)
+
+  // 1. Seed the first page from the estimate so the visualization mounts and
+  //    renders something we can measure. Re-seeds when the visualization
+  //    changes (measureKey); intentionally NOT on container resize.
+  useLayoutEffect(() => {
+    if (!enabled) {
+      setPerPage(undefined)
+      seedRef.current = undefined
+      measuredRef.current = false
+      return
+    }
+    const container = containerRef.current
+    if (!container) return
+
+    const available = container.clientHeight - RESERVED_CHROME_HEIGHT
+    const seed = clampPerPage(Math.floor(available / rowHeight))
+    seedRef.current = seed
+    measuredRef.current = false
+    setPerPage(seed)
+  }, [enabled, rowHeight, measureKey, containerRef])
+
+  // 2. Once the first page has rendered, measure the real content and correct
+  //    the page size to what actually fits — exactly once per seed. The
+  //    container and seed are read inside the timeout (rather than the effect
+  //    body) so the measurement survives mount churn: the ref is reliably
+  //    attached and laid out by the time it runs.
+  useEffect(() => {
+    if (!enabled || !ready || measuredRef.current) return
+
+    // A timeout (not requestAnimationFrame, which is paused in background
+    // tabs) lets layout settle after the first page renders, then measures.
+    const timer = setTimeout(() => {
+      const container = containerRef.current
+      const seed = seedRef.current
+      if (!container || seed === undefined || measuredRef.current) return
+      const scroller = findScrollContainer(container)
+      if (
+        !scroller ||
+        scroller.clientHeight === 0 ||
+        scroller.scrollHeight === 0
+      )
+        return
+      measuredRef.current = true
+      const fit = clampPerPage(
+        Math.floor((seed * scroller.clientHeight) / scroller.scrollHeight)
+      )
+      setPerPage((prev) => (prev === fit ? prev : fit))
+    }, 0)
+    return () => clearTimeout(timer)
+  }, [enabled, ready, perPage, measureKey, containerRef])
+
+  return enabled ? perPage : undefined
+}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Card/index.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Card/index.tsx
@@ -354,7 +354,11 @@ export const CardCollection = <
   const overridenDataAdapter = useMemo(() => {
     if (source.dataAdapter.paginationType === "pages") {
       const perPage = source.dataAdapter.perPage
-      const overridenPerPage = findNextMultiple(perPage ?? 24)
+      // "auto" is resolved to a number by OneDataCollection before it reaches
+      // the visualization; fall back to the default if it wasn't.
+      const overridenPerPage = findNextMultiple(
+        typeof perPage === "number" ? perPage : 24
+      )
       return {
         ...source.dataAdapter,
         perPage: overridenPerPage,

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/useDataCollectionTreeData.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Graph/useDataCollectionTreeData.ts
@@ -415,8 +415,10 @@ export function useDataCollectionTreeData<
         sortings,
         navigationFilters: src.currentNavigationFilters,
       }
+      // `adapter.perPage` may be `"auto"` (height-based sizing), which doesn't
+      // apply to the tree/graph fetch — fall back to the default page size.
       const perPage =
-        "perPage" in adapter && adapter.perPage
+        "perPage" in adapter && typeof adapter.perPage === "number"
           ? adapter.perPage
           : DEFAULT_TREE_PER_PAGE
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -399,6 +399,7 @@ export const TableCollection = <
       <TableWrapper>
         <div
           className={cn(
+            "min-h-0",
             bordered &&
               "overflow-hidden rounded-lg border border-solid border-f1-border-secondary [&_thead::before]:!bg-transparent [&_thead_th>div:first-child]:!bg-transparent [&_tbody>tr:last-child::after]:!bg-transparent"
           )}


### PR DESCRIPTION
## Description

Adds an auto page size for page-based, full-height `OneDataCollection`s so a page shows exactly the rows that fit the available height — no partial overflowing row and no wasted space — instead of a hardcoded `perPage` that rarely matches the container. Set `perPage: "auto"` on the data adapter (page-based pagination inside a `fullHeight` collection) and the page size is derived by measuring the rendered content. Also fixes a pre-existing bug where unbordered full-height tables didn't scroll internally, pushing the pagination out of view.

## Implementation details

- feat: add `perPage: "auto"` for page-based `fullHeight` collections — the page size is measured from the rendered content so it fills the available height without overflowing, capped at 30

  <details>
  <summary>How it sizes and why it's measured, not estimated</summary>

  A first page is seeded from a per-visualization row-height estimate, then the real page size is derived by comparing the scroll container's visible height to its content height — so it works across tables, lists and card grids regardless of row height or column count. Row heights are content- and width-dependent (a wrapping column can make table rows ~2× taller), so a fixed estimate can't be correct; the seed estimate is a lower bound so the measurement only ever trims down to what fits. List rows have a fixed height and seed exactly (no reflow); table/editable seed at the baseline and rely on the measurement.
  </details>

- feat: reuse already-loaded records when the page size shrinks, instead of refetching (no extra loading when the measurement trims the over-fetched first page)
- fix(Table): add `min-h-0` so unbordered full-height tables scroll internally and keep the pagination pinned in view (previously the content grew unbounded and pushed the footer off-screen)
- feat: export `getAutoPerPageMinHeight()` and `AUTO_PER_PAGE_MAX` / `AUTO_PER_PAGE_MIN_RESERVED_ROWS` so consumers can reserve a squeezed collection's minimum visible height
- test: cover the page-size reuse contract (no refetch when the page shrinks; fetch when it grows beyond loaded records)
- docs: document auto page size (Data Collection / Full height) and recommend full-height layout for CRUD-focused pages (Data Collection / CRUD patterns)
- test: add full-height auto page size stories — content above / below / around collections, two auto collections, a fixed sibling, and the squeezed case

Behaviour is demonstrated across the **Data Collection / Full height** Storybook stories.