### PR TITLE
fix(Table): don't animate rows when paginating

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -230,7 +230,16 @@ export const TableCollection = <
     data?.type === "flat"
       ? data.records.map((item, index) => `row-${getRowKey(item, index)}`)
       : []
-  const addedRowKeys = useAddedRowKeys(flatRowKeys)
+  // Identity of the current pagination position. When it changes the row set is
+  // swapped by navigation (paging / loading more), not by an insert, so the
+  // flash must be suppressed for that render.
+  const paginationResetKey =
+    paginationInfo?.type === "pages"
+      ? paginationInfo.currentPage
+      : paginationInfo?.type === "infinite-scroll"
+        ? paginationInfo.cursor
+        : undefined
+  const addedRowKeys = useAddedRowKeys(flatRowKeys, paginationResetKey)
 
   const selectionRegistry = useCreateSelectionRegistry<R>()
   const {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -241,6 +241,14 @@ export const TableCollection = <
         : undefined
   const addedRowKeys = useAddedRowKeys(flatRowKeys, paginationResetKey)
 
+  // Remount the flat row presence group on page-based page changes so the
+  // outgoing page doesn't animate out. Infinite scroll keeps a stable key: its
+  // rows are appended, not swapped, so they must not be torn down on load-more.
+  const flatPresenceKey =
+    paginationInfo?.type === "pages"
+      ? `flat-page-${paginationInfo.currentPage}`
+      : "flat"
+
   const selectionRegistry = useCreateSelectionRegistry<R>()
   const {
     selectedItems,
@@ -748,19 +756,27 @@ export const TableCollection = <
                   )
                 })}
               {data?.type === "flat" && (
-                <AnimatePresence initial={false}>
+                // Keying the presence group by page makes a page change remount
+                // the whole group, so the outgoing page's rows are dropped
+                // instantly instead of playing their exit animation. Inserts and
+                // deletes within a page (same key) still animate.
+                <AnimatePresence initial={false} key={flatPresenceKey}>
                   {data.records.map((item, index) => {
                     const rowKey = `row-${getRowKey(item, index)}`
+                    const isNew = addedRowKeys.has(rowKey)
                     const motionRow = (
                       <MotionRow
                         variants={getAnimationVariants()}
-                        initial="hidden"
+                        // Only a genuinely-inserted row plays the enter
+                        // animation; rows arriving via pagination or the initial
+                        // load appear in place, without movement.
+                        initial={isNew ? "hidden" : false}
                         animate="visible"
                         exit="hidden"
                         custom={index}
                         key={rowKey}
                         layout
-                        isNew={addedRowKeys.has(rowKey)}
+                        isNew={isNew}
                         groupIndex={0}
                         source={effectiveSource}
                         item={item}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/__tests__/useAddedRowKeys.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/__tests__/useAddedRowKeys.test.ts
@@ -1,0 +1,77 @@
+import { renderHook } from "@testing-library/react"
+import { describe, expect, it } from "vitest"
+
+import { useAddedRowKeys } from "../useAddedRowKeys"
+
+describe("useAddedRowKeys", () => {
+  it("never flashes the rows present on the initial load", () => {
+    const { result } = renderHook(({ keys }) => useAddedRowKeys(keys), {
+      initialProps: { keys: ["a", "b", "c"] },
+    })
+    expect([...result.current]).toEqual([])
+  })
+
+  it("flashes a row inserted after the baseline is seeded", () => {
+    const { result, rerender } = renderHook(
+      ({ keys }) => useAddedRowKeys(keys),
+      { initialProps: { keys: ["a", "b"] } }
+    )
+
+    rerender({ keys: ["a", "b", "c"] })
+    expect([...result.current]).toEqual(["c"])
+  })
+
+  it("flashes a given row at most once", () => {
+    const { result, rerender } = renderHook(
+      ({ keys }) => useAddedRowKeys(keys),
+      { initialProps: { keys: ["a"] } }
+    )
+
+    rerender({ keys: ["a", "b"] })
+    expect([...result.current]).toEqual(["b"])
+
+    // A subsequent unrelated re-render must not re-flash "b".
+    rerender({ keys: ["a", "b"] })
+    expect([...result.current]).toEqual([])
+  })
+
+  it("does not flash rows brought in by changing the page", () => {
+    const { result, rerender } = renderHook(
+      ({ keys, page }) => useAddedRowKeys(keys, page),
+      { initialProps: { keys: ["a", "b"], page: 1 } }
+    )
+
+    // Navigating to page 2 swaps in a whole new, never-seen row set.
+    rerender({ keys: ["c", "d"], page: 2 })
+    expect([...result.current]).toEqual([])
+
+    // ...and paging back is navigation too, not an insert.
+    rerender({ keys: ["a", "b"], page: 1 })
+    expect([...result.current]).toEqual([])
+  })
+
+  it("still flashes an insert made after paging to another page", () => {
+    const { result, rerender } = renderHook(
+      ({ keys, page }) => useAddedRowKeys(keys, page),
+      { initialProps: { keys: ["a", "b"], page: 1 } }
+    )
+
+    rerender({ keys: ["c", "d"], page: 2 })
+    expect([...result.current]).toEqual([])
+
+    // A create on page 2 adds a row without changing the page → it flashes.
+    rerender({ keys: ["c", "d", "e"], page: 2 })
+    expect([...result.current]).toEqual(["e"])
+  })
+
+  it("does not flash rows appended by an infinite-scroll cursor change", () => {
+    const { result, rerender } = renderHook(
+      ({ keys, cursor }) => useAddedRowKeys(keys, cursor),
+      { initialProps: { keys: ["a", "b"], cursor: "0" } }
+    )
+
+    // Loading more advances the cursor and appends rows: navigation, no flash.
+    rerender({ keys: ["a", "b", "c", "d"], cursor: "1" })
+    expect([...result.current]).toEqual([])
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/useAddedRowKeys.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/useAddedRowKeys.ts
@@ -11,13 +11,26 @@ import { useEffect, useRef } from "react"
  * already-seen rows flash again. The rows present on the initial load are
  * seeded without flashing, mirroring the `initial={false}` behaviour of the
  * row enter animation.
+ *
+ * `resetKey` identifies the current pagination position (page number or
+ * cursor). Changing pages swaps the whole row set for keys we've never seen,
+ * which is navigation — not an insert — so a change to `resetKey` reseeds the
+ * baseline and skips flashing for that render, just like the initial load.
  */
-export function useAddedRowKeys(keys: string[]): ReadonlySet<string> {
+export function useAddedRowKeys(
+  keys: string[],
+  resetKey?: unknown
+): ReadonlySet<string> {
   const seenRef = useRef<Set<string>>(new Set())
   const initializedRef = useRef(false)
+  const resetKeyRef = useRef(resetKey)
+
+  // A change to the pagination position means the incoming rows arrived by
+  // navigation, not by insertion: reseed the baseline and don't flash them.
+  const didReset = resetKeyRef.current !== resetKey
 
   const added = new Set<string>()
-  if (initializedRef.current) {
+  if (initializedRef.current && !didReset) {
     for (const key of keys) {
       if (!seenRef.current.has(key)) {
         added.add(key)
@@ -26,6 +39,13 @@ export function useAddedRowKeys(keys: string[]): ReadonlySet<string> {
   }
 
   useEffect(() => {
+    if (didReset) {
+      // Forget the previous page's keys entirely so the new page is treated as
+      // a fresh baseline (and a genuinely re-added row can still flash later).
+      seenRef.current = new Set()
+      resetKeyRef.current = resetKey
+    }
+
     // The first non-empty render seeds the baseline (initial load never
     // flashes); after that every key we've ever seen is remembered so it can
     // only flash the first time it appears.


### PR DESCRIPTION
## Description

PR #4709 added row animations to the flat table — a green flash on newly-inserted rows plus a staggered `AnimatePresence` enter/exit with `layout`. Both keyed off "row unseen since mount", which also matches every row that arrives by paging to another page. So changing pages flashed every row *and* cascaded the whole page in/out. This scopes the animations to genuine inserts and leaves pagination static.

## Implementation details

- fix: give `useAddedRowKeys` a `resetKey` identifying the pagination position (`currentPage` for page-based, `cursor` for infinite-scroll); a change reseeds its baseline silently, so paged-in rows are not treated as inserts and don't flash
- fix: gate each flat row's enter animation on `isNew`, so a row arriving via pagination or the initial load appears in place instead of playing the staggered `y` enter tween
- fix: key the flat `AnimatePresence` group by page, so a page change remounts it and the outgoing page is dropped instantly instead of animating out; infinite scroll keeps a stable key so appended rows aren't torn down on load-more

  <details>
  <summary>Why real inserts still animate</summary>

  A create action adds a row without changing the page or cursor: `resetKey` is unchanged (so the flash fires and `isNew` is true → enter tween plays) and the `AnimatePresence` key is unchanged (so `layout` still slides the rows below down). Only navigation changes the position and suppresses the animation.
  </details>

- test: add `useAddedRowKeys.test.ts` covering initial load, single insert, flash-at-most-once, page change (forward/back), insert after paging, and infinite-scroll cursor advance