### PR TITLE
fix(storybook): serve remote MCP at /mcp via Azure SWA rewrite

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,4 +86,6 @@ The repo includes a `.mcp.json` at the root that configures the local Storybook 
 
 **Remote / published** (docs toolset only):
 
-The Azure Static Web Apps deployment also exposes `/mcp` with the docs toolset enabled. Use the published URL for read-only component documentation access without a local dev server.
+The Azure Static Web Apps deployment exposes the MCP server at `https://f0.factorial.dev/mcp` with the docs toolset enabled. Use this URL for read-only component documentation access without a local dev server.
+
+The Azure Function itself is mounted at `/api/mcp` (Azure Static Web Apps serves managed Functions under the `/api/` prefix); `/mcp` is a rewrite to it configured in `packages/react/.storybook/static/staticwebapp.config.json`, so the remote endpoint matches the local `/mcp` convention.

--- a/packages/react/.storybook/static/staticwebapp.config.json
+++ b/packages/react/.storybook/static/staticwebapp.config.json
@@ -1,4 +1,11 @@
 {
+  "routes": [
+    {
+      "route": "/mcp",
+      "rewrite": "/api/mcp",
+      "methods": ["GET", "POST", "OPTIONS"]
+    }
+  ],
   "globalHeaders": {
     "access-control-allow-origin": "*",
     "access-control-allow-methods": "GET, POST, OPTIONS",

--- a/packages/react/api/src/functions/mcp.ts
+++ b/packages/react/api/src/functions/mcp.ts
@@ -35,6 +35,19 @@ async function mcpFunction(
   request: HttpRequest,
   _context: InvocationContext
 ): Promise<HttpResponseInit> {
+  // MCP's Streamable HTTP transport treats GET as a request to open a
+  // long-lived SSE stream for server->client notifications. Azure Functions
+  // cannot hold such a stream open, so the GET hangs with no response and
+  // clients report a "backend call failure". We never emit server-initiated
+  // notifications, so we signal "no SSE stream at this endpoint" with a 405,
+  // as the MCP spec prescribes — compliant clients then continue POST-only.
+  if (request.method === "GET") {
+    return {
+      status: 405,
+      headers: { Allow: "POST, OPTIONS" },
+    }
+  }
+
   const handler = await getHandler()
 
   const fetchRequest = new Request(request.url, {


### PR DESCRIPTION
## Description

The remote Storybook MCP server (an Azure Function behind `f0.factorial.dev`) was unreachable for two reasons: the wrong public path, and a GET request that hangs. This makes it work at `f0.factorial.dev/mcp` and fixes the "backend call failure" clients hit on connect.

## Implementation details

- fix: add a `/mcp` -> `/api/mcp` route rewrite in `packages/react/.storybook/static/staticwebapp.config.json` so the published MCP endpoint is reachable at `f0.factorial.dev/mcp`

  <details>
  <summary>Why this file works</summary>

  Azure Static Web Apps mounts managed Functions under the `/api/` prefix, so the server lives at `/api/mcp` and `/mcp` returned 404. The existing `globalHeaders` in this config already appear on live responses, confirming Azure deploys and honors this file — so the added `routes` rewrite will take effect on the next Storybook deploy.
  </details>

- fix: return `405` on GET to the MCP Azure Function (`packages/react/api/src/functions/mcp.ts`)

  <details>
  <summary>Why?</summary>

  MCP's Streamable HTTP transport treats GET as a request to open a long-lived SSE stream for server->client notifications. Azure Functions cannot hold that stream open, so `GET /api/mcp` hung with no response and MCP clients reported a "backend call failure" on connect. POST already worked. The endpoint emits no server-initiated notifications, so we return `405` as the MCP spec prescribes for endpoints with no SSE stream; compliant clients then continue POST-only and connect cleanly.
  </details>

- docs: document the remote MCP URL (`https://f0.factorial.dev/mcp`) and the `/api/mcp` rewrite in AGENTS.md

> [!NOTE]
> Both fixes take effect after the next `build-and-deploy-storybook` run. The rewrite (`/mcp`) needs the redeploy; the GET fix is in the Function build (`build-api`).