### PR TITLE
feat(categoryBarChart): center cell and add loading skeleton

### DIFF
--- a/packages/react/src/ui/value-display/types/categoryBarChart/__stories__/categoryBarChart.mdx
+++ b/packages/react/src/ui/value-display/types/categoryBarChart/__stories__/categoryBarChart.mdx
@@ -17,6 +17,7 @@ type value = {
     color?: string        // optional color name or hex; falls back to categorical palette
   }>
   hideTooltip?: boolean   // when true, suppresses hover tooltips
+  loading?: boolean       // when true, renders a skeleton (same size as the bar) until data arrives
 }
 ```
 
@@ -53,3 +54,9 @@ Set `hideTooltip: true` on the value to suppress the per-segment tooltip. Segmen
 #### Empty
 
 <Canvas of={CategoryBarChartStories.Empty} />
+
+#### Loading
+
+Set `loading: true` while the row's data is still loading. The cell renders a skeleton with the same height and width as the loaded bar, so the row doesn't jump and no empty dash flashes before the values arrive.
+
+<Canvas of={CategoryBarChartStories.Loading} />

--- a/packages/react/src/ui/value-display/types/categoryBarChart/__stories__/categoryBarChart.stories.tsx
+++ b/packages/react/src/ui/value-display/types/categoryBarChart/__stories__/categoryBarChart.stories.tsx
@@ -81,7 +81,7 @@ const meta = {
     docs: {
       description: {
         component:
-          "Horizontal stacked proportional bar chart cell. Displays category distribution as colored segments with a tooltip on hover/focus. Mirrors the standalone CategoryBarChart kit but sized for table cells.\n\n- **Tooltip**: shown by default per segment (color dot + name + value/percentage). Set `hideTooltip: true` on the value to suppress it.\n- **Clickable cells**: inside OneDataCollection the cell sits in a `pointer-events-none` wrapper with a stretched navigation link. The bar segments re-enable pointer events so the tooltip still opens, while a click on the cell navigates the row.",
+          "Horizontal stacked proportional bar chart cell. Displays category distribution as colored segments with a tooltip on hover/focus. Mirrors the standalone CategoryBarChart kit but sized for table cells.\n\n- **Tooltip**: shown by default per segment (color dot + name + value/percentage). Set `hideTooltip: true` on the value to suppress it.\n- **Loading**: set `loading: true` to render a skeleton with the same height/width as the loaded bar until the data is there, instead of flashing the empty dash.\n- **Clickable cells**: inside OneDataCollection the cell sits in a `pointer-events-none` wrapper with a stretched navigation link. The bar segments re-enable pointer events so the tooltip still opens, while a click on the cell navigates the row.",
       },
     },
   },
@@ -209,11 +209,14 @@ export const InsideClickableTableCell: Story = {
 type DataCollectionArgs = {
   /** When true, wrap each cell in OneTable's clickable mechanics. */
   clickableCells: boolean
+  /** When true, render each cell as a loading skeleton instead of the bar. */
+  loading: boolean
 }
 
 export const DataCollectionExample: StoryObj<DataCollectionArgs> = {
   args: {
     clickableCells: true,
+    loading: true,
   },
   argTypes: {
     clickableCells: {
@@ -221,6 +224,12 @@ export const DataCollectionExample: StoryObj<DataCollectionArgs> = {
       control: "boolean",
       description:
         "Wrap each cell in OneTable's clickable mechanics (pointer-events-none content + stretched navigation link). When off, the cells are plain (no row navigation), which is how the tooltip behaves outside OneDataCollection.",
+    },
+    loading: {
+      name: "Loading",
+      control: "boolean",
+      description:
+        "When on, every cell renders a skeleton (same size as the loaded bar) instead of the chart — this is what the column shows while the row's data is still loading, in place of the empty dash.",
     },
   },
   parameters: {
@@ -245,7 +254,7 @@ const value = {
       },
     },
   },
-  render: ({ clickableCells }) => {
+  render: ({ clickableCells, loading }) => {
     const wrap = (node: React.ReactNode) =>
       clickableCells ? <ClickableTableCell>{node}</ClickableTableCell> : node
     return (
@@ -273,7 +282,7 @@ const value = {
                       label: "Work location",
                       render: () => ({
                         type: "categoryBarChart",
-                        value: { dataPoints: row.dataPoints },
+                        value: { dataPoints: row.dataPoints, loading },
                       }),
                     }}
                   />
@@ -412,6 +421,39 @@ export const Empty: Story = {
         code: `{
   type: "categoryBarChart",
   value: { dataPoints: [] }, // renders a fallback dash
+}`,
+      },
+    },
+  },
+}
+
+export const Loading: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Work location",
+      render: () => ({
+        type: "categoryBarChart",
+        value: {
+          loading: true,
+          dataPoints: [],
+        },
+      }),
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "**Loading**: set `loading: true` while the row's data is still loading. The cell renders a skeleton with the exact same height and width as the loaded bar (`h-2 w-full`), so the row doesn't jump and no empty dash flashes before the values arrive.",
+      },
+      source: {
+        code: `{
+  type: "categoryBarChart",
+  value: {
+    loading: true, // skeleton matches the loaded bar size until data is there
+    dataPoints: [],
+  },
 }`,
       },
     },

--- a/packages/react/src/ui/value-display/types/categoryBarChart/categoryBarChart.test.tsx
+++ b/packages/react/src/ui/value-display/types/categoryBarChart/categoryBarChart.test.tsx
@@ -142,6 +142,40 @@ describe("CategoryBarChartCell", () => {
     })
   })
 
+  it("renders a skeleton instead of the dash while loading", () => {
+    const args: CategoryBarChartCellValue = { dataPoints: [], loading: true }
+
+    const { container } = render(CategoryBarChartCell(args, defaultMeta))
+
+    expect(screen.getByTestId("skeleton")).toBeInTheDocument()
+    expect(screen.queryByText("–")).not.toBeInTheDocument()
+    expect(
+      container.querySelector('[data-cell-type="categoryBarChart"]')
+    ).toHaveAttribute("aria-busy", "true")
+  })
+
+  it("keeps the skeleton the same size as the loaded bar (h-2 w-full)", () => {
+    const args: CategoryBarChartCellValue = { dataPoints: [], loading: true }
+
+    render(CategoryBarChartCell(args, defaultMeta))
+
+    expect(screen.getByTestId("skeleton")).toHaveClass("h-2", "w-full")
+  })
+
+  it("prioritises loading over available data points", () => {
+    const args: CategoryBarChartCellValue = {
+      dataPoints: [{ name: "Office", value: 15 }],
+      loading: true,
+    }
+
+    const { container } = render(CategoryBarChartCell(args, defaultMeta))
+
+    expect(screen.getByTestId("skeleton")).toBeInTheDocument()
+    expect(
+      container.querySelector('[role="img"][aria-label*="%"]')
+    ).not.toBeInTheDocument()
+  })
+
   it("handles duplicate names with unique keys", () => {
     const args: CategoryBarChartCellValue = {
       dataPoints: [

--- a/packages/react/src/ui/value-display/types/categoryBarChart/categoryBarChart.tsx
+++ b/packages/react/src/ui/value-display/types/categoryBarChart/categoryBarChart.tsx
@@ -1,4 +1,7 @@
 import { getCategoricalColor, getColor } from "@/kits/Charts/utils/colors"
+import { CSSProperties } from "react"
+
+import { Skeleton } from "@/ui/skeleton"
 import {
   Tooltip,
   TooltipContent,
@@ -19,9 +22,39 @@ export interface CategoryBarDataPoint {
 export interface CategoryBarChartCellValue {
   dataPoints: CategoryBarDataPoint[]
   hideTooltip?: boolean
+  /**
+   * Renders a skeleton (same height/width as the loaded bar) instead of the
+   * chart while the row's data is still loading. Prevents flashing the empty
+   * dash before the values arrive.
+   */
+  loading?: boolean
 }
 
 const CELL_MIN_HEIGHT_PX = 40
+
+/**
+ * Shared wrapper for every cell state (loaded, empty, loading). The table
+ * `<td>` is `align-top` by design (so multi-line cells align by their first
+ * line), which would leave the short 8px bar stuck to the top. To align the
+ * bar with the row's text instead, the wrapper takes the height of one text
+ * line (`h-5` = the `text-sm` line-height) and centers the bar within it — no
+ * `h-full` (it doesn't resolve against the cell's `min-height`) and no extra
+ * vertical space that would make the row taller than a normal one.
+ */
+function cellWrapperClassName(): string {
+  return "flex h-5 w-full items-center"
+}
+
+/**
+ * Inside a table the row height comes from the sibling cells, so we only set a
+ * horizontal min-width. Outside a table (e.g. cards) we keep a min-height so
+ * the bar keeps some presence on its own.
+ */
+function cellWrapperStyle(meta: ValueDisplayRendererContext): CSSProperties {
+  return meta.visualization === "table"
+    ? { minWidth: 80 }
+    : { minHeight: CELL_MIN_HEIGHT_PX, minWidth: 80 }
+}
 
 function formatPercentage(value: number, total: number): string {
   const pct = (value / total) * 100
@@ -46,6 +79,19 @@ export const CategoryBarChartCell = (
   args: CategoryBarChartCellValue,
   meta: ValueDisplayRendererContext
 ) => {
+  if (args?.loading) {
+    return (
+      <div
+        className={cellWrapperClassName()}
+        style={cellWrapperStyle(meta)}
+        data-cell-type="categoryBarChart"
+        aria-busy="true"
+      >
+        <Skeleton className="h-2 w-full rounded-2xs" />
+      </div>
+    )
+  }
+
   const dataPoints = args?.dataPoints
 
   if (!dataPoints || !Array.isArray(dataPoints) || dataPoints.length === 0) {
@@ -60,11 +106,8 @@ export const CategoryBarChartCell = (
 
   return (
     <div
-      className={cn(
-        "flex w-full items-center",
-        meta.visualization === "table" && "py-1"
-      )}
-      style={{ minHeight: CELL_MIN_HEIGHT_PX, minWidth: 80 }}
+      className={cellWrapperClassName()}
+      style={cellWrapperStyle(meta)}
       data-cell-type="categoryBarChart"
       role="img"
       aria-label="Category bar chart"


### PR DESCRIPTION
## Description

Fixes the Teams-hierarchy table where the in-cell category bar chart was pushed to the top of the row (FCT-59059). The bar now sits in a text-line-height box and is vertically centered, so it lines up with the row's text without changing the row height and without touching the shared table primitive (the `<td>` stays `align-top` by design). 
The cell also gains a `loading` flag that renders a skeleton — the same size as the loaded bar — instead of flashing the empty dash before the data arrives.

## Implementation details

- fix: center the categoryBarChart bar within a text-line-height box (`flex h-5 items-center`) so it aligns with the row's text — no `h-full` (it doesn't resolve against the cell's `min-height`) and no min-height/padding that would make the row taller than a normal one
- feat: add a `loading` flag to the cell value that renders a `Skeleton` (`h-2 w-full`, matching the loaded bar) in place of the `–` dash while the row's data is still loading; `loading` takes precedence over the data points
- test: cover the loading state (skeleton instead of dash, matching size, precedence over data)
- docs: document the `loading` flag, add a `Loading` story and a `Loading` toggle on `DataCollectionExample` (skeleton inside a table), and update the MDX

### Before
<img width="624" height="53" alt="image" src="https://github.com/user-attachments/assets/0e206e14-ec76-4bf6-af80-8560df56fe13" />

### After
<img width="689" height="129" alt="image" src="https://github.com/user-attachments/assets/6f364a8c-b11c-4a0b-bb14-c42c63676922" />
