### PR TITLE
feat(F0DataChart): add categoryBar variant

### DIFF
--- a/packages/react/src/kits/F0DataChart/F0DataChart.tsx
+++ b/packages/react/src/kits/F0DataChart/F0DataChart.tsx
@@ -1,6 +1,7 @@
 import type { F0DataChartProps } from "./types"
 
 import { BarChart } from "./components/BarChart/BarChart"
+import { CategoryBarChart } from "./components/CategoryBarChart/CategoryBarChart"
 import { DataChartEmptyStateView } from "./components/EmptyState/DataChartEmptyStateView"
 import { FunnelChart } from "./components/FunnelChart/FunnelChart"
 import { GaugeChart } from "./components/GaugeChart/GaugeChart"
@@ -35,5 +36,7 @@ export const F0DataChart = (props: F0DataChartProps) => {
       return <GaugeChart {...props} />
     case "heatmap":
       return <HeatmapChart {...props} />
+    case "categoryBar":
+      return <CategoryBarChart {...props} />
   }
 }

--- a/packages/react/src/kits/F0DataChart/__stories__/CategoryBar.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/CategoryBar.stories.tsx
@@ -1,0 +1,121 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import type { F0DataChartProps } from "../types"
+
+import { F0DataChart } from "../index"
+import { ResponsiveSnapshot } from "./decorators"
+
+const meta = {
+  component: F0DataChart,
+  title: "F0DataChart/Category bar",
+  tags: ["autodocs", "experimental"],
+  decorators: [
+    (Story) => (
+      <div className="w-[600px]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof F0DataChart>
+
+export default meta
+type Story = StoryObj<typeof F0DataChart>
+
+const headcountByDepartment = [
+  { name: "Engineering", value: 120 },
+  { name: "Sales", value: 80 },
+  { name: "Marketing", value: 45 },
+  { name: "Design", value: 25 },
+  { name: "HR", value: 10 },
+]
+
+export const Default: Story = {
+  args: {
+    type: "categoryBar",
+    data: headcountByDepartment,
+  },
+}
+
+export const WithoutLegend: Story = {
+  args: {
+    type: "categoryBar",
+    data: headcountByDepartment,
+    showLegend: false,
+  },
+}
+
+export const CustomColors: Story = {
+  args: {
+    type: "categoryBar",
+    data: [
+      { name: "Approved", value: 62, color: "viridian" },
+      { name: "Pending", value: 28, color: "yellow" },
+      { name: "Rejected", value: 10, color: "red" },
+    ],
+  },
+}
+
+export const WithFormatter: Story = {
+  args: {
+    type: "categoryBar",
+    data: [
+      { name: "Salaries", value: 1200000 },
+      { name: "Tooling", value: 300000 },
+      { name: "Offices", value: 500000 },
+    ],
+    valueFormatter: (v) => `${(v / 1000).toFixed(0)}k €`,
+  },
+}
+
+export const WithoutTooltip: Story = {
+  args: {
+    type: "categoryBar",
+    data: headcountByDepartment,
+    showTooltip: false,
+  },
+}
+
+/**
+ * Segments with `value: 0` are skipped entirely — no empty slivers.
+ */
+export const ZeroValueSegments: Story = {
+  args: {
+    type: "categoryBar",
+    data: [
+      { name: "Active", value: 90 },
+      { name: "Invited", value: 0 },
+      { name: "Suspended", value: 10 },
+    ],
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Responsive snapshot
+// ---------------------------------------------------------------------------
+
+const responsiveCategoryBarProps = (
+  column: "low" | "normal" | "large"
+): F0DataChartProps => ({
+  type: "categoryBar",
+  data:
+    column === "low"
+      ? headcountByDepartment.slice(0, 2)
+      : column === "normal"
+        ? headcountByDepartment.slice(0, 4)
+        : headcountByDepartment,
+})
+
+export const ResponsiveSnapshotMatrix: Story = {
+  decorators: [(Story) => <Story />],
+  render: () => <ResponsiveSnapshot getProps={responsiveCategoryBarProps} />,
+}
+
+/**
+ * No data — an empty `data` array triggers the empty state. Unlike other
+ * variants, an all-zero dataset is ALSO empty here: zero-width segments
+ * render nothing at all.
+ * See `F0DataChart/Empty states`.
+ */
+export const Empty: Story = {
+  args: { type: "categoryBar", data: [] },
+}

--- a/packages/react/src/kits/F0DataChart/__stories__/EmptyStates.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/EmptyStates.stories.tsx
@@ -64,6 +64,13 @@ export const EmptyHeatmap: Story = {
   },
 }
 
+export const EmptyCategoryBar: Story = {
+  args: {
+    type: "categoryBar",
+    data: [],
+  },
+}
+
 // ---------------------------------------------------------------------------
 // Behavior showcases
 // ---------------------------------------------------------------------------
@@ -137,6 +144,13 @@ const SNAPSHOT_VARIANTS: { label: string; props: F0DataChartProps }[] = [
       type: "heatmap",
       xCategories: [],
       yCategories: [],
+      data: [],
+    },
+  },
+  {
+    label: "Category bar",
+    props: {
+      type: "categoryBar",
       data: [],
     },
   },

--- a/packages/react/src/kits/F0DataChart/__stories__/Skeletons.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Skeletons.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import {
   BarChartSkeleton,
+  CategoryBarChartSkeleton,
   FunnelChartSkeleton,
   GaugeChartSkeleton,
   HeatmapChartSkeleton,
@@ -85,4 +86,8 @@ export const Gauge: StoryObj = {
 
 export const Heatmap: StoryObj = {
   render: () => <HeatmapChartSkeleton />,
+}
+
+export const CategoryBar: StoryObj = {
+  render: () => <CategoryBarChartSkeleton />,
 }

--- a/packages/react/src/kits/F0DataChart/__tests__/CategoryBarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/CategoryBarChart.test.tsx
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest"
+import "@testing-library/jest-dom/vitest"
+import { screen } from "@testing-library/react"
+import { zeroRender as render } from "@/testing/test-utils"
+
+import { F0DataChart } from "../F0DataChart"
+
+// Mock ECharts — pulled in transitively by the canvas variants
+vi.mock("echarts", () => ({
+  init: vi.fn(() => ({
+    setOption: vi.fn(),
+    resize: vi.fn(),
+    dispose: vi.fn(),
+    getDom: vi.fn(() => document.createElement("div")),
+  })),
+  use: vi.fn(),
+  getInstanceByDom: vi.fn(),
+  graphic: {
+    LinearGradient: vi.fn(),
+  },
+}))
+
+vi.mock("echarts/components", () => ({
+  AriaComponent: {},
+}))
+
+const data = [
+  { name: "Engineering", value: 60 },
+  { name: "Sales", value: 30 },
+  { name: "Design", value: 10 },
+]
+
+describe("CategoryBarChart", () => {
+  it("renders one segment per data point with proportional widths", () => {
+    render(<F0DataChart type="categoryBar" data={data} />)
+
+    const segments = screen.getAllByRole("img")
+    expect(segments).toHaveLength(3)
+    // Segment width lives on the tooltip trigger wrapping the segment
+    expect(segments[0].closest("[style*='width']")).toHaveStyle({
+      width: "60%",
+    })
+  })
+
+  it("skips zero-value segments entirely", () => {
+    render(
+      <F0DataChart
+        type="categoryBar"
+        data={[
+          { name: "Active", value: 90 },
+          { name: "Invited", value: 0 },
+          { name: "Suspended", value: 10 },
+        ]}
+      />
+    )
+
+    const segments = screen.getAllByRole("img")
+    expect(segments).toHaveLength(2)
+    expect(
+      segments.find((s) => s.getAttribute("title") === "Invited")
+    ).toBeUndefined()
+  })
+
+  it("shows the legend by default", () => {
+    render(<F0DataChart type="categoryBar" data={data} />)
+
+    const legendItems = screen.getAllByRole("listitem")
+    expect(legendItems).toHaveLength(3)
+    expect(legendItems[0]).toHaveTextContent("Engineering")
+  })
+
+  it("hides the legend with showLegend: false", () => {
+    render(<F0DataChart type="categoryBar" data={data} showLegend={false} />)
+
+    expect(screen.queryByRole("list")).not.toBeInTheDocument()
+  })
+
+  it("applies a custom color token to a segment", () => {
+    render(
+      <F0DataChart
+        type="categoryBar"
+        data={[{ name: "Approved", value: 100, color: "viridian" }]}
+      />
+    )
+
+    const [segment] = screen.getAllByRole("img")
+    // resolveChartColorToken resolves to a concrete hex — assert it's set
+    expect(segment.style.backgroundColor).not.toBe("")
+  })
+
+  it("renders the empty state for an empty data array", () => {
+    render(<F0DataChart type="categoryBar" data={[]} />)
+
+    expect(screen.queryAllByRole("img")).toHaveLength(0)
+    expect(screen.getByText("No data available")).toBeInTheDocument()
+  })
+
+  it("renders the empty state for an all-zero dataset", () => {
+    render(
+      <F0DataChart
+        type="categoryBar"
+        data={[
+          { name: "A", value: 0 },
+          { name: "B", value: 0 },
+        ]}
+      />
+    )
+
+    expect(screen.getByText("No data available")).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/kits/F0DataChart/__tests__/isDataChartEmpty.test.ts
+++ b/packages/react/src/kits/F0DataChart/__tests__/isDataChartEmpty.test.ts
@@ -196,4 +196,34 @@ describe("isDataChartEmpty", () => {
       ).toBe(false)
     })
   })
+
+  describe("categoryBar", () => {
+    it("empty data array is empty", () => {
+      expect(isDataChartEmpty({ type: "categoryBar", data: [] })).toBe(true)
+    })
+
+    it("all-zero segments ARE empty (zero-width segments render nothing)", () => {
+      expect(
+        isDataChartEmpty({
+          type: "categoryBar",
+          data: [
+            { name: "a", value: 0 },
+            { name: "b", value: 0 },
+          ],
+        })
+      ).toBe(true)
+    })
+
+    it("one non-zero segment is not empty", () => {
+      expect(
+        isDataChartEmpty({
+          type: "categoryBar",
+          data: [
+            { name: "a", value: 0 },
+            { name: "b", value: 5 },
+          ],
+        })
+      ).toBe(false)
+    })
+  })
 })

--- a/packages/react/src/kits/F0DataChart/components/CategoryBarChart/CategoryBarChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/CategoryBarChart/CategoryBarChart.tsx
@@ -1,0 +1,113 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/ui/tooltip"
+
+import type { F0DataChartCategoryBarProps } from "../../types"
+
+import { paletteColor, resolveChartColorToken } from "../../utils/colors"
+
+/**
+ * Formats a segment's share of the total as a percentage string,
+ * dropping the decimal when it is exact (e.g. "25" vs "33.3").
+ */
+const formatPercentage = (value: number, total: number): string => {
+  const percentage = (value / total) * 100
+  return percentage % 1 === 0 ? percentage.toFixed(0) : percentage.toFixed(1)
+}
+
+/**
+ * DOM-rendered proportional bar — unlike the canvas variants, segments are
+ * plain divs so tooltips, focus and theming come from the design system.
+ */
+export const CategoryBarChart = ({
+  data,
+  showLegend = true,
+  showTooltip = true,
+  valueFormatter,
+}: F0DataChartCategoryBarProps) => {
+  const total = data.reduce((sum, segment) => sum + segment.value, 0)
+
+  const resolveSegmentColor = (
+    segment: F0DataChartCategoryBarProps["data"][number],
+    index: number
+  ) =>
+    segment.color ? resolveChartColorToken(segment.color) : paletteColor(index)
+
+  return (
+    <TooltipProvider>
+      <div className="w-full">
+        <div className="flex h-2 gap-1 overflow-hidden">
+          {data.map((segment, index) => {
+            const percentage = total === 0 ? 0 : (segment.value / total) * 100
+            const color = resolveSegmentColor(segment, index)
+
+            if (percentage === 0) {
+              return null
+            }
+
+            return (
+              <Tooltip key={segment.name}>
+                <TooltipTrigger
+                  className="h-full cursor-default overflow-hidden rounded-2xs"
+                  style={{ width: `${percentage}%` }}
+                  title={segment.name}
+                  asChild
+                >
+                  <div
+                    className="h-full w-full"
+                    style={{ backgroundColor: color }}
+                    role="img"
+                    title={segment.name}
+                    tabIndex={0}
+                  />
+                </TooltipTrigger>
+                {showTooltip && (
+                  <TooltipContent className="flex items-center gap-1 text-sm">
+                    <div
+                      className="h-2.5 w-2.5 shrink-0 translate-y-px rounded-full"
+                      style={{ backgroundColor: color }}
+                    />
+                    <span className="pl-0.5 pr-2 text-f1-foreground-inverse-secondary dark:text-f1-foreground-secondary">
+                      {segment.name}
+                    </span>
+                    <span className="font-mono font-medium tabular-nums text-f1-foreground-inverse dark:text-f1-foreground">
+                      {valueFormatter
+                        ? valueFormatter(segment.value)
+                        : segment.value}{" "}
+                      ({formatPercentage(segment.value, total)}%)
+                    </span>
+                  </TooltipContent>
+                )}
+              </Tooltip>
+            )
+          })}
+        </div>
+        {showLegend && (
+          <div
+            className="mt-2 flex w-full flex-wrap gap-x-2.5 gap-y-0.5"
+            role="list"
+          >
+            {data.map((segment, index) => (
+              <div
+                key={segment.name}
+                className="flex items-center gap-1.5"
+                role="listitem"
+              >
+                <div
+                  className="h-2 w-2 shrink-0 rounded-full"
+                  style={{
+                    backgroundColor: resolveSegmentColor(segment, index),
+                  }}
+                />
+                <span className="text-f1-foreground">{segment.name}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </TooltipProvider>
+  )
+}

--- a/packages/react/src/kits/F0DataChart/components/EmptyState/EmptyState.tsx
+++ b/packages/react/src/kits/F0DataChart/components/EmptyState/EmptyState.tsx
@@ -6,6 +6,7 @@ import type { F0DataChartProps } from "../../types"
 
 import {
   BarChartSkeleton,
+  CategoryBarChartSkeleton,
   FunnelChartSkeleton,
   GaugeChartSkeleton,
   HeatmapChartSkeleton,
@@ -31,6 +32,7 @@ const skeletonByType: Record<F0DataChartProps["type"], () => ReactNode> = {
   radar: () => <RadarChartSkeleton showLegend={false} />,
   gauge: () => <GaugeChartSkeleton />,
   heatmap: () => <HeatmapChartSkeleton />,
+  categoryBar: () => <CategoryBarChartSkeleton showLegend={false} />,
 }
 
 /**

--- a/packages/react/src/kits/F0DataChart/index.ts
+++ b/packages/react/src/kits/F0DataChart/index.ts
@@ -6,6 +6,8 @@ export type {
   F0DataChartBarDataPoint,
   F0DataChartBarProps,
   F0DataChartBarSeries,
+  F0DataChartCategoryBarDataPoint,
+  F0DataChartCategoryBarProps,
   F0DataChartEmptyStateProps,
   F0DataChartFunnelDataPoint,
   F0DataChartFunnelProps,
@@ -30,6 +32,7 @@ export { type ChartColorToken, chartColorTokens } from "./utils/colors"
 export type { ChartTheme } from "./utils/theme"
 export {
   BarChartSkeleton,
+  CategoryBarChartSkeleton,
   FunnelChartSkeleton,
   GaugeChartSkeleton,
   HeatmapChartSkeleton,

--- a/packages/react/src/kits/F0DataChart/skeletons.tsx
+++ b/packages/react/src/kits/F0DataChart/skeletons.tsx
@@ -842,3 +842,49 @@ export function HeatmapChartSkeleton() {
     </div>
   )
 }
+
+// ---------------------------------------------------------------------------
+// CategoryBarChartSkeleton
+// ---------------------------------------------------------------------------
+
+/**
+ * Skeleton for category bar content area.
+ *
+ * Renders a single horizontal bar split into proportional segments plus an
+ * optional legend row, matching the real DOM-rendered component layout.
+ */
+export function CategoryBarChartSkeleton({
+  showLegend = true,
+}: {
+  showLegend?: boolean
+} = {}) {
+  // Pre-defined widths to simulate a proportional distribution
+  const segmentWidths = [34, 26, 18, 12, 10]
+
+  return (
+    <div className="flex h-full animate-pulse flex-col justify-center px-4 py-3">
+      {/* Segmented bar */}
+      <div className="flex h-2 gap-1 overflow-hidden">
+        {segmentWidths.map((width, i) => (
+          <Skeleton
+            key={i}
+            className="h-full rounded-2xs"
+            style={{ width: `${width}%` }}
+          />
+        ))}
+      </div>
+
+      {/* Legend placeholder */}
+      {showLegend && (
+        <div className="mt-2 flex flex-wrap items-center gap-x-2.5 gap-y-0.5">
+          {segmentWidths.map((_, i) => (
+            <div key={i} className="flex items-center gap-1.5">
+              <Skeleton className="h-2 w-2 rounded-full" />
+              <Skeleton className="h-2.5 w-12 rounded-sm" />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/react/src/kits/F0DataChart/types.ts
+++ b/packages/react/src/kits/F0DataChart/types.ts
@@ -415,6 +415,47 @@ export interface F0DataChartHeatmapProps extends F0DataChartCommonProps {
 }
 
 // ---------------------------------------------------------------------------
+// Category bar data types
+// ---------------------------------------------------------------------------
+
+/**
+ * A single segment of a category bar.
+ */
+export interface F0DataChartCategoryBarDataPoint {
+  /** Segment label — shown in tooltip and legend */
+  name: string
+  /** Numeric value. Segment width is proportional to the total. */
+  value: number
+  /** Override color for this segment. Must be an F0 design token name. */
+  color?: ChartColorToken
+}
+
+// ---------------------------------------------------------------------------
+// Discriminated union: categoryBar variant
+// ---------------------------------------------------------------------------
+
+/**
+ * Category bar variant props.
+ *
+ * A single horizontal bar split into proportional segments — a compact way
+ * to show how a total distributes across categories. DOM-rendered (no
+ * canvas): segment names come from the data points themselves, so this
+ * interface is separate from `F0DataChartBaseProps`.
+ */
+export interface F0DataChartCategoryBarProps extends F0DataChartCommonProps {
+  /** Chart type */
+  type: "categoryBar"
+  /** The segments to render, in order */
+  data: F0DataChartCategoryBarDataPoint[]
+  /** Show the legend below the bar. @default true */
+  showLegend?: boolean
+  /** Show a tooltip with name, value and percentage on segment hover. @default true */
+  showTooltip?: boolean
+  /** Format the value displayed in the tooltip */
+  valueFormatter?: (value: number) => string
+}
+
+// ---------------------------------------------------------------------------
 // Union
 // ---------------------------------------------------------------------------
 
@@ -422,7 +463,8 @@ export interface F0DataChartHeatmapProps extends F0DataChartCommonProps {
  * Props for the F0DataChart component.
  *
  * A unified chart component that supports bar, line, funnel, pie, radar,
- * gauge, and heatmap chart types via a discriminated `type` prop.
+ * gauge, heatmap, and categoryBar chart types via a discriminated `type`
+ * prop.
  */
 export type F0DataChartProps =
   | F0DataChartBarProps
@@ -432,3 +474,4 @@ export type F0DataChartProps =
   | F0DataChartRadarProps
   | F0DataChartGaugeProps
   | F0DataChartHeatmapProps
+  | F0DataChartCategoryBarProps

--- a/packages/react/src/kits/F0DataChart/utils/isDataChartEmpty.ts
+++ b/packages/react/src/kits/F0DataChart/utils/isDataChartEmpty.ts
@@ -43,6 +43,13 @@ export function isDataChartEmpty(props: F0DataChartProps): boolean {
       const data = props.data
       return !Array.isArray(data) || data.length === 0
     }
+    case "categoryBar": {
+      // All-zero segments render nothing (every width collapses to 0%),
+      // so unlike other variants an all-zero dataset IS empty here.
+      const data = props.data
+      if (!Array.isArray(data) || data.length === 0) return true
+      return data.every((segment) => !segment || !(segment.value > 0))
+    }
     default:
       return true
   }


### PR DESCRIPTION
## Description

Adds a `categoryBar` variant to `F0DataChart` — a single proportional bar split into segments with a dot legend and per-segment tooltip. It visually mirrors the deprecated `Charts/CategoryBarChart` (same bar height, gaps, rounded segments and legend layout) so the 4 monorepo consumers can migrate without visual regressions, while adopting the kit's conventions: discriminated `type` prop, `ChartColorToken` palette, automatic empty-state detection and a skeleton. Verified side-by-side against the original in a local Storybook.

## Screenshots (if applicable)

Side-by-side parity check (Charts left, F0DataChart right) run locally — segments, legend and tooltip match; only the default palette differs (kit-standard ECharts palette).

## Implementation details

- feat: add `F0DataChartCategoryBarProps` / `F0DataChartCategoryBarDataPoint` to the discriminated union
- feat: DOM-rendered `CategoryBarChart` component (design-system tooltips, no canvas)
- feat: empty-state detection for `categoryBar` — empty array and all-zero datasets both render the empty state

  <details>
  <summary>Why all-zero is empty here (unlike other variants)</summary>

  Zero-value segments collapse to 0% width and render nothing, so an
  all-zero dataset would produce a blank strip. Other variants keep
  axes/grid visible for all-zero data, so they stay non-empty.
  </details>

- feat: `CategoryBarChartSkeleton` + entry in the empty-state background map
- test: 7 unit tests for the component + 3 for `isDataChartEmpty`
- docs: stories (default, no legend, custom colors, formatter, zero-value segments, responsive matrix, empty) + skeleton/empty-state story entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)