### PR TITLE
fix(OneDataCollection): grey parent rows on hover in nested table

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
@@ -209,6 +209,95 @@ describe("TableCollection", () => {
     })
   })
 
+  describe("nested-row hover", () => {
+    it("greys parent (expandable) rows on hover, matching leaf rows", async () => {
+      type NestedPerson = Person & { children?: NestedPerson[] }
+
+      const parent: NestedPerson = {
+        id: 1,
+        name: "Parent Row",
+        email: "parent@example.com",
+        displayName: "Parent Row",
+        children: [
+          {
+            id: 2,
+            name: "Leaf Row",
+            email: "leaf@example.com",
+            displayName: "Leaf Row",
+          },
+        ],
+      }
+
+      // No itemUrl / itemOnClick — the exact case that previously disabled the
+      // row hover on parent rows while leaves kept it.
+      const nestedSource = {
+        currentFilters: {},
+        setCurrentFilters: vi.fn(),
+        currentSortings: null,
+        setCurrentSortings: vi.fn(),
+        currentNavigationFilters: {},
+        setCurrentNavigationFilters: vi.fn(),
+        navigationFilters: undefined,
+        currentSearch: undefined,
+        debouncedCurrentSearch: undefined,
+        setCurrentSearch: vi.fn(),
+        isLoading: false,
+        setIsLoading: vi.fn(),
+        currentGrouping: undefined,
+        setCurrentGrouping: vi.fn(),
+        itemsWithChildren: (item: NestedPerson) => !!item.children?.length,
+        fetchChildren: ({ item }: { item: NestedPerson }) => ({
+          records: item.children ?? [],
+        }),
+        dataAdapter: {
+          paginationType: "pages",
+          fetchData: async () => ({
+            records: [parent],
+            type: "pages",
+            total: 1,
+            perPage: 20,
+            currentPage: 1,
+            pagesCount: 1,
+          }),
+        },
+      } as unknown as DataCollectionSource<
+        Person,
+        TestFilters,
+        SortingsDefinition,
+        SummariesDefinition,
+        ItemActionsDefinition<Person>,
+        TestNavigationFilters,
+        GroupingDefinition<Person>
+      >
+
+      render(
+        <TableCollection<
+          Person,
+          TestFilters,
+          SortingsDefinition,
+          SummariesDefinition,
+          ItemActionsDefinition<Person>,
+          TestNavigationFilters,
+          GroupingDefinition<Person>
+        >
+          columns={testColumns}
+          source={nestedSource}
+          onSelectItems={vi.fn()}
+          onLoadData={vi.fn()}
+          onLoadError={vi.fn()}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getByText("Parent Row")).toBeInTheDocument()
+      })
+
+      const parentRow = screen.getByText("Parent Row").closest("tr")
+      expect(parentRow?.className).toMatch(/hover:bg-f1-background-hover/)
+      expect(parentRow?.className).not.toMatch(/hover:bg-transparent/)
+    })
+  })
+
   describe("features", () => {
     it("renders custom column formatting", async () => {
       const columnsWithCustomRender = [

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -234,7 +234,6 @@ const NestedRowContent = <
     <>
       <Row
         {...props}
-        disableHover={!props.source.itemOnClick}
         noBorder={shouldHideBorder}
         ref={combinedRowRef}
         nestedRowProps={{


### PR DESCRIPTION
## Problem

In the `OneDataCollection` **nested table** visualization, only leaf rows greyed on hover. Parent (expandable) rows did not — unless the source defined `itemOnClick`.

A source that navigates via `itemUrl` (no `itemOnClick`) — e.g. Job Catalog — hits the bug:

- Parent rows never grey on hover.
- Once the table is scrolled horizontally, **only the sticky (frozen) column greys**, because the sticky cell's own `group-hover:before:bg-f1-background-hover` ignores the row-level `disableHover`. The hover looks broken and inconsistent across columns.


https://github.com/user-attachments/assets/591a15b6-0134-468a-b514-84904edcebae



### Root cause

`NestedRow.tsx` rendered the parent row with:

```tsx
<Row disableHover={!props.source.itemOnClick} ... />
```

Leaf rows (plain `<Row>`) never pass `disableHover`, so they always grey. The parent path gated it on `itemOnClick`, creating the inconsistency.

## Fix

Drop the `disableHover={!source.itemOnClick}` gate on the parent row so it uses the default (`false`), matching leaf rows. The whole parent row now greys on hover, consistent with the sticky column.

- **Navigation unchanged** — `itemUrl` / `itemOnClick` still work exactly as before.
- **Chevron expand/collapse unchanged.**
- Action rows (`LoadMore`, `AddRow`) keep their explicit `disableHover`.


https://github.com/user-attachments/assets/d765ce07-4d2e-4131-9793-835b84840228



## Test

Adds a regression test in `Table.test.tsx`: a nested source with **no** `itemUrl`/`itemOnClick` now renders the parent row with `hover:bg-f1-background-hover` and no `hover:bg-transparent`. Verified it fails on the pre-fix code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)