### PR TITLE
feat(component-status): [FCT-59729] a11y as a stability requirement + live panel row

### DIFF
--- a/packages/react/docs/component-status.mdx
+++ b/packages/react/docs/component-status.mdx
@@ -63,14 +63,19 @@ is treated as **experimental**. This mirrors the
 | Has a play function        | The story defines a `play:` interaction test                        |
 | Has MDX documentation      | An `.mdx` docs page exists alongside the stories                     |
 | Docs reach `good` quality  | MDX adds DoDonts, a "when not to use" section, and 3+ named examples on top of the Acceptable base (sections + props table) |
+| Accessibility enforced      | Every story opts into blocking axe (`a11y: { test: "error" }`) — none skipped or downgraded to `todo`. On a green `main` this means the component is axe-clean (WCAG 2.0/2.1/2.2, A & AA) |
 
 > The doc bar is the **Good** tier — Promotion to stable requires it (Acceptable
 > is only the experimental Build bar). Tier heuristic: `none` → `stub` →
 > `acceptable` → `good` → `gold` (a coarse structural check, not a prose review).
 >
-> Not automated here (still manual promotion gates): the axe **a11y** test
-> passing, adoption by **≥3 product teams**, **no breaking changes for 60 days**,
-> and Foundations approval.
+> The **Accessibility** row shows live per-criterion detail when expanded (axe
+> runs client-side against the rendered stories in their default state); CI's
+> `test: "error"` run — which also drives play functions — remains the source of
+> truth.
+>
+> Not automated here (still manual promotion gates): adoption by **≥3 product
+> teams**, **no breaking changes for 60 days**, and Foundations approval.
 
 ## Programmatic API
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -184,6 +184,7 @@
     "@vitest/ui": "4.0.15",
     "@xyflow/react": "^12",
     "autoprefixer": "^10.4.21",
+    "axe-core": "^4.11.1",
     "axe-playwright": "^2.1.0",
     "chalk": "^5.4.1",
     "chromatic": "^11.28.0",

--- a/packages/react/scripts/component-status-build.mjs
+++ b/packages/react/scripts/component-status-build.mjs
@@ -228,6 +228,25 @@ function componentDirOf(storyFilePath) {
 }
 
 /**
+ * Accessibility posture of a story file (heuristic, mirrors the axe ratchet in
+ * .storybook/test-runner.ts). Ordered skipped < todo < enforced:
+ *  - "skipped":  at least one story opts out of axe (skipCi/withSkipA11y).
+ *  - "enforced": opts into blocking axe (`test: "error"`) with no skips and no
+ *    todo/warning downgrades — on a green main, implies axe-clean.
+ *  - "todo":     everything else (axe runs non-blocking).
+ * Limitation: a file mixing `error` with a per-story `todo` reads as "todo".
+ */
+export function a11yTierOf(content) {
+  const skipped =
+    /\bskipCi\b/.test(content) || /\bwithSkipA11y\s*\(/.test(content)
+  if (skipped) return "skipped"
+  const enforced =
+    /\btest\s*:\s*["']error["']/.test(content) &&
+    !/\btest\s*:\s*["'](todo|warning)["']/.test(content)
+  return enforced ? "enforced" : "todo"
+}
+
+/**
  * Scan `srcDir` and build the full component-status dataset. Pure filesystem
  * work — no committed artifact, no subprocesses. `srcDir` defaults to this
  * package's `src/`; tests pass a fixture tree.
@@ -301,24 +320,7 @@ export function computeComponentStatusData(srcDir = SRC_DIR) {
     }
     const docSignals = docSignalsOf(mdxContent)
 
-    // Accessibility posture (heuristic, mirrors the axe ratchet in
-    // .storybook/test-runner.ts). Ordered skipped < todo < enforced:
-    //  - "skipped":  at least one story opts out of axe (skipCi/withSkipA11y).
-    //  - "enforced": opts into blocking axe (`test: "error"`) with no skips and
-    //    no todo/warning downgrades — on a green main, implies axe-clean.
-    //  - "todo":     everything else (axe runs non-blocking).
-    // Limitation: a file mixing `error` with a per-story `todo` reads as "todo".
-    const a11ySkipped =
-      /\bskipCi\b/.test(content) || /\bwithSkipA11y\s*\(/.test(content)
-    const a11yEnforced =
-      /\btest\s*:\s*["']error["']/.test(content) &&
-      !a11ySkipped &&
-      !/\btest\s*:\s*["'](todo|warning)["']/.test(content)
-    const a11yTier = a11ySkipped
-      ? "skipped"
-      : a11yEnforced
-        ? "enforced"
-        : "todo"
+    const a11yTier = a11yTierOf(content)
 
     components.push({
       name: storyName,

--- a/packages/react/scripts/component-status-build.mjs
+++ b/packages/react/scripts/component-status-build.mjs
@@ -49,7 +49,7 @@ export function meetsStableBar(c) {
     c.hasPlayFunction &&
     c.hasMdxDocs &&
     DOC_TIER_ORDER.indexOf(c.docQuality) >= DOC_TIER_ORDER.indexOf("good") &&
-    c.a11yEnforced
+    c.a11yTier === "enforced"
   )
 }
 
@@ -302,16 +302,23 @@ export function computeComponentStatusData(srcDir = SRC_DIR) {
     const docSignals = docSignalsOf(mdxContent)
 
     // Accessibility posture (heuristic, mirrors the axe ratchet in
-    // .storybook/test-runner.ts). "enforced" means the file opts its stories
-    // into blocking axe (`test: "error"`) with no skips and no todo/warning
-    // downgrades — which, on a green main, implies the stories are axe-clean.
-    // Limitation: a file mixing `error` with a per-story `todo` reads as debt.
+    // .storybook/test-runner.ts). Ordered skipped < todo < enforced:
+    //  - "skipped":  at least one story opts out of axe (skipCi/withSkipA11y).
+    //  - "enforced": opts into blocking axe (`test: "error"`) with no skips and
+    //    no todo/warning downgrades — on a green main, implies axe-clean.
+    //  - "todo":     everything else (axe runs non-blocking).
+    // Limitation: a file mixing `error` with a per-story `todo` reads as "todo".
     const a11ySkipped =
       /\bskipCi\b/.test(content) || /\bwithSkipA11y\s*\(/.test(content)
     const a11yEnforced =
       /\btest\s*:\s*["']error["']/.test(content) &&
       !a11ySkipped &&
       !/\btest\s*:\s*["'](todo|warning)["']/.test(content)
+    const a11yTier = a11ySkipped
+      ? "skipped"
+      : a11yEnforced
+        ? "enforced"
+        : "todo"
 
     components.push({
       name: storyName,
@@ -326,9 +333,8 @@ export function computeComponentStatusData(srcDir = SRC_DIR) {
       hasMdxDocs: Boolean(mdxPath),
       docQuality: scoreDocQuality(mdxContent, docSignals),
       docSignals,
-      // Accessibility: enforced = axe blocks on this component's stories.
-      a11yEnforced,
-      a11ySkipped,
+      // Accessibility posture: "skipped" | "todo" | "enforced".
+      a11yTier,
       storyFile: relative,
     })
   }

--- a/packages/react/scripts/component-status-build.mjs
+++ b/packages/react/scripts/component-status-build.mjs
@@ -48,7 +48,8 @@ export function meetsStableBar(c) {
     c.hasUnitTests &&
     c.hasPlayFunction &&
     c.hasMdxDocs &&
-    DOC_TIER_ORDER.indexOf(c.docQuality) >= DOC_TIER_ORDER.indexOf("good")
+    DOC_TIER_ORDER.indexOf(c.docQuality) >= DOC_TIER_ORDER.indexOf("good") &&
+    c.a11yEnforced
   )
 }
 
@@ -300,6 +301,18 @@ export function computeComponentStatusData(srcDir = SRC_DIR) {
     }
     const docSignals = docSignalsOf(mdxContent)
 
+    // Accessibility posture (heuristic, mirrors the axe ratchet in
+    // .storybook/test-runner.ts). "enforced" means the file opts its stories
+    // into blocking axe (`test: "error"`) with no skips and no todo/warning
+    // downgrades — which, on a green main, implies the stories are axe-clean.
+    // Limitation: a file mixing `error` with a per-story `todo` reads as debt.
+    const a11ySkipped =
+      /\bskipCi\b/.test(content) || /\bwithSkipA11y\s*\(/.test(content)
+    const a11yEnforced =
+      /\btest\s*:\s*["']error["']/.test(content) &&
+      !a11ySkipped &&
+      !/\btest\s*:\s*["'](todo|warning)["']/.test(content)
+
     components.push({
       name: storyName,
       zone,
@@ -313,6 +326,9 @@ export function computeComponentStatusData(srcDir = SRC_DIR) {
       hasMdxDocs: Boolean(mdxPath),
       docQuality: scoreDocQuality(mdxContent, docSignals),
       docSignals,
+      // Accessibility: enforced = axe blocks on this component's stories.
+      a11yEnforced,
+      a11ySkipped,
       storyFile: relative,
     })
   }

--- a/packages/react/scripts/component-status-build.test.ts
+++ b/packages/react/scripts/component-status-build.test.ts
@@ -4,7 +4,10 @@ import { dirname, join } from "node:path"
 
 import { afterAll, beforeAll, describe, expect, test } from "vitest"
 
-import { computeComponentStatusData } from "./component-status-build.mjs"
+import {
+  a11yTierOf,
+  computeComponentStatusData,
+} from "./component-status-build.mjs"
 
 /**
  * These tests exercise the filesystem scan / extraction against a synthetic
@@ -233,5 +236,46 @@ describe("computeComponentStatusData (extraction)", () => {
       data.components.filter((c) => c.apiStatus === "stable").length
     )
     expect(data.stats.byDocQuality.gold).toBe(1)
+  })
+})
+
+describe("a11yTierOf", () => {
+  test("'skipped' when a story opts out via skipCi", () => {
+    expect(
+      a11yTierOf(`export const S = { parameters: { a11y: { skipCi: true } } }`)
+    ).toBe("skipped")
+  })
+
+  test("'skipped' when a story opts out via withSkipA11y()", () => {
+    expect(
+      a11yTierOf(`export const S = withSkipA11y({ parameters: {} })`)
+    ).toBe("skipped")
+  })
+
+  test("'enforced' when axe is blocking (test: \"error\") with no skips or downgrades", () => {
+    expect(
+      a11yTierOf(`export default { parameters: { a11y: { test: "error" } } }`)
+    ).toBe("enforced")
+  })
+
+  test("'todo' when no a11y config is present", () => {
+    expect(a11yTierOf(`export default { title: "X" }`)).toBe("todo")
+  })
+
+  test("'todo' when a file mixes error with a per-story todo (documented limitation)", () => {
+    expect(
+      a11yTierOf(
+        `export default { parameters: { a11y: { test: "error" } } }
+         export const Known = { parameters: { a11y: { test: "todo" } } }`
+      )
+    ).toBe("todo")
+  })
+
+  test("skip wins over error (precedence)", () => {
+    expect(
+      a11yTierOf(
+        `export default { parameters: { a11y: { test: "error", skipCi: true } } }`
+      )
+    ).toBe("skipped")
   })
 })

--- a/packages/react/src/component-status/A11yRow.tsx
+++ b/packages/react/src/component-status/A11yRow.tsx
@@ -1,0 +1,214 @@
+import type { AxeResults, Result, TagValue } from "axe-core"
+import React, { useCallback, useRef, useState } from "react"
+
+/**
+ * The Accessibility row inside the Maturity-level checklist.
+ *
+ * Collapsed, it shows the build-time posture (enforced / not-enforced / axe
+ * skipped) — cheap, works anywhere the panel ships. On first expand, and only
+ * inside Storybook, it lazily loads axe-core and runs it against the story
+ * canvases already rendered on the docs page, then lists the failing WCAG
+ * criteria. CI (`test: "error"`, with play functions) remains the source of
+ * truth — this is a fresh, default-state indicator.
+ */
+
+const WCAG_TAGS: TagValue[] = [
+  "wcag2a",
+  "wcag2aa",
+  "wcag21a",
+  "wcag21aa",
+  "wcag22a",
+  "wcag22aa",
+]
+
+interface Criterion {
+  ruleId: string
+  description: string
+  sc: string | null
+  level: string
+  version: string
+  nodes: number
+}
+
+/** Derive WCAG success criterion, level and version from an axe rule's tags. */
+function wcagFromTags(
+  tags: string[]
+): Omit<Criterion, "ruleId" | "description" | "nodes"> {
+  let sc: string | null = null
+  for (const t of tags) {
+    const m = /^wcag(\d)(\d)(\d{1,2})$/.exec(t)
+    if (m) {
+      sc = `${m[1]}.${m[2]}.${m[3]}`
+      break
+    }
+  }
+  const level = tags.some((t) => /^wcag2\d?aa$/.test(t)) ? "AA" : "A"
+  const version =
+    tags.includes("wcag22a") || tags.includes("wcag22aa")
+      ? "2.2"
+      : tags.includes("wcag21a") || tags.includes("wcag21aa")
+        ? "2.1"
+        : "2.0"
+  return { sc, level, version }
+}
+
+type AuditState =
+  | { status: "idle" }
+  | { status: "running" }
+  | { status: "unavailable" }
+  | { status: "done"; criteria: Criterion[] }
+
+function isInStorybookDocs(): boolean {
+  return (
+    typeof document !== "undefined" &&
+    document.querySelector("#storybook-docs") !== null
+  )
+}
+
+async function runAudit(): Promise<Criterion[]> {
+  const { default: axe } = await import("axe-core")
+  const canvases = Array.from(
+    document.querySelectorAll<HTMLElement>("#storybook-docs .docs-story")
+  )
+  const targets = canvases.length > 0 ? canvases : []
+
+  const byRule = new Map<string, Criterion>()
+  // Serialize: axe throws "Axe is already running" on concurrent runs.
+  for (const node of targets) {
+    let results: AxeResults
+    try {
+      results = await axe.run(node, {
+        runOnly: { type: "tag", values: WCAG_TAGS },
+      })
+    } catch {
+      continue
+    }
+    for (const v of results.violations as Result[]) {
+      const existing = byRule.get(v.id)
+      const nodeCount = v.nodes.length
+      if (existing) {
+        existing.nodes += nodeCount
+      } else {
+        byRule.set(v.id, {
+          ruleId: v.id,
+          description: v.description,
+          nodes: nodeCount,
+          ...wcagFromTags(v.tags),
+        })
+      }
+    }
+  }
+  return Array.from(byRule.values()).sort((a, b) => b.nodes - a.nodes)
+}
+
+export function A11yRow({
+  detail,
+  enforced,
+  skipped,
+}: {
+  detail: string
+  enforced: boolean
+  skipped: boolean
+}) {
+  const [audit, setAudit] = useState<AuditState>({ status: "idle" })
+  const started = useRef(false)
+
+  const onToggle = useCallback(
+    (e: React.SyntheticEvent<HTMLDetailsElement>) => {
+      if (!e.currentTarget.open || started.current) return
+      started.current = true
+      if (!isInStorybookDocs()) {
+        setAudit({ status: "unavailable" })
+        return
+      }
+      setAudit({ status: "running" })
+      runAudit().then(
+        (criteria) => setAudit({ status: "done", criteria }),
+        () => setAudit({ status: "unavailable" })
+      )
+    },
+    []
+  )
+
+  const met = enforced
+  const glyph = met ? "✓" : skipped ? "–" : "✕"
+  const glyphColor = met
+    ? "text-f1-foreground-positive"
+    : skipped
+      ? "text-f1-foreground-secondary"
+      : "text-f1-foreground-warning"
+  const posture = met
+    ? "enforced"
+    : skipped
+      ? "axe skipped — not measured"
+      : "not enforced — running axe on this component’s stories"
+
+  return (
+    <li className="flex items-start gap-2">
+      <span aria-hidden className={`mt-0.5 shrink-0 ${glyphColor}`}>
+        {glyph}
+      </span>
+      <details className="min-w-0 flex-1" onToggle={onToggle}>
+        <summary className="cursor-pointer list-none text-base text-f1-foreground marker:hidden [&::-webkit-details-marker]:hidden">
+          Accessibility{" "}
+          <span className="text-f1-foreground-secondary">— {posture}</span>
+        </summary>
+        <div className="mt-1 text-base text-f1-foreground-secondary">
+          {detail}
+          {audit.status === "running" && (
+            <p className="mt-2 italic">Running axe on the rendered stories…</p>
+          )}
+          {audit.status === "unavailable" && (
+            <p className="mt-2">
+              Live results are available on the Storybook docs page. See the
+              story’s <strong>Accessibility</strong> tab for per-element detail.
+            </p>
+          )}
+          {audit.status === "done" && audit.criteria.length === 0 && (
+            <p className="mt-2 text-f1-foreground-positive">
+              No violations in the stories’ default state.
+            </p>
+          )}
+          {audit.status === "done" && audit.criteria.length > 0 && (
+            <ul className="mt-2 list-none space-y-1 p-0">
+              {audit.criteria.map((c) => (
+                <li
+                  key={c.ruleId}
+                  className="flex items-start gap-2 !text-base"
+                >
+                  <span
+                    aria-hidden
+                    className="shrink-0 text-f1-foreground-warning"
+                  >
+                    ⚠
+                  </span>
+                  <span>
+                    <code className="text-f1-foreground">{c.ruleId}</code>
+                    {c.sc && (
+                      <span className="text-f1-foreground-secondary">
+                        {" "}
+                        · WCAG {c.sc} {c.level} ({c.version})
+                      </span>
+                    )}
+                    <span className="text-f1-foreground-secondary">
+                      {" "}
+                      · {c.description} · {c.nodes}{" "}
+                      {c.nodes === 1 ? "element" : "elements"}
+                    </span>
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+          {(audit.status === "done" || audit.status === "unavailable") && (
+            <p className="mt-2 text-sm text-f1-foreground-secondary">
+              Checked in each story’s default state — violations behind
+              interactions (open menus, dialogs) aren’t shown here. CI enforces
+              the full set, including play-function states.
+            </p>
+          )}
+        </div>
+      </details>
+    </li>
+  )
+}

--- a/packages/react/src/component-status/A11yRow.tsx
+++ b/packages/react/src/component-status/A11yRow.tsx
@@ -103,12 +103,10 @@ async function runAudit(): Promise<Criterion[]> {
 
 export function A11yRow({
   detail,
-  enforced,
-  skipped,
+  tier,
 }: {
   detail: string
-  enforced: boolean
-  skipped: boolean
+  tier: "skipped" | "todo" | "enforced"
 }) {
   const [audit, setAudit] = useState<AuditState>({ status: "idle" })
   const started = useRef(false)
@@ -130,15 +128,17 @@ export function A11yRow({
     []
   )
 
+  const enforced = tier === "enforced"
   const glyph = enforced ? "✓" : "✕"
   const glyphColor = enforced
     ? "text-f1-foreground-positive"
     : "text-f1-foreground-secondary"
-  const posture = enforced
-    ? "enforced"
-    : skipped
-      ? "axe skipped"
-      : "not enforced yet"
+  const posture =
+    tier === "enforced"
+      ? "enforced"
+      : tier === "skipped"
+        ? "axe skipped"
+        : "not enforced yet"
 
   return (
     <div role="listitem" className="flex items-start gap-2">

--- a/packages/react/src/component-status/A11yRow.tsx
+++ b/packages/react/src/component-status/A11yRow.tsx
@@ -130,85 +130,116 @@ export function A11yRow({
     []
   )
 
-  const met = enforced
-  const glyph = met ? "✓" : skipped ? "–" : "✕"
-  const glyphColor = met
+  const glyph = enforced ? "✓" : "✕"
+  const glyphColor = enforced
     ? "text-f1-foreground-positive"
-    : skipped
-      ? "text-f1-foreground-secondary"
-      : "text-f1-foreground-warning"
-  const posture = met
+    : "text-f1-foreground-secondary"
+  const posture = enforced
     ? "enforced"
     : skipped
-      ? "axe skipped — not measured"
-      : "not enforced — running axe on this component’s stories"
+      ? "axe skipped"
+      : "not enforced yet"
 
   return (
     <li className="flex items-start gap-2">
       <span aria-hidden className={`mt-0.5 shrink-0 ${glyphColor}`}>
         {glyph}
       </span>
-      <details className="min-w-0 flex-1" onToggle={onToggle}>
-        <summary className="cursor-pointer list-none text-base text-f1-foreground marker:hidden [&::-webkit-details-marker]:hidden">
+      <div className="min-w-0">
+        {/* Label + posture, always visible — matches the other checklist rows. */}
+        <div className="text-base text-f1-foreground">
           Accessibility{" "}
           <span className="text-f1-foreground-secondary">— {posture}</span>
-        </summary>
-        <div className="mt-1 text-base text-f1-foreground-secondary">
-          {detail}
-          {audit.status === "running" && (
-            <p className="mt-2 italic">Running axe on the rendered stories…</p>
-          )}
-          {audit.status === "unavailable" && (
-            <p className="mt-2">
-              Live results are available on the Storybook docs page. See the
-              story’s <strong>Accessibility</strong> tab for per-element detail.
-            </p>
-          )}
-          {audit.status === "done" && audit.criteria.length === 0 && (
-            <p className="mt-2 text-f1-foreground-positive">
-              No violations in the stories’ default state.
-            </p>
-          )}
-          {audit.status === "done" && audit.criteria.length > 0 && (
-            <ul className="mt-2 list-none space-y-1 p-0">
-              {audit.criteria.map((c) => (
-                <li
-                  key={c.ruleId}
-                  className="flex items-start gap-2 !text-base"
-                >
-                  <span
-                    aria-hidden
-                    className="shrink-0 text-f1-foreground-warning"
-                  >
-                    ⚠
-                  </span>
-                  <span>
-                    <code className="text-f1-foreground">{c.ruleId}</code>
-                    {c.sc && (
-                      <span className="text-f1-foreground-secondary">
-                        {" "}
-                        · WCAG {c.sc} {c.level} ({c.version})
-                      </span>
-                    )}
-                    <span className="text-f1-foreground-secondary">
-                      {" "}
-                      · {c.description} · {c.nodes}{" "}
-                      {c.nodes === 1 ? "element" : "elements"}
-                    </span>
-                  </span>
-                </li>
-              ))}
-            </ul>
-          )}
-          {(audit.status === "done" || audit.status === "unavailable") && (
-            <p className="mt-2 text-sm text-f1-foreground-secondary">
-              Checked in each story’s default state — violations behind
-              interactions (open menus, dialogs) aren’t shown here. CI enforces
-              the full set, including play-function states.
-            </p>
-          )}
         </div>
-      </details>
+        <div className="mt-0.5 text-base text-f1-foreground-secondary">
+          {detail}
+          {/* Only the live per-criterion results are collapsed — expanding
+              triggers the axe run so the docs page stays cheap by default. */}
+          <details className="mt-1" onToggle={onToggle}>
+            <summary className="cursor-pointer list-none text-f1-foreground marker:hidden [&::-webkit-details-marker]:hidden">
+              Check the rendered stories
+            </summary>
+            <div className="mt-2" aria-live="polite">
+              {audit.status === "running" && (
+                <div className="flex items-center gap-2">
+                  <svg
+                    className="h-4 w-4 shrink-0 animate-spin text-f1-foreground-secondary motion-reduce:animate-none"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    aria-hidden="true"
+                  >
+                    <circle
+                      cx="12"
+                      cy="12"
+                      r="9"
+                      stroke="currentColor"
+                      strokeOpacity="0.25"
+                      strokeWidth="3"
+                    />
+                    <path
+                      d="M21 12a9 9 0 0 0-9-9"
+                      stroke="currentColor"
+                      strokeWidth="3"
+                      strokeLinecap="round"
+                    />
+                  </svg>
+                  <span>Checking the rendered stories…</span>
+                </div>
+              )}
+              {audit.status === "unavailable" && (
+                <p className="m-0">
+                  Live results are available on the Storybook docs page. See the
+                  story’s <strong>Accessibility</strong> tab for per-element
+                  detail.
+                </p>
+              )}
+              {audit.status === "done" && audit.criteria.length === 0 && (
+                <p className="m-0 text-f1-foreground-positive">
+                  No violations in the stories’ default state.
+                </p>
+              )}
+              {audit.status === "done" && audit.criteria.length > 0 && (
+                <ul className="m-0 list-none space-y-1 p-0">
+                  {audit.criteria.map((c) => (
+                    <li
+                      key={c.ruleId}
+                      className="flex items-start gap-2 !text-base"
+                    >
+                      <span
+                        aria-hidden
+                        className="shrink-0 text-f1-foreground-warning"
+                      >
+                        ⚠
+                      </span>
+                      <span>
+                        <code className="text-f1-foreground">{c.ruleId}</code>
+                        {c.sc && (
+                          <span className="text-f1-foreground-secondary">
+                            {" "}
+                            · WCAG {c.sc} {c.level} ({c.version})
+                          </span>
+                        )}
+                        <span className="text-f1-foreground-secondary">
+                          {" "}
+                          · {c.description} · {c.nodes}{" "}
+                          {c.nodes === 1 ? "element" : "elements"}
+                        </span>
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+              {(audit.status === "done" || audit.status === "unavailable") && (
+                <p className="mt-2 text-sm text-f1-foreground-secondary">
+                  Checked in each story’s default state — violations behind
+                  interactions (open menus, dialogs) aren’t shown here. CI
+                  enforces the full set, including play-function states.
+                </p>
+              )}
+            </div>
+          </details>
+        </div>
+      </div>
     </li>
   )
 }

--- a/packages/react/src/component-status/A11yRow.tsx
+++ b/packages/react/src/component-status/A11yRow.tsx
@@ -141,7 +141,7 @@ export function A11yRow({
       : "not enforced yet"
 
   return (
-    <li className="flex items-start gap-2">
+    <div role="listitem" className="flex items-start gap-2">
       <span aria-hidden className={`mt-0.5 shrink-0 ${glyphColor}`}>
         {glyph}
       </span>
@@ -199,11 +199,12 @@ export function A11yRow({
                 </p>
               )}
               {audit.status === "done" && audit.criteria.length > 0 && (
-                <ul className="m-0 list-none space-y-1 p-0">
+                <div role="list" className="space-y-1">
                   {audit.criteria.map((c) => (
-                    <li
+                    <div
                       key={c.ruleId}
-                      className="flex items-start gap-2 !text-base"
+                      role="listitem"
+                      className="flex items-start gap-2 text-base"
                     >
                       <span
                         aria-hidden
@@ -225,9 +226,9 @@ export function A11yRow({
                           {c.nodes === 1 ? "element" : "elements"}
                         </span>
                       </span>
-                    </li>
+                    </div>
                   ))}
-                </ul>
+                </div>
               )}
               {(audit.status === "done" || audit.status === "unavailable") && (
                 <p className="mt-2 text-sm text-f1-foreground-secondary">
@@ -240,6 +241,6 @@ export function A11yRow({
           </details>
         </div>
       </div>
-    </li>
+    </div>
   )
 }

--- a/packages/react/src/component-status/ComponentStability.test.tsx
+++ b/packages/react/src/component-status/ComponentStability.test.tsx
@@ -24,6 +24,8 @@ const DATASET: ComponentEntry[] = [
       hasDoDonts: false,
       exampleCount: 0,
     },
+    a11yEnforced: false,
+    a11ySkipped: false,
     storyFile: "components/F0Card/__stories__/Card.stories.tsx",
   },
   {
@@ -45,6 +47,8 @@ const DATASET: ComponentEntry[] = [
       hasDoDonts: true,
       exampleCount: 4,
     },
+    a11yEnforced: true,
+    a11ySkipped: false,
     storyFile: "components/F0Alert/__stories__/F0Alert.stories.tsx",
   },
 ]
@@ -96,5 +100,19 @@ describe("ComponentStability", () => {
       <ComponentStability componentName="DoesNotExist" components={DATASET} />
     )
     expect(container).toBeEmptyDOMElement()
+  })
+
+  test("shows the Accessibility row with its build-time posture", () => {
+    // Enforced component: the row reads "enforced" (collapsed, no axe run).
+    const { unmount } = render(
+      <ComponentStability componentName="Alert" components={DATASET} />
+    )
+    expect(screen.getByText("Accessibility")).toBeInTheDocument()
+    expect(screen.getByText(/— enforced/)).toBeInTheDocument()
+    unmount()
+
+    // Not enforced: the row invites expanding to see the issues.
+    render(<ComponentStability componentName="Card" components={DATASET} />)
+    expect(screen.getByText(/not enforced/)).toBeInTheDocument()
   })
 })

--- a/packages/react/src/component-status/ComponentStability.test.tsx
+++ b/packages/react/src/component-status/ComponentStability.test.tsx
@@ -24,8 +24,7 @@ const DATASET: ComponentEntry[] = [
       hasDoDonts: false,
       exampleCount: 0,
     },
-    a11yEnforced: false,
-    a11ySkipped: false,
+    a11yTier: "todo",
     storyFile: "components/F0Card/__stories__/Card.stories.tsx",
   },
   {
@@ -47,8 +46,7 @@ const DATASET: ComponentEntry[] = [
       hasDoDonts: true,
       exampleCount: 4,
     },
-    a11yEnforced: true,
-    a11ySkipped: false,
+    a11yTier: "enforced",
     storyFile: "components/F0Alert/__stories__/F0Alert.stories.tsx",
   },
 ]
@@ -102,17 +100,20 @@ describe("ComponentStability", () => {
     expect(container).toBeEmptyDOMElement()
   })
 
-  test("shows the Accessibility row with its build-time posture", () => {
-    // Enforced component: the row reads "enforced" (collapsed, no axe run).
-    const { unmount } = render(
-      <ComponentStability componentName="Alert" components={DATASET} />
-    )
-    expect(screen.getByText("Accessibility")).toBeInTheDocument()
-    expect(screen.getByText(/— enforced/)).toBeInTheDocument()
-    unmount()
-
-    // Not enforced: the row invites expanding to see the issues.
-    render(<ComponentStability componentName="Card" components={DATASET} />)
-    expect(screen.getByText(/not enforced/)).toBeInTheDocument()
-  })
+  test.each([
+    { tier: "enforced" as const, posture: "enforced", glyph: "✓" },
+    { tier: "todo" as const, posture: "not enforced yet", glyph: "✕" },
+    { tier: "skipped" as const, posture: "axe skipped", glyph: "✕" },
+  ])(
+    "renders the Accessibility row posture for tier=$tier (no axe run)",
+    ({ tier, posture, glyph }) => {
+      const one = [{ ...DATASET[1], name: "Widget", a11yTier: tier }]
+      render(<ComponentStability componentName="Widget" components={one} />)
+      const label = screen.getByText("Accessibility").closest("div")!
+      expect(label.textContent).toContain(`— ${posture}`)
+      // the row's glyph reflects met (✓) vs unmet (✕)
+      const row = label.parentElement!.parentElement!
+      expect(row.textContent).toContain(glyph)
+    }
+  )
 })

--- a/packages/react/src/component-status/ComponentStability.tsx
+++ b/packages/react/src/component-status/ComponentStability.tsx
@@ -92,7 +92,11 @@ export function ComponentStability({
       </p>
 
       {status.showChecklist && (
-        <ul className="mt-4 list-none space-y-3 p-0">
+        // role="list" divs (not <ul>/<li>): Storybook docs injects a global
+        // `#storybook-docs ul { margin-bottom: 24px !important }` that .sb-unstyled
+        // doesn't neutralize and no utility class can outrank, so semantic-role
+        // divs keep the spacing under our control while preserving list semantics.
+        <div role="list" className="mt-4 space-y-3">
           {status.requirements.map((req) =>
             req.key === "a11y" ? (
               <A11yRow
@@ -102,7 +106,11 @@ export function ComponentStability({
                 skipped={status.a11ySkipped}
               />
             ) : (
-              <li key={req.key} className="flex items-start gap-2">
+              <div
+                key={req.key}
+                role="listitem"
+                className="flex items-start gap-2"
+              >
                 <span
                   aria-hidden
                   className={`mt-0.5 shrink-0 ${req.met ? "text-f1-foreground-positive" : "text-f1-foreground-secondary"}`}
@@ -116,11 +124,12 @@ export function ComponentStability({
                   <div className="mt-0.5 text-base text-f1-foreground-secondary">
                     {req.detail}
                     {req.criteria && req.criteria.length > 0 && (
-                      <ul className="mt-1 list-none space-y-0.5 p-0">
+                      <div role="list" className="mt-1 space-y-0.5">
                         {req.criteria.map((criterion) => (
-                          <li
+                          <div
                             key={criterion.label}
-                            className="flex items-start gap-2 !text-base"
+                            role="listitem"
+                            className="flex items-start gap-2 text-base"
                           >
                             <span
                               aria-hidden
@@ -129,16 +138,16 @@ export function ComponentStability({
                               {criterion.met ? "✓" : "✕"}
                             </span>
                             <span>{criterion.label}</span>
-                          </li>
+                          </div>
                         ))}
-                      </ul>
+                      </div>
                     )}
                   </div>
                 </div>
-              </li>
+              </div>
             )
           )}
-        </ul>
+        </div>
       )}
     </div>
   )

--- a/packages/react/src/component-status/ComponentStability.tsx
+++ b/packages/react/src/component-status/ComponentStability.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 
+import { A11yRow } from "./A11yRow"
 import {
   getComponentStatus,
   type ApiStatus,
@@ -92,40 +93,51 @@ export function ComponentStability({
 
       {status.showChecklist && (
         <ul className="mt-4 list-none space-y-3 p-0">
-          {status.requirements.map((req) => (
-            <li key={req.key} className="flex items-start gap-2">
-              <span
-                aria-hidden
-                className={`mt-0.5 shrink-0 ${req.met ? "text-f1-foreground-positive" : "text-f1-foreground-secondary"}`}
-              >
-                {req.met ? "✓" : "✕"}
-              </span>
-              <div>
-                <div className="text-base text-f1-foreground">{req.label}</div>
-                <div className="mt-0.5 text-base text-f1-foreground-secondary">
-                  {req.detail}
-                  {req.criteria && req.criteria.length > 0 && (
-                    <ul className="mt-1 list-none space-y-0.5 p-0">
-                      {req.criteria.map((criterion) => (
-                        <li
-                          key={criterion.label}
-                          className="flex items-start gap-2 !text-base"
-                        >
-                          <span
-                            aria-hidden
-                            className={`shrink-0 ${criterion.met ? "text-f1-foreground-positive" : "text-f1-foreground-secondary"}`}
+          {status.requirements.map((req) =>
+            req.key === "a11y" ? (
+              <A11yRow
+                key={req.key}
+                detail={req.detail}
+                enforced={status.a11yEnforced}
+                skipped={status.a11ySkipped}
+              />
+            ) : (
+              <li key={req.key} className="flex items-start gap-2">
+                <span
+                  aria-hidden
+                  className={`mt-0.5 shrink-0 ${req.met ? "text-f1-foreground-positive" : "text-f1-foreground-secondary"}`}
+                >
+                  {req.met ? "✓" : "✕"}
+                </span>
+                <div>
+                  <div className="text-base text-f1-foreground">
+                    {req.label}
+                  </div>
+                  <div className="mt-0.5 text-base text-f1-foreground-secondary">
+                    {req.detail}
+                    {req.criteria && req.criteria.length > 0 && (
+                      <ul className="mt-1 list-none space-y-0.5 p-0">
+                        {req.criteria.map((criterion) => (
+                          <li
+                            key={criterion.label}
+                            className="flex items-start gap-2 !text-base"
                           >
-                            {criterion.met ? "✓" : "✕"}
-                          </span>
-                          <span>{criterion.label}</span>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
+                            <span
+                              aria-hidden
+                              className={`shrink-0 ${criterion.met ? "text-f1-foreground-positive" : "text-f1-foreground-secondary"}`}
+                            >
+                              {criterion.met ? "✓" : "✕"}
+                            </span>
+                            <span>{criterion.label}</span>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
                 </div>
-              </div>
-            </li>
-          ))}
+              </li>
+            )
+          )}
         </ul>
       )}
     </div>

--- a/packages/react/src/component-status/ComponentStability.tsx
+++ b/packages/react/src/component-status/ComponentStability.tsx
@@ -102,8 +102,7 @@ export function ComponentStability({
               <A11yRow
                 key={req.key}
                 detail={req.detail}
-                enforced={status.a11yEnforced}
-                skipped={status.a11ySkipped}
+                tier={status.a11yTier}
               />
             ) : (
               <div

--- a/packages/react/src/component-status/component-status.test.ts
+++ b/packages/react/src/component-status/component-status.test.ts
@@ -31,8 +31,7 @@ function entry(overrides: Partial<ComponentEntry> = {}): ComponentEntry {
       hasDoDonts: true,
       exampleCount: 4,
     },
-    a11yEnforced: true,
-    a11ySkipped: false,
+    a11yTier: "enforced",
     storyFile: "components/F0Example/__stories__/F0Example.stories.tsx",
     ...overrides,
   }
@@ -337,12 +336,15 @@ describe("STABLE_REQUIREMENTS", () => {
     ])
   })
 
-  test("a component clean on everything but a11y is not stable", () => {
-    const status = evaluateComponentStatus(
-      entry({ apiStatus: "stable", tags: ["stable"], a11yEnforced: false })
-    )
-    expect(status.meetsBar).toBe(false)
-    expect(status.missing).toEqual(["Accessibility enforced"])
-    expect(status.effectiveStatus).toBe("experimental")
-  })
+  test.each(["skipped", "todo"] as const)(
+    "a component clean on everything but a11y (%s) is not stable",
+    (a11yTier) => {
+      const status = evaluateComponentStatus(
+        entry({ apiStatus: "stable", tags: ["stable"], a11yTier })
+      )
+      expect(status.meetsBar).toBe(false)
+      expect(status.missing).toEqual(["Accessibility enforced"])
+      expect(status.effectiveStatus).toBe("experimental")
+    }
+  )
 })

--- a/packages/react/src/component-status/component-status.test.ts
+++ b/packages/react/src/component-status/component-status.test.ts
@@ -31,6 +31,8 @@ function entry(overrides: Partial<ComponentEntry> = {}): ComponentEntry {
       hasDoDonts: true,
       exampleCount: 4,
     },
+    a11yEnforced: true,
+    a11ySkipped: false,
     storyFile: "components/F0Example/__stories__/F0Example.stories.tsx",
     ...overrides,
   }
@@ -324,13 +326,23 @@ describe("effectiveStatus parity (TS policy vs generator helper)", () => {
 })
 
 describe("STABLE_REQUIREMENTS", () => {
-  test("is the checklist of stories, tests, play, docs, and doc quality", () => {
+  test("is the checklist of stories, tests, play, docs, doc quality, and a11y", () => {
     expect(STABLE_REQUIREMENTS.map((r) => r.key)).toEqual([
       "stories",
       "unitTests",
       "playFunction",
       "mdxDocs",
       "docQuality",
+      "a11y",
     ])
+  })
+
+  test("a component clean on everything but a11y is not stable", () => {
+    const status = evaluateComponentStatus(
+      entry({ apiStatus: "stable", tags: ["stable"], a11yEnforced: false })
+    )
+    expect(status.meetsBar).toBe(false)
+    expect(status.missing).toEqual(["Accessibility enforced"])
+    expect(status.effectiveStatus).toBe("experimental")
   })
 })

--- a/packages/react/src/component-status/component-status.ts
+++ b/packages/react/src/component-status/component-status.ts
@@ -294,7 +294,7 @@ export const STABLE_REQUIREMENTS: ReadonlyArray<{
     key: "a11y",
     label: "Accessibility enforced",
     detail:
-      'Every story runs axe in blocking mode (a11y: { test: "error" }) — none skipped or downgraded to "todo". On a green main this means the component is axe-clean (WCAG 2.0/2.1/2.2, A & AA).',
+      'Every story runs axe blocking (test: "error"), never skipped or "todo" — on a green main, axe-clean (WCAG 2.0–2.2, A/AA).',
     isMet: (c) => c.a11yEnforced,
   },
 ]

--- a/packages/react/src/component-status/component-status.ts
+++ b/packages/react/src/component-status/component-status.ts
@@ -38,6 +38,14 @@ export type ApiStatus =
 
 export type DocQuality = "none" | "stub" | "acceptable" | "good" | "gold"
 
+/**
+ * A component's accessibility posture, ordered like doc quality. "skipped" =
+ * at least one story opts out of axe; "todo" = axe runs but non-blocking;
+ * "enforced" = every story runs axe at test:"error" (⇒ axe-clean on a green
+ * main). Stable requires "enforced".
+ */
+export type A11yTier = "skipped" | "todo" | "enforced"
+
 /** Granular MDX signals used to score the doc tier and its per-criterion checks. */
 export interface DocSignals {
   /** How many of Anatomy / Guidelines / Accessibility are present (0–3). */
@@ -62,11 +70,8 @@ export interface ComponentEntry {
   hasMdxDocs: boolean
   docQuality: DocQuality
   docSignals: DocSignals
-  /** Every story opts into blocking axe (`test: "error"`), none skipped or
-   * downgraded to todo/warning — implies axe-clean on a green main. */
-  a11yEnforced: boolean
-  /** At least one story skips axe entirely (skipCi / withSkipA11y). */
-  a11ySkipped: boolean
+  /** Accessibility posture: "skipped" | "todo" | "enforced" (see A11yTier). */
+  a11yTier: A11yTier
   storyFile: string
 }
 
@@ -221,6 +226,12 @@ function docQualityAtLeast(actual: DocQuality, min: DocQuality): boolean {
   return DOC_QUALITY_ORDER.indexOf(actual) >= DOC_QUALITY_ORDER.indexOf(min)
 }
 
+export const A11Y_TIER_ORDER: A11yTier[] = ["skipped", "todo", "enforced"]
+
+export function a11yTierAtLeast(actual: A11yTier, min: A11yTier): boolean {
+  return A11Y_TIER_ORDER.indexOf(actual) >= A11Y_TIER_ORDER.indexOf(min)
+}
+
 /**
  * The Definition of Done for a stable component — the mechanically-checkable
  * subset of the lifecycle DoD (Lifecycle/Definition of Done). Each requirement
@@ -295,7 +306,7 @@ export const STABLE_REQUIREMENTS: ReadonlyArray<{
     label: "Accessibility enforced",
     detail:
       'Every story runs axe blocking (test: "error"), never skipped or "todo" — on a green main, axe-clean (WCAG 2.0–2.2, A/AA).',
-    isMet: (c) => c.a11yEnforced,
+    isMet: (c) => a11yTierAtLeast(c.a11yTier, "enforced"),
   },
 ]
 

--- a/packages/react/src/component-status/component-status.ts
+++ b/packages/react/src/component-status/component-status.ts
@@ -62,6 +62,11 @@ export interface ComponentEntry {
   hasMdxDocs: boolean
   docQuality: DocQuality
   docSignals: DocSignals
+  /** Every story opts into blocking axe (`test: "error"`), none skipped or
+   * downgraded to todo/warning — implies axe-clean on a green main. */
+  a11yEnforced: boolean
+  /** At least one story skips axe entirely (skipCi / withSkipA11y). */
+  a11ySkipped: boolean
   storyFile: string
 }
 
@@ -284,6 +289,13 @@ export const STABLE_REQUIREMENTS: ReadonlyArray<{
       },
     ],
     isMet: (c) => docQualityAtLeast(c.docQuality, MIN_DOC_QUALITY),
+  },
+  {
+    key: "a11y",
+    label: "Accessibility enforced",
+    detail:
+      'Every story runs axe in blocking mode (a11y: { test: "error" }) — none skipped or downgraded to "todo". On a green main this means the component is axe-clean (WCAG 2.0/2.1/2.2, A & AA).',
+    isMet: (c) => c.a11yEnforced,
   },
 ]
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -628,6 +628,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
+      axe-core:
+        specifier: ^4.11.1
+        version: 4.11.1
       axe-playwright:
         specifier: ^2.1.0
         version: 2.1.0(playwright@1.57.0)
@@ -6003,7 +6006,7 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
-    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   big-integer@1.6.52:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
@@ -7709,7 +7712,7 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   gl-matrix@3.4.4:


### PR DESCRIPTION
## Description

https://factorialmakers.atlassian.net/browse/FCT-59729

Makes accessibility a first-class part of the component **definition of done**. It adds an "Accessibility" requirement to the Maturity-level checklist (so it gates the Stable/Experimental badge) and a collapsible **Accessibility row** in the `ComponentStability` doc block that, when expanded, runs axe **live in the browser** against the component's rendered stories and lists the failing WCAG criteria. Part of Path to AA — closes the gap flagged in `docs/component-status.mdx` (a11y was previously a manual, non-automated promotion gate).

## Screenshots

The Accessibility row across its states (captured from local Storybook).

**Skipped — collapsed** (Select) · component grandfathered on the skip allowlist; axe not enforced, not measured.

<img width="939" height="544" alt="shot-select-skipped-collapsed" src="https://github.com/user-attachments/assets/ab3839e5-f3bf-4b48-87ac-d5abf3950942" />

---

**Not enforced ("todo") — collapsed** (Card) · axe runs non-blocking; row shows the posture, detail on one line.

<img width="939" height="544" alt="shot-card-collapsed" src="https://github.com/user-attachments/assets/e6c16f0f-b564-4340-8dca-c955faf982a7" />

---

**Not enforced — expanded** (Card) · live axe surfaces a real violation mapped to its WCAG criterion (`scrollable-region-focusable`, WCAG 2.1.1 A), with the default-state footnote.

<img width="939" height="617" alt="shot-card-expanded" src="https://github.com/user-attachments/assets/7b6619de-11ff-4934-b238-75ae09836f6d" />

---

**Not enforced, clean — expanded** (Button) · live axe finds nothing in the default state.

<img width="939" height="596" alt="shot-button-expanded-clean" src="https://github.com/user-attachments/assets/c4587493-9930-4c77-9702-d015c247510e" />

---

**Expanded, rich example** (Select) · multiple criteria incl. the new WCAG 2.2 `target-size` (2.5.8 AA) and `nested-interactive` (4.1.2 A).

<img width="939" height="692" alt="shot-select-expanded" src="https://github.com/user-attachments/assets/3944b04a-0f87-4fba-a285-3444680148f4" />

---

**Enforced** (mock) · Stable badge; every requirement ✓ including Accessibility.

<img width="1248" height="542" alt="shot-enforced-collapsed" src="https://github.com/user-attachments/assets/f82b5cc6-db7b-4c62-896c-5ed876318757" />

## Video

https://github.com/user-attachments/assets/b86bcf51-f70b-4e70-9040-4deacbf55302

## Implementation details

- feat: compute `a11yEnforced` / `a11ySkipped` per component in `component-status-build.mjs` (regex over each story's `a11y.test` / `skipCi` / `withSkipA11y`, mirroring the `hasPlayFunction` heuristic); fold `a11yEnforced` into `meetsStableBar`.
- feat: add the `a11y` entry to `STABLE_REQUIREMENTS` and the field to `ComponentEntry` (`component-status.ts`).
- feat: new `A11yRow` doc-block component — collapsed shows build-time posture (enforced / not-enforced / skipped); on first expand (Storybook only) lazily imports `axe-core` and runs it over the rendered `.docs-story` canvases with the **same WCAG tag scope as CI** (2.0/2.1/2.2, A & AA), then lists failing rules mapped to their WCAG success criterion.

  <details>
  <summary>Two flows + why live (not CI-baked)</summary>

  Posture is build-time (baked into the virtual module) so it works in local dev and on the published ds.factorial.dev identically, and gates the badge. The per-rule detail runs client-side on expand because both local dev and the published static build are the same app running in a browser — a CI-baked JSON would be stale in local dev exactly when someone is editing the component. A muted footnote notes results are the stories' **default state**; CI's `test:"error"` run (which drives play functions) stays the source of truth. Degrades gracefully outside Storybook (posture only, no axe pull).
  </details>

- chore: promote `axe-core` to an explicit `devDependency` (was transitive under `@storybook/addon-a11y`).
- test: update the checklist-keys lock test, add the "clean-but-for-a11y ⇒ not stable" case, extend fixtures, and cover the a11y row's posture rendering.
- docs: add "Accessibility enforced" to the DoD table in `docs/component-status.mdx`.

## ⚠️ Reviewer note — 5 components move to Experimental

Because `meetsBar` is AND-of-all and **no component is `test:"error"` yet** (the ratchet is just starting), this gate currently downgrades the 5 previously-stable components — **Alert, Avatar, Button, ButtonDropdown, Link** — to Experimental. That's the intended signal ("not yet proven-and-locked accessible"); they return to Stable once their stories are ratcheted to `test:"error"` (fixing any violations first). Shipping the hard gate now was a deliberate call — happy to soften to informational-only if preferred.

## Verification

- `tsc --noEmit`, oxlint, and `vitest run src/component-status` (35 tests incl. the TS↔.mjs parity test) all green.
- `build-storybook` succeeds with the new imports.
- Build-script sanity: enforced/skipped posture computes correctly over the real 260-component dataset (0 enforced today, 28 skipped).
- Live expand + published-parity to verify manually on the deploy preview / ds.factorial.dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
