### PR TITLE
ci(a11y): [FCT-59730] comment a11y issues for the components a PR changed

### DIFF
--- a/.github/workflows/storybook-tests.yaml
+++ b/.github/workflows/storybook-tests.yaml
@@ -22,8 +22,14 @@ jobs:
       !contains(github.event.pull_request.labels.*.name, 'autorelease')
     timeout-minutes: 60
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history so the a11y comment can diff changed files vs main.
+          fetch-depth: 0
       - uses: ./.github/actions/setup-node-pnpm
       - name: Get Playwright version
         id: playwright-version
@@ -48,6 +54,7 @@ jobs:
           pnpm --filter @factorialco/f0-react run build-storybook --quiet
 
       - name: Serve Storybook and run tests
+        id: run_tests
         env:
           DEBUG: vite
           VITEST_LOG_LEVEL: debug
@@ -55,3 +62,40 @@ jobs:
           pnpx concurrently -k -s first -n "SB,TEST" -c "magenta,blue" \
              "pnpx http-server packages/react/storybook-static --port 6006 --silent" \
              "pnpx wait-on http://localhost:6006 --timeout 60000 && sleep 2 && pnpm --filter @factorialco/f0-react test-storybook"
+
+      # Turn the a11y violations captured during the run into a PR comment,
+      # scoped to the stories/components this PR changed. Runs whenever the
+      # tests actually executed (pass or fail — enforced failures still count),
+      # but not when Storybook failed to build (run_tests skipped).
+      - name: Build a11y comment for changed components
+        id: a11y_comment
+        if: >
+          always() && steps.run_tests.outcome != 'skipped' &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
+        run: |
+          git fetch origin main --quiet || true
+          pnpm --filter @factorialco/f0-react exec tsx .scripts/check-a11y-comment.ts \
+            --compare-commit origin/main > /tmp/a11y-output.txt 2>&1 || true
+          LAST_JSON_LINE=$(grep -n '^{' /tmp/a11y-output.txt | tail -n 1 | cut -d: -f1)
+          if [ -n "$LAST_JSON_LINE" ]; then
+            sed -n "${LAST_JSON_LINE},\$p" /tmp/a11y-output.txt > /tmp/a11y-data.json
+            jq -r '.commentMarkdown // ""' /tmp/a11y-data.json > /tmp/a11y-comment.md || true
+            {
+              echo "body<<A11Y_COMMENT_EOF"
+              cat /tmp/a11y-comment.md
+              echo "A11Y_COMMENT_EOF"
+            } >> "$GITHUB_OUTPUT"
+          fi
+      - name: Post a11y PR comment
+        if: >
+          always() && steps.a11y_comment.outputs.body != '' &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        continue-on-error: true
+        uses: ./.github/actions/add-or-update-pr-comment
+        with:
+          comment-type: a11y_axe
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          comment-body: ${{ steps.a11y_comment.outputs.body }}

--- a/packages/react/.gitignore
+++ b/packages/react/.gitignore
@@ -1,3 +1,6 @@
 
 # Generated at Storybook startup for the sidebar status dots
 .storybook/*.generated.json
+
+# Written by the a11y test-runner; consumed by the a11y PR-comment step
+a11y-violations.jsonl

--- a/packages/react/.scripts/__tests__/check-a11y-comment.test.ts
+++ b/packages/react/.scripts/__tests__/check-a11y-comment.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  buildMarkdown,
+  componentDirOf,
+  isAffected,
+  type StoryViolations,
+} from "../check-a11y-comment"
+
+const cardTodo: StoryViolations = {
+  id: "components-card--default",
+  title: "Components/Card",
+  name: "Default",
+  file: "src/components/F0Card/__stories__/Card.stories.tsx",
+  mode: "todo",
+  rules: [
+    {
+      id: "target-size",
+      impact: "serious",
+      nodes: 4,
+      sc: "2.5.8",
+      level: "AA",
+      version: "2.2",
+    },
+  ],
+}
+
+const selectError: StoryViolations = {
+  id: "components-select--default",
+  title: "Components/Select",
+  name: "Default",
+  file: "src/components/F0Select/__stories__/F0Select.stories.tsx",
+  mode: "error",
+  rules: [
+    {
+      id: "button-name",
+      impact: "critical",
+      nodes: 1,
+      sc: "4.1.2",
+      level: "A",
+      version: "2.0",
+    },
+  ],
+}
+
+describe("componentDirOf", () => {
+  it("maps a __stories__ file to the component folder", () => {
+    expect(componentDirOf(cardTodo.file)).toBe("src/components/F0Card")
+  })
+  it("maps a co-located story to its own folder", () => {
+    expect(componentDirOf("src/patterns/F0Form/index.stories.tsx")).toBe(
+      "src/patterns/F0Form"
+    )
+  })
+})
+
+describe("isAffected", () => {
+  it("is true when the component folder changed", () => {
+    const changed = new Set(["src/components/F0Card"])
+    expect(isAffected(cardTodo, changed)).toBe(true)
+    expect(isAffected(selectError, changed)).toBe(false)
+  })
+})
+
+describe("buildMarkdown", () => {
+  it("renders the clean state with the scope note", () => {
+    const md = buildMarkdown([])
+    expect(md).toContain("✅ No a11y issues in the stories this PR changed")
+    expect(md).toContain("base-vs-head delta") // future-improvements note
+  })
+
+  it("lists issues with WCAG mapping and mode, and flags blocking count", () => {
+    const md = buildMarkdown([cardTodo, selectError])
+    expect(md).toContain("2 issues") // total rules
+    expect(md).toContain("2 stories")
+    expect(md).toContain("1 blocking")
+    // rule → WCAG mapping + mode badges
+    expect(md).toContain("`target-size`")
+    expect(md).toContain("WCAG 2.5.8 AA (2.2)")
+    expect(md).toContain("🟡 `todo`")
+    expect(md).toContain("`button-name`")
+    expect(md).toContain("WCAG 4.1.2 A (2.0)")
+    expect(md).toContain("🔴 `error`")
+  })
+
+  it("says all non-blocking when there are no error-mode stories", () => {
+    const md = buildMarkdown([cardTodo])
+    expect(md).toContain("all non-blocking")
+  })
+})

--- a/packages/react/.scripts/check-a11y-comment.ts
+++ b/packages/react/.scripts/check-a11y-comment.ts
@@ -1,0 +1,178 @@
+#!/usr/bin/env tsx
+/**
+ * check-a11y-comment.ts
+ *
+ * Turns the a11y violations captured by the Storybook test-runner
+ * (packages/react/a11y-violations.jsonl) into a PR-comment body, scoped to the
+ * stories/components the PR actually changed.
+ *
+ * The Storybook job visits every story, so the raw violation set is the global
+ * a11y debt — the same on every PR. To make the comment relevant, we keep only
+ * violations whose story file (or its component folder) was changed vs the
+ * compare commit (main). See the "future improvements" note in the output for
+ * what this deliberately does NOT do yet (delta vs main, downstream ripple).
+ *
+ * Usage (CI):
+ *   tsx .scripts/check-a11y-comment.ts --compare-commit <main-sha> [--json]
+ *   tsx .scripts/check-a11y-comment.ts --changed-files "a,b,c" [--json]  # tests
+ *
+ * Emits a single JSON object as its last stdout line: { commentMarkdown, ... }.
+ */
+import { execSync } from "node:child_process"
+import { existsSync, readFileSync } from "node:fs"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const PKG_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const ARTIFACT = resolve(PKG_DIR, "a11y-violations.jsonl")
+const COMMENT_MARKER_NOTE =
+  "Scope: only stories in the files/component folders this PR changed. " +
+  "It can't yet flag downstream ripple from shared-code/token changes, or diff " +
+  "against `main` (planned: base-vs-head delta)."
+
+interface Rule {
+  id: string
+  impact: string | null
+  nodes: number
+  sc: string | null
+  level: string
+  version: string
+}
+interface StoryViolations {
+  id: string
+  title: string
+  name: string
+  file: string
+  mode: string
+  rules: Rule[]
+}
+
+/** Story file → its component directory (a story in `__stories__/` maps to the
+ * parent). Mirrors componentDirOf in scripts/component-status-build.mjs. */
+function componentDirOf(file: string): string {
+  const dir = dirname(file)
+  return dir.endsWith("/__stories__") ? dirname(dir) : dir
+}
+
+function parseArgs(): { compareCommit?: string; changedFiles?: string[] } {
+  const args = process.argv.slice(2)
+  const at = (flag: string) => {
+    const i = args.indexOf(flag)
+    return i !== -1 && args[i + 1] ? args[i + 1] : undefined
+  }
+  const cf = at("--changed-files")
+  return {
+    compareCommit: at("--compare-commit"),
+    changedFiles: cf
+      ? cf
+          .split(",")
+          .map((s) => s.trim())
+          .filter(Boolean)
+      : undefined,
+  }
+}
+
+/** Files changed vs the compare commit, relative to packages/react (matching
+ * the artifact's `src/...` paths). */
+function changedReactFiles(compareCommit: string): string[] {
+  const out = execSync(`git diff --name-only ${compareCommit}...HEAD`, {
+    encoding: "utf-8",
+    cwd: PKG_DIR,
+  })
+  return out
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .filter((f) => f.startsWith("packages/react/"))
+    .map((f) => f.slice("packages/react/".length))
+}
+
+function readArtifact(): StoryViolations[] {
+  if (!existsSync(ARTIFACT)) return []
+  return readFileSync(ARTIFACT, "utf-8")
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .flatMap((l) => {
+      try {
+        return [JSON.parse(l) as StoryViolations]
+      } catch {
+        return []
+      }
+    })
+}
+
+/** A story is affected if its file changed, or any file in its component dir
+ * changed. */
+function isAffected(story: StoryViolations, changedDirs: Set<string>): boolean {
+  return changedDirs.has(componentDirOf(story.file))
+}
+
+function buildMarkdown(affected: StoryViolations[]): string {
+  const header = "### ♿ Accessibility (axe) — components changed in this PR\n"
+  const note = `\n<sub>${COMMENT_MARKER_NOTE}</sub>\n`
+
+  if (affected.length === 0) {
+    return `${header}\n✅ No a11y issues in the stories this PR changed.\n${note}`
+  }
+
+  const totalRules = affected.reduce((n, s) => n + s.rules.length, 0)
+  const enforced = affected.filter((s) => s.mode === "error")
+  const summary =
+    `\n**${totalRules} issue${totalRules === 1 ? "" : "s"}** across ` +
+    `**${affected.length} stor${affected.length === 1 ? "y" : "ies"}**` +
+    (enforced.length
+      ? ` — ${enforced.length} blocking (\`test: "error"\`).`
+      : ` — all non-blocking (\`todo\`).`) +
+    "\n"
+
+  const rows = affected
+    .flatMap((s) =>
+      s.rules.map((r) => {
+        const wcag = r.sc ? `WCAG ${r.sc} ${r.level} (${r.version})` : r.level
+        const mode = s.mode === "error" ? "🔴 `error`" : "🟡 `todo`"
+        return `| ${s.title} / ${s.name} | \`${r.id}\` | ${wcag} | ${r.impact ?? "—"} | ${r.nodes} | ${mode} |`
+      })
+    )
+    .join("\n")
+
+  const table =
+    "\n| Story | Rule | WCAG | Impact | Nodes | Mode |\n" +
+    "| --- | --- | --- | --- | --- | --- |\n" +
+    rows +
+    "\n"
+
+  return `${header}${summary}${table}${note}`
+}
+
+function main(): void {
+  const { compareCommit, changedFiles } = parseArgs()
+  const changed =
+    changedFiles ?? (compareCommit ? changedReactFiles(compareCommit) : [])
+  const changedDirs = new Set(changed.map(componentDirOf))
+
+  const all = readArtifact()
+  const affected = all.filter((s) => isAffected(s, changedDirs))
+
+  const commentMarkdown = buildMarkdown(affected)
+  // Machine output on stdout (process.stdout.write, not console — this file may
+  // be linted with no-console; the workflow greps the last JSON line).
+  process.stdout.write(
+    JSON.stringify(
+      {
+        affectedStories: affected.length,
+        totalStoriesWithViolations: all.length,
+        changedFiles: changed.length,
+        commentMarkdown,
+      },
+      null,
+      2
+    ) + "\n"
+  )
+}
+
+if (process.argv[1] && /check-a11y-comment\.(ts|js)$/.test(process.argv[1])) {
+  main()
+}
+
+export { buildMarkdown, componentDirOf, isAffected, type StoryViolations }

--- a/packages/react/.storybook/test-runner.ts
+++ b/packages/react/.storybook/test-runner.ts
@@ -8,6 +8,7 @@ import {
 } from "axe-playwright"
 import type Reporter from "axe-playwright/dist/types"
 import { appendFileSync, readFileSync } from "fs"
+import { join } from "path"
 
 // Story files grandfathered to skip axe while their violations are burned
 // down (Path to AA). Maps file → number of allowed skip call-sites; counts
@@ -26,8 +27,72 @@ const a11ySkipAllowlist: Set<string> = new Set(
 
 const A11Y_TEST_MODES = ["error", "todo", "warning"] as const
 
+// Machine-readable a11y record consumed by the PR-comment step
+// (.scripts/check-a11y-comment.ts). One JSONL line per violating story so the
+// workflow can report the issues in the stories a PR changed. Written to the
+// package root (cwd is packages/react under `pnpm --filter … test-storybook`,
+// matching where the check script reads it) — an absolute path, since the
+// test-runner relocates import.meta.url when it transforms this module.
+const A11Y_ARTIFACT = join(process.cwd(), "a11y-violations.jsonl")
+
+/**
+ * Map an axe rule's tags to its WCAG success criterion, level and version.
+ * Inlined (not shared with A11yRow's copy) because the test-runner's loader
+ * doesn't resolve sibling .ts imports cleanly — dedupe once both land.
+ */
+function wcagFromTags(tags: string[]): {
+  sc: string | null
+  level: string
+  version: string
+} {
+  let sc: string | null = null
+  for (const t of tags) {
+    const m = /^wcag(\d)(\d)(\d{1,2})$/.exec(t)
+    if (m) {
+      sc = `${m[1]}.${m[2]}.${m[3]}`
+      break
+    }
+  }
+  const level = tags.some((t) => /^wcag2\d?aa$/.test(t)) ? "AA" : "A"
+  const version =
+    tags.includes("wcag22a") || tags.includes("wcag22aa")
+      ? "2.2"
+      : tags.includes("wcag21a") || tags.includes("wcag21aa")
+        ? "2.1"
+        : "2.0"
+  return { sc, level, version }
+}
+
 // Infer the violations type from getViolations return type
 type Violations = Awaited<ReturnType<typeof getViolations>>
+
+/**
+ * Append one compact JSONL line describing a story's violations. Best-effort:
+ * never let artifact writing break a test. Kept small (rule id/impact/SC +
+ * node counts, no node HTML) so each append stays within O_APPEND atomicity.
+ */
+function recordA11yViolations(
+  story: { id: string; title: string; name: string; file: string },
+  mode: string,
+  violations: Violations
+): void {
+  try {
+    const line =
+      JSON.stringify({
+        ...story,
+        mode,
+        rules: violations.map((v) => ({
+          id: v.id,
+          impact: v.impact ?? null,
+          nodes: v.nodes.length,
+          ...wcagFromTags(v.tags),
+        })),
+      }) + "\n"
+    appendFileSync(A11Y_ARTIFACT, line)
+  } catch {
+    // ignore — the comment is a nice-to-have, not worth failing CI over
+  }
+}
 
 /**
  * Custom reporter that only logs violations, suppressing success messages
@@ -138,6 +203,19 @@ const config: TestRunnerConfig = {
       if (violations.length > 0) {
         const reporter = new SilentReporter()
         await reporter.report(violations)
+
+        // Record for the PR-comment step — both todo debt and enforced
+        // failures, written before the error-mode throw below.
+        recordA11yViolations(
+          {
+            id: context.id,
+            title: context.title,
+            name: context.name,
+            file: storyFile,
+          },
+          testMode,
+          violations
+        )
 
         if (testMode === "error") {
           // Throw a simple, single-line error for error mode


### PR DESCRIPTION
## Description

https://factorialmakers.atlassian.net/browse/FCT-59730

The Storybook Tests job runs axe on every story, but the findings only land in the run's step summary — invisible on the PR. This posts them as a **sticky PR comment scoped to the stories/components the PR actually changed** (todo debt + enforced failures), so authors/reviewers see the a11y impact of their change without digging through logs. Part of Path to AA.

Reuses the `add-or-update-pr-comment` composite action (same pattern as the cycle-dependencies / api-surface checks).

## Screenshots

Real `a11y_axe` comments posted by this workflow on CI:

**Passing — no a11y issues in the changed components**

<img width="1600" height="380" alt="a11y-comment-passing" src="https://github.com/user-attachments/assets/d3ace54e-81df-40a1-a76f-2479cd981e7b" />

---

**Failures — violations in a changed component (todo debt surfaced; build stays green)**

<img width="1600" height="592" alt="a11y-comment-failures" src="https://github.com/user-attachments/assets/ede2b79e-c5cc-4977-b277-9b9825292105" />

## Implementation details

- feat: the Storybook test-runner writes a compact `a11y-violations.jsonl` (git-ignored) — one line per violating story, each rule mapped to its WCAG success criterion / level / version. Captures both `todo` debt and enforced (`test:"error"`) failures.
- feat: new `.scripts/check-a11y-comment.ts` reads that artifact, computes the files changed vs `main` (`git diff`), keeps only violations whose story file or component folder changed, and renders `commentMarkdown` (grouped table: story · rule · WCAG · impact · nodes · mode; or a clean-state message).
- feat: `storybook-tests.yaml` gains `pull-requests: write` + full history, and an `if: always()` step (so it posts even when an enforced story fails the job) that extracts the markdown and posts via `add-or-update-pr-comment` (marker `a11y_axe`). Guarded to same-repo PRs; non-fatal (`continue-on-error`).
- test: unit tests for the comment builder (filtering, WCAG mapping, todo vs error, clean state).

  <details>
  <summary>Why scoped to changed components (and not a delta)</summary>

  `test-storybook` visits every story, so the raw violation set is the global a11y debt — identical on every PR and not useful as-is. F0 has no per-story change detection or a11y baseline, so a true "added/removed N violations" delta would need new infra. Scoping to the touched stories/components (via git-diff-vs-main) makes the comment relevant with the plumbing we have.
  </details>

## Verification

- `tsc`, `oxlint`, and `vitest run .scripts` (comment-builder tests) pass.
- Verified the artifact write path (`process.cwd()`-based) and the script's read→filter→markdown end-to-end against a fixture (changed = one component → comment scoped to just that component).
- **Confirmed live on CI** (see Screenshots): this PR touches only tooling → the clean-state comment; a throwaway PR adding one low-contrast story (`test:"todo"`) → the failures comment scoped to that component, with the build still green.

## Future improvements (deliberately out of scope)

- **Delta vs main** ("added/removed N violations") — needs a base-vs-head double run (api-surface style) or a committed per-story baseline.
- **Downstream ripple** — shared-code/token changes that affect many components aren't detected; only stories in changed files/component folders are flagged.
- The comment surfaces the scope + these caveats inline (small `<sub>` note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)