### PR TITLE
fix(storybook): auto-recover from stale chunk imports after redeploy

### DIFF
--- a/packages/react/.storybook/manager-head.html
+++ b/packages/react/.storybook/manager-head.html
@@ -156,6 +156,40 @@
 </style>
 
 <script>
+  // Recover from stale lazy-loaded chunks after a redeploy. The manager
+  // lazy-loads its own chunks (index, docs) the same way the preview loads
+  // story chunks, so it hits the same "Failed to fetch dynamically imported
+  // module" 404 when a merge to main redeploys the site under an open tab.
+  // See preview-head.html for the full explanation.
+  ;(function () {
+    var KEY = "sb:chunk-reload-at"
+    function recover() {
+      var now = Date.now()
+      var last = Number(sessionStorage.getItem(KEY) || 0)
+      if (now - last < 10000) return
+      sessionStorage.setItem(KEY, String(now))
+      window.location.reload()
+    }
+    window.addEventListener("vite:preloadError", function (event) {
+      event.preventDefault()
+      recover()
+    })
+    window.addEventListener("unhandledrejection", function (event) {
+      var reason = event && event.reason
+      var msg = reason && (reason.message || String(reason))
+      if (
+        typeof msg === "string" &&
+        /Failed to fetch dynamically imported module|error loading dynamically imported module|Importing a module script failed/i.test(
+          msg
+        )
+      ) {
+        recover()
+      }
+    })
+  })()
+</script>
+
+<script>
   ;(function () {
     // hide internal tags in production builds menu
     setTimeout(function () {

--- a/packages/react/.storybook/preview-head.html
+++ b/packages/react/.storybook/preview-head.html
@@ -420,3 +420,44 @@
   }
 </style>
 <script src="https://cdn.jsdelivr.net/npm/react-render-tracker"></script>
+<script>
+  // Recover from stale lazy-loaded chunks after a redeploy.
+  //
+  // f0.factorial.dev is a static Storybook build: each story is a
+  // content-hashed chunk loaded on demand via dynamic import(). When main is
+  // merged the site is rebuilt and every hash changes, so a tab left open
+  // still references chunk names that no longer exist on the server. The next
+  // navigation to a not-yet-loaded story then 404s with "Failed to fetch
+  // dynamically imported module". Vite dispatches `vite:preloadError` for
+  // exactly this — reload once to pull the fresh index and current hashes.
+  ;(function () {
+    var KEY = "sb:chunk-reload-at"
+    function recover() {
+      var now = Date.now()
+      var last = Number(sessionStorage.getItem(KEY) || 0)
+      // If we reloaded seconds ago the chunk is genuinely gone (broken
+      // deploy), not just stale — stop, so we never loop forever.
+      if (now - last < 10000) return
+      sessionStorage.setItem(KEY, String(now))
+      window.location.reload()
+    }
+    window.addEventListener("vite:preloadError", function (event) {
+      event.preventDefault()
+      recover()
+    })
+    // Belt-and-suspenders for imports that don't route through Vite's
+    // preload helper: match the rejection message directly.
+    window.addEventListener("unhandledrejection", function (event) {
+      var reason = event && event.reason
+      var msg = reason && (reason.message || String(reason))
+      if (
+        typeof msg === "string" &&
+        /Failed to fetch dynamically imported module|error loading dynamically imported module|Importing a module script failed/i.test(
+          msg
+        )
+      ) {
+        recover()
+      }
+    })
+  })()
+</script>


### PR DESCRIPTION
## Description

Fixes the intermittent "Failed to fetch dynamically imported module" error on f0.factorial.dev that only clears after a manual refresh. The static Storybook build code-splits each story into a content-hashed chunk loaded lazily via dynamic `import()`; when `main` is merged the site is redeployed with fresh hashes and the old chunk files are deleted, so a tab left open still references chunk names that no longer exist and 404s on the next navigation to a not-yet-loaded story. This adds a small handler that transparently reloads the page once when such a stale import fails, turning a dead-end error into an invisible recovery.

<img width="1627" height="491" alt="Screenshot 2026-07-22 at 18 35 21" src="https://github.com/user-attachments/assets/a17bbfff-14f0-4940-993d-452ba7674825" />

## Implementation details

- fix: listen for Vite's `vite:preloadError` in the preview iframe and reload once to pull the fresh story index and current chunk hashes
- fix: apply the same handler in the manager, which lazy-loads its own chunks (index, docs) the same way
- fix: match the raw rejection message as a fallback for imports that don't route through Vite's preload helper
- chore: guard the reload with a 10s `sessionStorage` timestamp so a genuinely missing chunk (broken deploy) reloads once instead of looping forever

  <details>
  <summary>Why not just keep old chunks around?</summary>

  Retaining a grace window of superseded chunks at the CDN/hosting layer is the deeper mitigation, but it's a hosting-config change outside this repo. The reload-on-preload-error handler is the pragmatic fix used by most Vite/Storybook deployments and needs no infra changes. The two are complementary.
  </details>

Note: this can't be reproduced in `storybook dev` (that's the unrelated dev-mode re-optimization path); it only manifests in a production static build served over a redeploy.