### PR TITLE
fix(tailwind): [FCT-59728] close the unterminated row-flash keyframe

### DIFF
--- a/packages/react/tailwind.config.ts
+++ b/packages/react/tailwind.config.ts
@@ -30,6 +30,7 @@ export default {
         "row-flash": {
           from: { backgroundColor: "hsl(var(--positive-50) / 0.2)" },
           to: { backgroundColor: "hsl(var(--positive-50) / 0)" },
+        },
         // Chat typing indicator: a soft rise-and-dim wave with a rest phase
         // (WhatsApp-style), instead of `bounce`'s hard ball-drop curve.
         "typing-dot": {


### PR DESCRIPTION
## Description

https://factorialmakers.atlassian.net/browse/FCT-59728

The `row-flash` keyframe object added in #4709 was missing its closing brace, so the `typing-dot` block nested inside it and the whole config ended one brace short. Tailwind's `loadConfig` parses `tailwind.config.ts` with sucrase, which hit EOF and threw `Unexpected token, expected "," (50:1)` — failing the Storybook preview build and, with it, every Storybook-building CI job (Storybook Tests, Build types, Chromatic, ALPHA) across the repo. It only surfaced on cold CI runs; a warm local jiti/sucrase cache masked it, so local builds looked green.

## Implementation details

- fix: add the missing `},` closing the `row-flash` keyframe object in `packages/react/tailwind.config.ts`

Verified by running the exact failing parser (sucrase, `transforms: ['typescript','imports']`) over the config — it now transforms cleanly, resolving the `(50:1)` error.