### PR TITLE
feat(WarningTag): add warning tag variant to sidebar

### DIFF
--- a/packages/react/src/patterns/Navigation/Sidebar/Menu/index.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/Menu/index.tsx
@@ -11,24 +11,26 @@ import {
 import { AvatarVariant, F0Avatar } from "@/components/avatars/F0Avatar"
 import { F0Icon, IconType } from "@/components/F0Icon"
 import { F0TagRaw } from "@/components/tags/F0TagRaw"
-import { OneEllipsis } from "@/lib/OneEllipsis"
-import { Counter } from "@/ui/Counter"
 import { Dropdown, DropdownItem } from "@/experimental/Navigation/Dropdown"
 import { NavigationItem } from "@/experimental/Navigation/utils"
 import { Tooltip } from "@/experimental/Overlays/Tooltip"
 import { Delete, EllipsisHorizontal, MoveDown, MoveUp } from "@/icons/app"
 import { Link, useNavigation } from "@/lib/linkHandler"
+import { OneEllipsis } from "@/lib/OneEllipsis"
 import { useI18n } from "@/lib/providers/i18n"
 import { useTouchScreen } from "@/lib/useTouchScreen"
 import { cn, focusRing } from "@/lib/utils"
+import { Counter } from "@/ui/Counter"
 
 import { SidebarCollapsibleSection } from "../CollapsibleSection"
 import { DragProvider, useDragContext } from "./DragContext"
 
+export type MenuItemTagVariant = "default" | "warning"
+
 export interface MenuItem extends NavigationItem {
   icon: IconType
   badge?: number
-  tag?: string
+  tag?: string | { text: string; variant?: MenuItemTagVariant }
 }
 
 type FavoriteMenuItem = (
@@ -61,6 +63,13 @@ export interface MenuProps {
   onFavoritesChange?: (favorites: FavoriteMenuItem[]) => void
 }
 
+const menuTagVariantClassName: Record<MenuItemTagVariant, string | undefined> =
+  {
+    default: undefined,
+    warning:
+      "border-transparent bg-f1-background-warning text-f1-foreground-warning",
+  }
+
 const MenuItemContent = ({
   item,
   active,
@@ -68,6 +77,8 @@ const MenuItemContent = ({
   item: MenuItem
   active: boolean
 }) => {
+  const tag = typeof item.tag === "string" ? { text: item.tag } : item.tag
+
   return (
     <div className="flex w-full items-center justify-between">
       <div className="flex min-w-0 items-center gap-1.5 font-medium text-f1-foreground">
@@ -81,9 +92,14 @@ const MenuItemContent = ({
         />
         <span>{item.label}</span>
       </div>
-      {(item.tag || item.badge) && (
+      {(tag || item.badge) && (
         <div className="flex flex-shrink-0 items-center gap-1.5">
-          {item.tag && <F0TagRaw text={item.tag} />}
+          {tag && (
+            <F0TagRaw
+              text={tag.text}
+              className={menuTagVariantClassName[tag.variant ?? "default"]}
+            />
+          )}
           {item.badge && <Counter value={item.badge} size="sm" type="bold" />}
         </div>
       )}
@@ -93,7 +109,7 @@ const MenuItemContent = ({
 
 const MenuItem = ({ item }: { item: MenuItem }) => {
   const { isActive } = useNavigation()
-  const { label: _label, icon: _icon, ...rest } = item
+  const { label: _label, icon: _icon, tag: _tag, badge: _badge, ...rest } = item
 
   const active = isActive(rest.href, { exact: rest.exactMatch })
 

--- a/packages/react/src/patterns/Navigation/Sidebar/index.stories.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/index.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 import { ComponentProps, useState } from "react"
 import { expect, within } from "storybook/test"
 
-import { Comment, Home } from "@/icons/app"
+import { Comment, Home, Sparkles } from "@/icons/app"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import {
@@ -93,6 +93,47 @@ export const Default: Story = {
         </div>
       )
     },
+  ],
+}
+
+export const WithTag: Story = {
+  args: {
+    header: <Header defaultSelected="1" />,
+    body: (
+      <Menu
+        tree={[
+          {
+            id: "1",
+            title: "Company",
+            items: [
+              { label: "Home", icon: Home, href: "/", exactMatch: true },
+              {
+                label: "Messages",
+                icon: Comment,
+                href: "/messages",
+                tag: "New",
+              },
+              {
+                label: "Analytics",
+                icon: Sparkles,
+                href: "/analytics",
+                tag: { text: "-25%", variant: "warning" },
+              },
+            ],
+            isRoot: true,
+            isSortable: false,
+          },
+        ]}
+      />
+    ),
+    footer: <SidebarFooter {...SidebarFooterStories.Default.args} />,
+  },
+  decorators: [
+    (Story) => (
+      <div className="relative h-[500px] w-[240px] rounded border border-solid border-f1-border-secondary bg-f1-background-tertiary">
+        <Story />
+      </div>
+    ),
   ],
 }
 


### PR DESCRIPTION
## Description

Adds an optional **`warning` color variant** to the sidebar `Menu` item tag. Today `MenuItem.tag` is a plain string that always renders in the default (neutral) style; this widens it to also accept `{ text, variant }` so a tag can be colorized with an F0 semantic variant. Needed to surface attention/promotional tags in the sidebar (e.g. a discount pill) instead of only the neutral "New"-style pill.

Fully backward-compatible: every existing `tag="New"` keeps working and looks identical (the default variant applies no extra styling).

## Type of change

- [ ] New component (aligned in #f0-support, lands in `experimental/`)
- [x] Component enhancement / variant (existing component, no breaking change)
- [ ] New pattern (composition of existing F0 components)
- [ ] Variant or improvement of existing pattern
- [ ] Promotion (`experimental/` → stable)
- [ ] Deprecation (adds `@deprecated` + `@removeIn` + `@migration`)
- [ ] Removal (deletes a deprecated component past `@removeIn`)
- [ ] Bug fix
- [ ] Documentation only
- [ ] Refactor / internal change (no API or behavior change)
- [ ] Other:

## Lifecycle phase (if applicable)

N/A — additive, non-breaking enhancement to an existing component. No promotion/new-component alignment required.

- Linked #f0-support thread: —
- Phase exit criteria met: —

## Screenshots (if applicable)

Storybook: **Patterns → Navigation → Sidebar → With Tag** (`patterns-navigation-sidebar--with-tag`)

<img width="1349" height="1002" alt="Screenshot 2026-07-23 at 15 13 33" src="https://github.com/user-attachments/assets/e8c01896-220b-40d1-a40a-1269faa0f4b3" />

<!-- screenshot attached below -->

[Link to Figma Design](Figma URL here)

## Implementation details

- **`MenuItem.tag`** widened from `string` to `string | { text: string; variant?: MenuItemTagVariant }`. New exported type `MenuItemTagVariant = "default" | "warning"`. A plain string is normalized to `{ text }` with `variant: "default"`, so existing usage is untouched.
- **Colors reuse existing F0 semantic tokens** — no new design tokens. The `warning` variant maps to `bg-f1-background-warning` + `text-f1-foreground-warning` (same tokens `Badge`'s `warning` variant uses), so it's theme-aware in light/dark. Applied via `F0TagRaw`'s `className` (its documented coloring hook); `default` passes no class and keeps the neutral outline.
- **Minor correctness fix:** `tag` and `badge` are now destructured out of the props spread onto `<Link>` (they're rendered content, not anchor attributes — and an object `tag` would otherwise leak to the DOM).
- **Story:** added `With Tag` to `Patterns/Navigation/Sidebar` showing the default (`New`) and `warning` (`-25%`) pills side by side in a realistic sidebar.
- Verified: `tsc`, `oxlint`, `oxfmt` clean on the changed files; story renders in Storybook.
