### PR TITLE
feat(Charts): deprecate Charts kit and migrate internal consumers

### DIFF
--- a/packages/react/src/experimental/F0SegmentedBar/F0SegmentedBar.tsx
+++ b/packages/react/src/experimental/F0SegmentedBar/F0SegmentedBar.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from "react"
 
-import { getColor } from "@/kits/Charts/utils/colors"
+import { getColor } from "@/lib/chart-colors"
 import { withDataTestId } from "@/lib/data-testid"
 import { experimentalComponent } from "@/lib/experimental"
 import { useI18n } from "@/lib/providers/i18n"

--- a/packages/react/src/experimental/F0SegmentedBar/__tests__/F0SegmentedBar.test.tsx
+++ b/packages/react/src/experimental/F0SegmentedBar/__tests__/F0SegmentedBar.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { getColor } from "@/kits/Charts/utils/colors"
+import { getColor } from "@/lib/chart-colors"
 import { zeroRender as render, screen } from "@/testing/test-utils"
 
 import { F0SegmentedBar } from "../index"

--- a/packages/react/src/experimental/Information/Headers/Metadata/MetadataValue.tsx
+++ b/packages/react/src/experimental/Information/Headers/Metadata/MetadataValue.tsx
@@ -1,7 +1,7 @@
 import { F0Avatar } from "@/components/avatars/F0Avatar"
 import { F0AvatarList } from "@/components/avatars/F0AvatarList"
 import { F0AvatarListProps } from "@/components/avatars/F0AvatarList/types"
-import { getColor } from "@/kits/Charts/utils/colors"
+import { getColor } from "@/lib/chart-colors"
 import { F0Icon } from "@/components/F0Icon"
 import { F0TagDot } from "@/components/tags/F0TagDot"
 import { F0TagRaw } from "@/components/tags/F0TagRaw"

--- a/packages/react/src/experimental/Widgets/Charts/AreaChartWidget/index.tsx
+++ b/packages/react/src/experimental/Widgets/Charts/AreaChartWidget/index.tsx
@@ -2,8 +2,17 @@ import { forwardRef } from "react"
 
 import { experimentalComponent } from "@/lib/experimental"
 
-import { AreaChart, AreaChartProps } from "@/kits/Charts/AreaChart"
+import type { AreaChartProps } from "@/kits/Charts/AreaChart"
+import { F0DataChart } from "@/kits/F0DataChart"
+import { usePrivacyMode } from "@/lib/privacyMode"
 import { withSkeleton } from "../../../../lib/skeleton"
+import {
+  toAxisEchartsOptions,
+  toCategories,
+  toLineSeries,
+  toLineType,
+  toValueFormatter,
+} from "../adapters"
 import { ChartContainer, ComposeChartContainerProps } from "../ChartContainer"
 
 export interface AreaChartWidgetProps extends ComposeChartContainerProps<AreaChartProps> {
@@ -15,6 +24,11 @@ const _AreaChartWidget = withSkeleton(
     { canBeBlurred, ...props },
     ref
   ) {
+    const { enabled: privacyModeEnabled } = usePrivacyMode()
+    // Privacy mode: mask value labels and disable the tooltip, mirroring the
+    // deprecated Charts AreaChart behavior for sensitive data (e.g. salaries)
+    const blurred = Boolean(canBeBlurred && privacyModeEnabled)
+
     const newContainerProps = {
       ...props,
       header: {
@@ -23,16 +37,41 @@ const _AreaChartWidget = withSkeleton(
       },
     }
 
-    const newPropsChart = {
-      ...props.chart,
-      yAxis: props.chart.yAxis ? { ...props.chart.yAxis } : { hide: true },
-    }
+    // Widget default: hide the value axis for a compact look (overridable)
+    const {
+      data,
+      dataConfig,
+      lineType,
+      xAxis,
+      yAxis = { hide: true },
+    } = props.chart
 
     return (
       <ChartContainer
         ref={ref}
         {...newContainerProps}
-        chart={<AreaChart {...newPropsChart} canBeBlurred={canBeBlurred} />}
+        chart={
+          <F0DataChart
+            type="line"
+            categories={toCategories(data)}
+            series={toLineSeries(dataConfig, data)}
+            lineType={toLineType(lineType)}
+            showArea
+            showLegend={false}
+            categoryFormatter={xAxis?.tickFormatter}
+            valueFormatter={
+              blurred ? () => "**" : toValueFormatter(yAxis?.tickFormatter)
+            }
+            echartsOptions={{
+              ...toAxisEchartsOptions({
+                categoryAxis: xAxis,
+                valueAxis: yAxis,
+                valueAxisName: "y",
+              }),
+              ...(blurred ? { tooltip: { show: false } } : {}),
+            }}
+          />
+        }
       />
     )
   }),

--- a/packages/react/src/experimental/Widgets/Charts/BarChartWidget/index.tsx
+++ b/packages/react/src/experimental/Widgets/Charts/BarChartWidget/index.tsx
@@ -2,19 +2,45 @@ import { forwardRef } from "react"
 
 import { experimentalComponent } from "@/lib/experimental"
 
-import { BarChart, BarChartProps } from "@/kits/Charts/BarChart"
+import type { BarChartProps } from "@/kits/Charts/BarChart"
+import { F0DataChart } from "@/kits/F0DataChart"
 import { withSkeleton } from "../../../../lib/skeleton"
+import {
+  toAxisEchartsOptions,
+  toBarSeries,
+  toCategories,
+  toValueFormatter,
+} from "../adapters"
 import { ChartContainer, ComposeChartContainerProps } from "../ChartContainer"
 
 const BarChartContainer = forwardRef<
   HTMLDivElement,
   ComposeChartContainerProps<BarChartProps>
 >(function BarChartContainer(props, ref) {
+  // Widget default: hide the value axis for a compact look (overridable)
+  const { data, dataConfig, type, xAxis, yAxis = { hide: true } } = props.chart
+
   return (
     <ChartContainer
       ref={ref}
       {...props}
-      chart={<BarChart yAxis={{ hide: true }} {...props.chart} />}
+      chart={
+        <F0DataChart
+          type="bar"
+          categories={toCategories(data)}
+          series={toBarSeries(dataConfig, data)}
+          stacked={type === "stacked" || type === "stacked-by-sign"}
+          showLegend={props.chart.legend ?? false}
+          showLabels={props.chart.label}
+          categoryFormatter={xAxis?.tickFormatter}
+          valueFormatter={toValueFormatter(yAxis?.tickFormatter)}
+          echartsOptions={toAxisEchartsOptions({
+            categoryAxis: xAxis,
+            valueAxis: yAxis,
+            valueAxisName: "y",
+          })}
+        />
+      }
     />
   )
 })

--- a/packages/react/src/experimental/Widgets/Charts/LineChartWidget/index.tsx
+++ b/packages/react/src/experimental/Widgets/Charts/LineChartWidget/index.tsx
@@ -2,18 +2,51 @@ import { forwardRef } from "react"
 
 import { experimentalComponent } from "@/lib/experimental"
 
-import { LineChart, LineChartProps } from "@/kits/Charts/LineChart"
+import type { LineChartProps } from "@/kits/Charts/LineChart"
+import { F0DataChart } from "@/kits/F0DataChart"
 import { withSkeleton } from "../../../../lib/skeleton"
+import {
+  toAxisEchartsOptions,
+  toCategories,
+  toLineSeries,
+  toLineType,
+  toValueFormatter,
+} from "../adapters"
 import { ChartContainer, ComposeChartContainerProps } from "../ChartContainer"
 
 const _LineChartWidget = withSkeleton(
   forwardRef<HTMLDivElement, ComposeChartContainerProps<LineChartProps>>(
     function LineChartWidget(props, ref) {
+      // Widget default: hide the value axis for a compact look (overridable)
+      const {
+        data,
+        dataConfig,
+        lineType,
+        xAxis,
+        yAxis = { hide: true },
+      } = props.chart
+
       return (
         <ChartContainer
           ref={ref}
           {...props}
-          chart={<LineChart yAxis={{ hide: true }} {...props.chart} />}
+          chart={
+            <F0DataChart
+              type="line"
+              categories={toCategories(data)}
+              series={toLineSeries(dataConfig, data)}
+              lineType={toLineType(lineType)}
+              showArea={false}
+              showLegend={false}
+              categoryFormatter={xAxis?.tickFormatter}
+              valueFormatter={toValueFormatter(yAxis?.tickFormatter)}
+              echartsOptions={toAxisEchartsOptions({
+                categoryAxis: xAxis,
+                valueAxis: yAxis,
+                valueAxisName: "y",
+              })}
+            />
+          }
         />
       )
     }

--- a/packages/react/src/experimental/Widgets/Charts/PieChartWidget/index.tsx
+++ b/packages/react/src/experimental/Widgets/Charts/PieChartWidget/index.tsx
@@ -2,18 +2,39 @@ import { forwardRef } from "react"
 
 import { experimentalComponent } from "@/lib/experimental"
 
-import { PieChart, PieChartProps } from "@/kits/Charts/PieChart"
+import type { PieChartProps } from "@/kits/Charts/PieChart"
+import { F0DataChart } from "@/kits/F0DataChart"
 import { withSkeleton } from "../../../../lib/skeleton"
+import { toChartColorToken } from "../adapters"
 import { ChartContainer, ComposeChartContainerProps } from "../ChartContainer"
 
 const _PieChartWidget = withSkeleton(
   forwardRef<HTMLDivElement, ComposeChartContainerProps<PieChartProps>>(
     function PieChartWidget(props, ref) {
+      const { data, dataConfig } = props.chart
+
       return (
         <ChartContainer
           ref={ref}
           {...props}
-          chart={<PieChart {...props.chart} />}
+          chart={
+            <F0DataChart
+              type="pie"
+              // Donut ring, matching the deprecated Charts PieChart default
+              innerRadius={70}
+              showLabels={false}
+              series={{
+                name: "",
+                data: data.map((item) => ({
+                  name: item.label,
+                  value: item.value,
+                  color:
+                    toChartColorToken(item.color) ??
+                    toChartColorToken(dataConfig[item.label]?.color),
+                })),
+              }}
+            />
+          }
         />
       )
     }

--- a/packages/react/src/experimental/Widgets/Charts/RadialProgressWidget/index.tsx
+++ b/packages/react/src/experimental/Widgets/Charts/RadialProgressWidget/index.tsx
@@ -2,11 +2,10 @@ import { forwardRef } from "react"
 
 import { experimentalComponent } from "@/lib/experimental"
 
-import {
-  RadialProgressChart,
-  RadialProgressProps,
-} from "@/kits/Charts/RadialProgressChart"
+import type { RadialProgressProps } from "@/kits/Charts/RadialProgressChart"
+import { F0DataChart } from "@/kits/F0DataChart"
 import { withSkeleton } from "../../../../lib/skeleton"
+import { toChartColorToken } from "../adapters"
 import { Widget } from "../../Widget"
 
 export type RadialProgressWidgetProps = {
@@ -25,7 +24,19 @@ const _RadialProgressWidget = withSkeleton(
       return (
         <Widget ref={ref} header={header}>
           <div className="flex h-40 items-center justify-center">
-            <RadialProgressChart {...chart} />
+            <F0DataChart
+              type="gauge"
+              value={chart.value}
+              max={chart.max}
+              color={toChartColorToken(chart.color)}
+              name={chart.overview?.label}
+              showValue={Boolean(chart.overview)}
+              valueFormatter={
+                chart.overview
+                  ? () => String(chart.overview!.number)
+                  : undefined
+              }
+            />
           </div>
         </Widget>
       )

--- a/packages/react/src/experimental/Widgets/Charts/VerticalBarChartWidget/index.tsx
+++ b/packages/react/src/experimental/Widgets/Charts/VerticalBarChartWidget/index.tsx
@@ -2,21 +2,55 @@ import { forwardRef } from "react"
 
 import { experimentalComponent } from "@/lib/experimental"
 
-import {
-  VerticalBarChart,
-  VerticalBarChartProps,
-} from "@/kits/Charts/VerticalBarChart"
+import type { VerticalBarChartProps } from "@/kits/Charts/VerticalBarChart"
+import { F0DataChart } from "@/kits/F0DataChart"
 import { withSkeleton } from "../../../../lib/skeleton"
+import {
+  toAxisEchartsOptions,
+  toBarSeries,
+  toCategories,
+  toValueFormatter,
+} from "../adapters"
 import { ChartContainer, ComposeChartContainerProps } from "../ChartContainer"
 
 const _VerticalBarChartWidget = withSkeleton(
   forwardRef<HTMLDivElement, ComposeChartContainerProps<VerticalBarChartProps>>(
     function VerticalBarChartWidget(props, ref) {
+      // VerticalBarChart renders horizontal bars (legacy naming); the value
+      // axis is X. Widget default: hide it for a compact look (overridable).
+      const {
+        data,
+        dataConfig,
+        valueFormatter,
+        xAxis = { hide: true },
+        yAxis,
+      } = props.chart
+
       return (
         <ChartContainer
           ref={ref}
           {...props}
-          chart={<VerticalBarChart xAxis={{ hide: true }} {...props.chart} />}
+          chart={
+            <F0DataChart
+              type="bar"
+              orientation="horizontal"
+              categories={toCategories(data)}
+              series={toBarSeries(dataConfig, data)}
+              showLegend={false}
+              showLabels={props.chart.label}
+              categoryFormatter={yAxis?.tickFormatter}
+              valueFormatter={
+                valueFormatter
+                  ? (value: number) => String(valueFormatter(value))
+                  : toValueFormatter(xAxis?.tickFormatter)
+              }
+              echartsOptions={toAxisEchartsOptions({
+                categoryAxis: yAxis,
+                valueAxis: xAxis,
+                valueAxisName: "x",
+              })}
+            />
+          }
         />
       )
     }

--- a/packages/react/src/experimental/Widgets/Charts/adapters.ts
+++ b/packages/react/src/experimental/Widgets/Charts/adapters.ts
@@ -1,0 +1,108 @@
+import type * as echarts from "echarts"
+
+import type { AxisConfig, ChartItem } from "@/kits/Charts/utils/types"
+import type {
+  F0DataChartBarSeries,
+  F0DataChartLineSeries,
+} from "@/kits/F0DataChart"
+import { legacyChartColorToToken } from "@/lib/chart-colors"
+import type { ChartConfig, LineChartConfig } from "@/ui/chart"
+
+/**
+ * Adapters from the deprecated Charts data model (`dataConfig` + row-shaped
+ * `data`) to F0DataChart's `categories` + `series`. They let the chart
+ * widgets keep their public API while rendering F0DataChart internally, so
+ * consumers migrate off Recharts without touching their code.
+ */
+
+export const toChartColorToken = legacyChartColorToToken
+
+/** Extract the category axis labels from row-shaped Charts data */
+export const toCategories = <K extends ChartConfig>(
+  data: ChartItem<K>[]
+): string[] => data.map((item) => item.label)
+
+/** Build one F0DataChart series per `dataConfig` entry */
+export const toBarSeries = <K extends ChartConfig>(
+  dataConfig: K,
+  data: ChartItem<K>[]
+): F0DataChartBarSeries[] =>
+  Object.entries(dataConfig).map(([key, config]) => ({
+    name: typeof config.label === "string" ? config.label : key,
+    data: data.map((item) => item.values[key] ?? 0),
+    color: toChartColorToken(config.color),
+  }))
+
+/** Build one F0DataChart line series per `dataConfig` entry */
+export const toLineSeries = <K extends LineChartConfig>(
+  dataConfig: K,
+  data: ChartItem<K>[]
+): F0DataChartLineSeries[] =>
+  Object.entries(dataConfig).map(([key, config]) => ({
+    name: typeof config.label === "string" ? config.label : key,
+    data: data.map((item) => item.values[key] ?? 0),
+    color: toChartColorToken(config.color),
+    dashed: config.dashed,
+  }))
+
+/** Map the Charts line interpolation names onto F0DataChart's */
+export const toLineType = (
+  lineType?: "natural" | "linear" | "step" | "monotoneX"
+): "linear" | "smooth" | "step" | undefined => {
+  switch (lineType) {
+    case "natural":
+    case "monotoneX":
+      return "smooth"
+    case "linear":
+      return "linear"
+    case "step":
+      return "step"
+    default:
+      return undefined
+  }
+}
+
+/**
+ * Wrap a Charts axis tick formatter (string-based) as an F0DataChart
+ * value formatter (number-based).
+ */
+export const toValueFormatter = (
+  tickFormatter?: (value: string) => string
+): ((value: number) => string) | undefined =>
+  tickFormatter ? (value: number) => tickFormatter(String(value)) : undefined
+
+/**
+ * Translate Charts `AxisConfig` hide/domain flags into raw ECharts axis
+ * options. `valueAxis` says which ECharts axis carries values ("y" for
+ * vertical charts and lines, "x" for horizontal bars).
+ */
+export const toAxisEchartsOptions = ({
+  categoryAxis,
+  valueAxis,
+  valueAxisName,
+}: {
+  categoryAxis?: AxisConfig
+  valueAxis?: AxisConfig
+  valueAxisName: "x" | "y"
+}): Partial<echarts.EChartsOption> => {
+  const options: Partial<echarts.EChartsOption> = {}
+
+  const valueAxisOptions: Record<string, unknown> = {}
+  if (valueAxis?.hide) valueAxisOptions.show = false
+  if (valueAxis?.domain) {
+    valueAxisOptions.min = valueAxis.domain[0]
+    valueAxisOptions.max = valueAxis.domain[1]
+  }
+
+  const categoryAxisOptions: Record<string, unknown> = {}
+  if (categoryAxis?.hide) categoryAxisOptions.show = false
+
+  if (Object.keys(valueAxisOptions).length > 0) {
+    options[valueAxisName === "y" ? "yAxis" : "xAxis"] = valueAxisOptions
+  }
+  if (Object.keys(categoryAxisOptions).length > 0) {
+    options[valueAxisName === "y" ? "xAxis" : "yAxis"] = categoryAxisOptions
+  }
+
+  return options
+}

--- a/packages/react/src/experimental/Widgets/Content/ProgressBarDuo/index.tsx
+++ b/packages/react/src/experimental/Widgets/Content/ProgressBarDuo/index.tsx
@@ -1,6 +1,6 @@
 import { forwardRef } from "react"
 
-import { getColor } from "@/kits/Charts/utils/colors"
+import { getColor } from "@/lib/chart-colors"
 
 interface DualProgressBarProps {
   value: number

--- a/packages/react/src/kits/Charts/RadialProgressChart/index.tsx
+++ b/packages/react/src/kits/Charts/RadialProgressChart/index.tsx
@@ -7,6 +7,11 @@ export interface RadialProgressProps {
   overview?: { number: number; label: string }
 }
 
+/**
+ * @deprecated The Charts kit is deprecated and RadialProgressChart has no
+ * known consumers — it will be removed. Use `<F0DataChart type="gauge" />`
+ * for gauge-style progress.
+ */
 export function RadialProgressChart({
   value,
   max = 100,

--- a/packages/react/src/kits/Charts/exports.ts
+++ b/packages/react/src/kits/Charts/exports.ts
@@ -10,14 +10,28 @@ import { ProgressBar as ProgressBarComponent } from "./ProgressChart"
 import { RadarChart as RadarChartComponent } from "./RadarChart"
 import { VerticalBarChart as VerticalBarChartComponent } from "./VerticalBarChart"
 
+/**
+ * @deprecated The Charts kit (Recharts) is deprecated in favor of
+ * `F0DataChart`. Renders a line chart with area fill — use
+ * `<F0DataChart type="line" showArea />` instead.
+ */
 export const AreaChart = withDataTestId(
   Component({ name: "AreaChart", type: "info" }, AreaChartComponent)
 )
 
+/**
+ * @deprecated The Charts kit (Recharts) is deprecated in favor of
+ * `F0DataChart`. Despite the name, this renders VERTICAL columns — use
+ * `<F0DataChart type="bar" />` instead.
+ */
 export const BarChart = withDataTestId(
   Component({ name: "BarChart", type: "info" }, BarChartComponent)
 )
 
+/**
+ * @deprecated The Charts kit (Recharts) is deprecated in favor of
+ * `F0DataChart`. Use `<F0DataChart type="categoryBar" />` instead.
+ */
 export const CategoryBarChart = withDataTestId(
   Component(
     { name: "CategoryBarChart", type: "info" },
@@ -25,14 +39,28 @@ export const CategoryBarChart = withDataTestId(
   )
 )
 
+/**
+ * @deprecated The Charts kit (Recharts) is deprecated in favor of
+ * `F0DataChart`. Use `<F0DataChart type="line" />` instead.
+ */
 export const LineChart = withDataTestId(
   Component({ name: "LineChart", type: "info" }, LineChartComponent)
 )
 
+/**
+ * @deprecated The Charts kit (Recharts) is deprecated in favor of
+ * `F0DataChart`. Use `<F0DataChart type="pie" />` (with `innerRadius` for
+ * the donut style) instead.
+ */
 export const PieChart = withDataTestId(
   Component({ name: "PieChart", type: "info" }, PieChartComponent)
 )
 
+/**
+ * @deprecated The Charts kit (Recharts) is deprecated in favor of
+ * `F0DataChart`. Despite the name, this renders HORIZONTAL bars — use
+ * `<F0DataChart type="bar" orientation="horizontal" />` instead.
+ */
 export const VerticalBarChart = withDataTestId(
   Component(
     { name: "VerticalBarChart", type: "info" },
@@ -40,14 +68,28 @@ export const VerticalBarChart = withDataTestId(
   )
 )
 
+/**
+ * @deprecated The Charts kit (Recharts) is deprecated. This is a progress
+ * indicator, not a data chart — use the `progressBar` value-display type
+ * (data collections / cards) or the `ui/progress` primitive instead.
+ */
 export const ProgressBarChart = withDataTestId(
   Component({ name: "ProgressBarChart", type: "info" }, ProgressBarComponent)
 )
 
+/**
+ * @deprecated The Charts kit (Recharts) is deprecated and ComboChart has no
+ * known consumers — it will be removed without a replacement. Compose
+ * `F0DataChart` charts or use `echartsOptions` for mixed series.
+ */
 export const ComboChart = withDataTestId(
   Component({ name: "ComboChart", type: "info" }, ComboChartComponent)
 )
 
+/**
+ * @deprecated The Charts kit (Recharts) is deprecated in favor of
+ * `F0DataChart`. Use `<F0DataChart type="radar" />` instead.
+ */
 export const RadarChart = withDataTestId(
   Component({ name: "RadarChart", type: "info" }, RadarChartComponent)
 )

--- a/packages/react/src/kits/Charts/utils/colors.tsx
+++ b/packages/react/src/kits/Charts/utils/colors.tsx
@@ -1,20 +1,6 @@
-export const getCategoricalColor = (index: number, opacity?: number) => {
-  const categoricalColors = [
-    "categorical-1",
-    "categorical-2",
-    "categorical-3",
-    "categorical-4",
-    "categorical-5",
-    "categorical-6",
-    "categorical-7",
-    "categorical-8",
-  ]
-  return getColor(categoricalColors[index % categoricalColors.length], opacity)
-}
-
-export const getColor = (color: string, opacity?: number) => {
-  const opacityString = opacity !== undefined ? ` / ${opacity}` : ""
-  const chartColorName = `chart-${color}`
-
-  return `hsl(var(--${chartColorName})${opacityString})`
-}
+/**
+ * @deprecated Chart color helpers moved to `@/lib/chart-colors` — import
+ * from there instead. This re-export only remains so the deprecated Charts
+ * kit keeps compiling until it is removed.
+ */
+export { getCategoricalColor, getColor } from "@/lib/chart-colors"

--- a/packages/react/src/kits/F0DataChart/F0DataChart.tsx
+++ b/packages/react/src/kits/F0DataChart/F0DataChart.tsx
@@ -1,6 +1,7 @@
 import type { F0DataChartProps } from "./types"
 
 import { BarChart } from "./components/BarChart/BarChart"
+import { CategoryBarChart } from "./components/CategoryBarChart/CategoryBarChart"
 import { DataChartEmptyStateView } from "./components/EmptyState/DataChartEmptyStateView"
 import { FunnelChart } from "./components/FunnelChart/FunnelChart"
 import { GaugeChart } from "./components/GaugeChart/GaugeChart"
@@ -35,5 +36,7 @@ export const F0DataChart = (props: F0DataChartProps) => {
       return <GaugeChart {...props} />
     case "heatmap":
       return <HeatmapChart {...props} />
+    case "categoryBar":
+      return <CategoryBarChart {...props} />
   }
 }

--- a/packages/react/src/kits/F0DataChart/__stories__/CategoryBar.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/CategoryBar.stories.tsx
@@ -1,0 +1,121 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import type { F0DataChartProps } from "../types"
+
+import { F0DataChart } from "../index"
+import { ResponsiveSnapshot } from "./decorators"
+
+const meta = {
+  component: F0DataChart,
+  title: "F0DataChart/Category bar",
+  tags: ["autodocs", "experimental"],
+  decorators: [
+    (Story) => (
+      <div className="w-[600px]">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof F0DataChart>
+
+export default meta
+type Story = StoryObj<typeof F0DataChart>
+
+const headcountByDepartment = [
+  { name: "Engineering", value: 120 },
+  { name: "Sales", value: 80 },
+  { name: "Marketing", value: 45 },
+  { name: "Design", value: 25 },
+  { name: "HR", value: 10 },
+]
+
+export const Default: Story = {
+  args: {
+    type: "categoryBar",
+    data: headcountByDepartment,
+  },
+}
+
+export const WithoutLegend: Story = {
+  args: {
+    type: "categoryBar",
+    data: headcountByDepartment,
+    showLegend: false,
+  },
+}
+
+export const CustomColors: Story = {
+  args: {
+    type: "categoryBar",
+    data: [
+      { name: "Approved", value: 62, color: "viridian" },
+      { name: "Pending", value: 28, color: "yellow" },
+      { name: "Rejected", value: 10, color: "red" },
+    ],
+  },
+}
+
+export const WithFormatter: Story = {
+  args: {
+    type: "categoryBar",
+    data: [
+      { name: "Salaries", value: 1200000 },
+      { name: "Tooling", value: 300000 },
+      { name: "Offices", value: 500000 },
+    ],
+    valueFormatter: (v) => `${(v / 1000).toFixed(0)}k €`,
+  },
+}
+
+export const WithoutTooltip: Story = {
+  args: {
+    type: "categoryBar",
+    data: headcountByDepartment,
+    showTooltip: false,
+  },
+}
+
+/**
+ * Segments with `value: 0` are skipped entirely — no empty slivers.
+ */
+export const ZeroValueSegments: Story = {
+  args: {
+    type: "categoryBar",
+    data: [
+      { name: "Active", value: 90 },
+      { name: "Invited", value: 0 },
+      { name: "Suspended", value: 10 },
+    ],
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Responsive snapshot
+// ---------------------------------------------------------------------------
+
+const responsiveCategoryBarProps = (
+  column: "low" | "normal" | "large"
+): F0DataChartProps => ({
+  type: "categoryBar",
+  data:
+    column === "low"
+      ? headcountByDepartment.slice(0, 2)
+      : column === "normal"
+        ? headcountByDepartment.slice(0, 4)
+        : headcountByDepartment,
+})
+
+export const ResponsiveSnapshotMatrix: Story = {
+  decorators: [(Story) => <Story />],
+  render: () => <ResponsiveSnapshot getProps={responsiveCategoryBarProps} />,
+}
+
+/**
+ * No data — an empty `data` array triggers the empty state. Unlike other
+ * variants, an all-zero dataset is ALSO empty here: zero-width segments
+ * render nothing at all.
+ * See `F0DataChart/Empty states`.
+ */
+export const Empty: Story = {
+  args: { type: "categoryBar", data: [] },
+}

--- a/packages/react/src/kits/F0DataChart/__stories__/EmptyStates.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/EmptyStates.stories.tsx
@@ -64,6 +64,13 @@ export const EmptyHeatmap: Story = {
   },
 }
 
+export const EmptyCategoryBar: Story = {
+  args: {
+    type: "categoryBar",
+    data: [],
+  },
+}
+
 // ---------------------------------------------------------------------------
 // Behavior showcases
 // ---------------------------------------------------------------------------
@@ -137,6 +144,13 @@ const SNAPSHOT_VARIANTS: { label: string; props: F0DataChartProps }[] = [
       type: "heatmap",
       xCategories: [],
       yCategories: [],
+      data: [],
+    },
+  },
+  {
+    label: "Category bar",
+    props: {
+      type: "categoryBar",
       data: [],
     },
   },

--- a/packages/react/src/kits/F0DataChart/__stories__/Skeletons.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Skeletons.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import {
   BarChartSkeleton,
+  CategoryBarChartSkeleton,
   FunnelChartSkeleton,
   GaugeChartSkeleton,
   HeatmapChartSkeleton,
@@ -85,4 +86,8 @@ export const Gauge: StoryObj = {
 
 export const Heatmap: StoryObj = {
   render: () => <HeatmapChartSkeleton />,
+}
+
+export const CategoryBar: StoryObj = {
+  render: () => <CategoryBarChartSkeleton />,
 }

--- a/packages/react/src/kits/F0DataChart/__tests__/CategoryBarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/CategoryBarChart.test.tsx
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from "vitest"
+import "@testing-library/jest-dom/vitest"
+import { screen } from "@testing-library/react"
+import { zeroRender as render } from "@/testing/test-utils"
+
+import { F0DataChart } from "../F0DataChart"
+
+// Mock ECharts — pulled in transitively by the canvas variants
+vi.mock("echarts", () => ({
+  init: vi.fn(() => ({
+    setOption: vi.fn(),
+    resize: vi.fn(),
+    dispose: vi.fn(),
+    getDom: vi.fn(() => document.createElement("div")),
+  })),
+  use: vi.fn(),
+  getInstanceByDom: vi.fn(),
+  graphic: {
+    LinearGradient: vi.fn(),
+  },
+}))
+
+vi.mock("echarts/components", () => ({
+  AriaComponent: {},
+}))
+
+const data = [
+  { name: "Engineering", value: 60 },
+  { name: "Sales", value: 30 },
+  { name: "Design", value: 10 },
+]
+
+describe("CategoryBarChart", () => {
+  it("renders one segment per data point with proportional widths", () => {
+    render(<F0DataChart type="categoryBar" data={data} />)
+
+    const segments = screen.getAllByRole("img")
+    expect(segments).toHaveLength(3)
+    // Segment width lives on the tooltip trigger wrapping the segment
+    expect(segments[0].closest("[style*='width']")).toHaveStyle({
+      width: "60%",
+    })
+  })
+
+  it("skips zero-value segments entirely", () => {
+    render(
+      <F0DataChart
+        type="categoryBar"
+        data={[
+          { name: "Active", value: 90 },
+          { name: "Invited", value: 0 },
+          { name: "Suspended", value: 10 },
+        ]}
+      />
+    )
+
+    const segments = screen.getAllByRole("img")
+    expect(segments).toHaveLength(2)
+    expect(
+      segments.find((s) => s.getAttribute("title") === "Invited")
+    ).toBeUndefined()
+  })
+
+  it("shows the legend by default", () => {
+    render(<F0DataChart type="categoryBar" data={data} />)
+
+    const legendItems = screen.getAllByRole("listitem")
+    expect(legendItems).toHaveLength(3)
+    expect(legendItems[0]).toHaveTextContent("Engineering")
+  })
+
+  it("hides the legend with showLegend: false", () => {
+    render(<F0DataChart type="categoryBar" data={data} showLegend={false} />)
+
+    expect(screen.queryByRole("list")).not.toBeInTheDocument()
+  })
+
+  it("applies a custom color token to a segment", () => {
+    render(
+      <F0DataChart
+        type="categoryBar"
+        data={[{ name: "Approved", value: 100, color: "viridian" }]}
+      />
+    )
+
+    const [segment] = screen.getAllByRole("img")
+    // resolveChartColorToken resolves to a concrete hex — assert it's set
+    expect(segment.style.backgroundColor).not.toBe("")
+  })
+
+  it("renders the empty state for an empty data array", () => {
+    render(<F0DataChart type="categoryBar" data={[]} />)
+
+    expect(screen.queryAllByRole("img")).toHaveLength(0)
+    expect(screen.getByText("No data available")).toBeInTheDocument()
+  })
+
+  it("renders the empty state for an all-zero dataset", () => {
+    render(
+      <F0DataChart
+        type="categoryBar"
+        data={[
+          { name: "A", value: 0 },
+          { name: "B", value: 0 },
+        ]}
+      />
+    )
+
+    expect(screen.getByText("No data available")).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/kits/F0DataChart/__tests__/isDataChartEmpty.test.ts
+++ b/packages/react/src/kits/F0DataChart/__tests__/isDataChartEmpty.test.ts
@@ -196,4 +196,34 @@ describe("isDataChartEmpty", () => {
       ).toBe(false)
     })
   })
+
+  describe("categoryBar", () => {
+    it("empty data array is empty", () => {
+      expect(isDataChartEmpty({ type: "categoryBar", data: [] })).toBe(true)
+    })
+
+    it("all-zero segments ARE empty (zero-width segments render nothing)", () => {
+      expect(
+        isDataChartEmpty({
+          type: "categoryBar",
+          data: [
+            { name: "a", value: 0 },
+            { name: "b", value: 0 },
+          ],
+        })
+      ).toBe(true)
+    })
+
+    it("one non-zero segment is not empty", () => {
+      expect(
+        isDataChartEmpty({
+          type: "categoryBar",
+          data: [
+            { name: "a", value: 0 },
+            { name: "b", value: 5 },
+          ],
+        })
+      ).toBe(false)
+    })
+  })
 })

--- a/packages/react/src/kits/F0DataChart/components/CategoryBarChart/CategoryBarChart.tsx
+++ b/packages/react/src/kits/F0DataChart/components/CategoryBarChart/CategoryBarChart.tsx
@@ -1,0 +1,113 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/ui/tooltip"
+
+import type { F0DataChartCategoryBarProps } from "../../types"
+
+import { paletteColor, resolveChartColorToken } from "../../utils/colors"
+
+/**
+ * Formats a segment's share of the total as a percentage string,
+ * dropping the decimal when it is exact (e.g. "25" vs "33.3").
+ */
+const formatPercentage = (value: number, total: number): string => {
+  const percentage = (value / total) * 100
+  return percentage % 1 === 0 ? percentage.toFixed(0) : percentage.toFixed(1)
+}
+
+/**
+ * DOM-rendered proportional bar — unlike the canvas variants, segments are
+ * plain divs so tooltips, focus and theming come from the design system.
+ */
+export const CategoryBarChart = ({
+  data,
+  showLegend = true,
+  showTooltip = true,
+  valueFormatter,
+}: F0DataChartCategoryBarProps) => {
+  const total = data.reduce((sum, segment) => sum + segment.value, 0)
+
+  const resolveSegmentColor = (
+    segment: F0DataChartCategoryBarProps["data"][number],
+    index: number
+  ) =>
+    segment.color ? resolveChartColorToken(segment.color) : paletteColor(index)
+
+  return (
+    <TooltipProvider>
+      <div className="w-full">
+        <div className="flex h-2 gap-1 overflow-hidden">
+          {data.map((segment, index) => {
+            const percentage = total === 0 ? 0 : (segment.value / total) * 100
+            const color = resolveSegmentColor(segment, index)
+
+            if (percentage === 0) {
+              return null
+            }
+
+            return (
+              <Tooltip key={segment.name}>
+                <TooltipTrigger
+                  className="h-full cursor-default overflow-hidden rounded-2xs"
+                  style={{ width: `${percentage}%` }}
+                  title={segment.name}
+                  asChild
+                >
+                  <div
+                    className="h-full w-full"
+                    style={{ backgroundColor: color }}
+                    role="img"
+                    title={segment.name}
+                    tabIndex={0}
+                  />
+                </TooltipTrigger>
+                {showTooltip && (
+                  <TooltipContent className="flex items-center gap-1 text-sm">
+                    <div
+                      className="h-2.5 w-2.5 shrink-0 translate-y-px rounded-full"
+                      style={{ backgroundColor: color }}
+                    />
+                    <span className="pl-0.5 pr-2 text-f1-foreground-inverse-secondary dark:text-f1-foreground-secondary">
+                      {segment.name}
+                    </span>
+                    <span className="font-mono font-medium tabular-nums text-f1-foreground-inverse dark:text-f1-foreground">
+                      {valueFormatter
+                        ? valueFormatter(segment.value)
+                        : segment.value}{" "}
+                      ({formatPercentage(segment.value, total)}%)
+                    </span>
+                  </TooltipContent>
+                )}
+              </Tooltip>
+            )
+          })}
+        </div>
+        {showLegend && (
+          <div
+            className="mt-2 flex w-full flex-wrap gap-x-2.5 gap-y-0.5"
+            role="list"
+          >
+            {data.map((segment, index) => (
+              <div
+                key={segment.name}
+                className="flex items-center gap-1.5"
+                role="listitem"
+              >
+                <div
+                  className="h-2 w-2 shrink-0 rounded-full"
+                  style={{
+                    backgroundColor: resolveSegmentColor(segment, index),
+                  }}
+                />
+                <span className="text-f1-foreground">{segment.name}</span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </TooltipProvider>
+  )
+}

--- a/packages/react/src/kits/F0DataChart/components/EmptyState/EmptyState.tsx
+++ b/packages/react/src/kits/F0DataChart/components/EmptyState/EmptyState.tsx
@@ -6,6 +6,7 @@ import type { F0DataChartProps } from "../../types"
 
 import {
   BarChartSkeleton,
+  CategoryBarChartSkeleton,
   FunnelChartSkeleton,
   GaugeChartSkeleton,
   HeatmapChartSkeleton,
@@ -31,6 +32,7 @@ const skeletonByType: Record<F0DataChartProps["type"], () => ReactNode> = {
   radar: () => <RadarChartSkeleton showLegend={false} />,
   gauge: () => <GaugeChartSkeleton />,
   heatmap: () => <HeatmapChartSkeleton />,
+  categoryBar: () => <CategoryBarChartSkeleton showLegend={false} />,
 }
 
 /**

--- a/packages/react/src/kits/F0DataChart/index.ts
+++ b/packages/react/src/kits/F0DataChart/index.ts
@@ -6,6 +6,8 @@ export type {
   F0DataChartBarDataPoint,
   F0DataChartBarProps,
   F0DataChartBarSeries,
+  F0DataChartCategoryBarDataPoint,
+  F0DataChartCategoryBarProps,
   F0DataChartEmptyStateProps,
   F0DataChartFunnelDataPoint,
   F0DataChartFunnelProps,
@@ -30,6 +32,7 @@ export { type ChartColorToken, chartColorTokens } from "./utils/colors"
 export type { ChartTheme } from "./utils/theme"
 export {
   BarChartSkeleton,
+  CategoryBarChartSkeleton,
   FunnelChartSkeleton,
   GaugeChartSkeleton,
   HeatmapChartSkeleton,

--- a/packages/react/src/kits/F0DataChart/skeletons.tsx
+++ b/packages/react/src/kits/F0DataChart/skeletons.tsx
@@ -842,3 +842,49 @@ export function HeatmapChartSkeleton() {
     </div>
   )
 }
+
+// ---------------------------------------------------------------------------
+// CategoryBarChartSkeleton
+// ---------------------------------------------------------------------------
+
+/**
+ * Skeleton for category bar content area.
+ *
+ * Renders a single horizontal bar split into proportional segments plus an
+ * optional legend row, matching the real DOM-rendered component layout.
+ */
+export function CategoryBarChartSkeleton({
+  showLegend = true,
+}: {
+  showLegend?: boolean
+} = {}) {
+  // Pre-defined widths to simulate a proportional distribution
+  const segmentWidths = [34, 26, 18, 12, 10]
+
+  return (
+    <div className="flex h-full animate-pulse flex-col justify-center px-4 py-3">
+      {/* Segmented bar */}
+      <div className="flex h-2 gap-1 overflow-hidden">
+        {segmentWidths.map((width, i) => (
+          <Skeleton
+            key={i}
+            className="h-full rounded-2xs"
+            style={{ width: `${width}%` }}
+          />
+        ))}
+      </div>
+
+      {/* Legend placeholder */}
+      {showLegend && (
+        <div className="mt-2 flex flex-wrap items-center gap-x-2.5 gap-y-0.5">
+          {segmentWidths.map((_, i) => (
+            <div key={i} className="flex items-center gap-1.5">
+              <Skeleton className="h-2 w-2 rounded-full" />
+              <Skeleton className="h-2.5 w-12 rounded-sm" />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/react/src/kits/F0DataChart/types.ts
+++ b/packages/react/src/kits/F0DataChart/types.ts
@@ -415,6 +415,47 @@ export interface F0DataChartHeatmapProps extends F0DataChartCommonProps {
 }
 
 // ---------------------------------------------------------------------------
+// Category bar data types
+// ---------------------------------------------------------------------------
+
+/**
+ * A single segment of a category bar.
+ */
+export interface F0DataChartCategoryBarDataPoint {
+  /** Segment label — shown in tooltip and legend */
+  name: string
+  /** Numeric value. Segment width is proportional to the total. */
+  value: number
+  /** Override color for this segment. Must be an F0 design token name. */
+  color?: ChartColorToken
+}
+
+// ---------------------------------------------------------------------------
+// Discriminated union: categoryBar variant
+// ---------------------------------------------------------------------------
+
+/**
+ * Category bar variant props.
+ *
+ * A single horizontal bar split into proportional segments — a compact way
+ * to show how a total distributes across categories. DOM-rendered (no
+ * canvas): segment names come from the data points themselves, so this
+ * interface is separate from `F0DataChartBaseProps`.
+ */
+export interface F0DataChartCategoryBarProps extends F0DataChartCommonProps {
+  /** Chart type */
+  type: "categoryBar"
+  /** The segments to render, in order */
+  data: F0DataChartCategoryBarDataPoint[]
+  /** Show the legend below the bar. @default true */
+  showLegend?: boolean
+  /** Show a tooltip with name, value and percentage on segment hover. @default true */
+  showTooltip?: boolean
+  /** Format the value displayed in the tooltip */
+  valueFormatter?: (value: number) => string
+}
+
+// ---------------------------------------------------------------------------
 // Union
 // ---------------------------------------------------------------------------
 
@@ -422,7 +463,8 @@ export interface F0DataChartHeatmapProps extends F0DataChartCommonProps {
  * Props for the F0DataChart component.
  *
  * A unified chart component that supports bar, line, funnel, pie, radar,
- * gauge, and heatmap chart types via a discriminated `type` prop.
+ * gauge, heatmap, and categoryBar chart types via a discriminated `type`
+ * prop.
  */
 export type F0DataChartProps =
   | F0DataChartBarProps
@@ -432,3 +474,4 @@ export type F0DataChartProps =
   | F0DataChartRadarProps
   | F0DataChartGaugeProps
   | F0DataChartHeatmapProps
+  | F0DataChartCategoryBarProps

--- a/packages/react/src/kits/F0DataChart/utils/isDataChartEmpty.ts
+++ b/packages/react/src/kits/F0DataChart/utils/isDataChartEmpty.ts
@@ -43,6 +43,13 @@ export function isDataChartEmpty(props: F0DataChartProps): boolean {
       const data = props.data
       return !Array.isArray(data) || data.length === 0
     }
+    case "categoryBar": {
+      // All-zero segments render nothing (every width collapses to 0%),
+      // so unlike other variants an all-zero dataset IS empty here.
+      const data = props.data
+      if (!Array.isArray(data) || data.length === 0) return true
+      return data.every((segment) => !segment || !(segment.value > 0))
+    }
     default:
       return true
   }

--- a/packages/react/src/lib/chart-colors.ts
+++ b/packages/react/src/lib/chart-colors.ts
@@ -1,0 +1,58 @@
+import type { ChartColorToken } from "@/kits/F0DataChart"
+
+/**
+ * Chart color helpers, formerly at `kits/Charts/utils/colors`.
+ *
+ * They resolve the `--chart-*` CSS custom properties from the F0 theme and
+ * are used by non-chart components (segmented bars, progress bars, value
+ * displays) as well as the deprecated Charts kit. Living here they survive
+ * the Charts kit removal.
+ */
+
+export const getCategoricalColor = (index: number, opacity?: number) => {
+  const categoricalColors = [
+    "categorical-1",
+    "categorical-2",
+    "categorical-3",
+    "categorical-4",
+    "categorical-5",
+    "categorical-6",
+    "categorical-7",
+    "categorical-8",
+  ]
+  return getColor(categoricalColors[index % categoricalColors.length], opacity)
+}
+
+export const getColor = (color: string, opacity?: number) => {
+  const opacityString = opacity !== undefined ? ` / ${opacity}` : ""
+  const chartColorName = `chart-${color}`
+
+  return `hsl(var(--${chartColorName})${opacityString})`
+}
+
+/**
+ * Legacy Charts categorical palette (`--chart-categorical-N`) mapped to the
+ * closest F0 chart color token. Used by migration adapters so explicit
+ * `color: "categorical-N"` configs keep roughly the same hue when a legacy
+ * Charts consumer is re-rendered with F0DataChart.
+ */
+const categoricalToToken: Record<string, ChartColorToken> = {
+  "categorical-1": "viridian",
+  "categorical-2": "malibu",
+  "categorical-3": "grass",
+  "categorical-4": "barbie",
+  "categorical-5": "orange",
+  "categorical-6": "indigo",
+  "categorical-7": "army",
+  "categorical-8": "camel",
+}
+
+/**
+ * Map a legacy Charts color string to an F0 chart color token, or
+ * `undefined` when there is no meaningful equivalent (raw CSS strings,
+ * unknown names) — callers fall back to the kit palette.
+ */
+export const legacyChartColorToToken = (
+  color?: string
+): ChartColorToken | undefined =>
+  color ? categoricalToToken[color] : undefined

--- a/packages/react/src/sds/Profile/CategoryBarSection/index.tsx
+++ b/packages/react/src/sds/Profile/CategoryBarSection/index.tsx
@@ -1,13 +1,15 @@
-import {
-  CategoryBarChart,
-  CategoryBarProps,
-} from "@/kits/Charts/CategoryBarChart"
+import { F0DataChart } from "@/kits/F0DataChart"
+import { legacyChartColorToToken } from "@/lib/chart-colors"
 import { cn } from "@/lib/utils"
 
 interface CategoryBarSectionProps {
   title: string
   subtitle: string
-  data: CategoryBarProps["data"]
+  data: {
+    name: string
+    value: number
+    color?: string
+  }[]
   helpText?: string
   legend?: boolean
   hideTooltip?: boolean
@@ -28,10 +30,20 @@ export function CategoryBarSection({
         <span className="text-xl text-f1-foreground-secondary">{subtitle}</span>
       </div>
       <div className="mt-2">
-        <CategoryBarChart
-          data={data}
-          legend={legend}
-          hideTooltip={hideTooltip}
+        <F0DataChart
+          type="categoryBar"
+          data={data.map((segment) => ({
+            name: segment.name,
+            value: segment.value,
+            // Legacy colors were free-form strings; non-categorical values
+            // (raw CSS) have no token equivalent and fall back to "smoke"
+            // as a muted remainder tone.
+            color: segment.color
+              ? (legacyChartColorToToken(segment.color) ?? "smoke")
+              : undefined,
+          }))}
+          showLegend={legend}
+          showTooltip={!hideTooltip}
         />
       </div>
       {!!helpText && (

--- a/packages/react/src/ui/value-display/types/barSeries/barSeries.tsx
+++ b/packages/react/src/ui/value-display/types/barSeries/barSeries.tsx
@@ -3,7 +3,7 @@
  * secondary value (under/over/two-tone coloring). Used as the base for hourDistribution
  * and other presets.
  */
-import { getColor } from "@/kits/Charts/utils/colors"
+import { getColor } from "@/lib/chart-colors"
 import {
   TooltipContent,
   Tooltip as TooltipPrimitive,

--- a/packages/react/src/ui/value-display/types/categoryBarChart/categoryBarChart.tsx
+++ b/packages/react/src/ui/value-display/types/categoryBarChart/categoryBarChart.tsx
@@ -1,4 +1,4 @@
-import { getCategoricalColor, getColor } from "@/kits/Charts/utils/colors"
+import { getCategoricalColor, getColor } from "@/lib/chart-colors"
 import {
   Tooltip,
   TooltipContent,

--- a/packages/react/src/ui/value-display/types/progressBar/progressBar.tsx
+++ b/packages/react/src/ui/value-display/types/progressBar/progressBar.tsx
@@ -2,7 +2,7 @@
  * Progress Bar cell type for displaying progress values in data collections.
  * Supports both direct values and objects with placeholder states and custom labels.
  */
-import { getColor } from "@/kits/Charts/utils/colors"
+import { getColor } from "@/lib/chart-colors"
 import { Progress } from "@/ui/progress"
 
 import { ValueDisplayRendererContext } from "../../renderers"


### PR DESCRIPTION
## Description

Marks every `kits/Charts` export as `@deprecated` (each JSDoc points to its `F0DataChart` replacement, documenting the inverted Bar/VerticalBar naming) and migrates every internal consumer so no f0 component renders Recharts anymore: the six chart widgets keep their public API but render `F0DataChart` through shared data-model adapters, `CategoryBarSection` uses the new `categoryBar` variant, and the chart color helpers move to `lib/chart-colors` (re-exported from the old path) so non-chart consumers survive the future removal of the kit.

> **Stacked on #4822** (categoryBar variant). Draft until CI validates — local verification was not reliable at commit time (parallel work in the same checkout).

## Implementation details

- chore: add `@deprecated` JSDoc to all 9 Charts exports + `RadialProgressChart`, pointing to the F0DataChart equivalent
- feat: shared adapters (`toCategories`, `toBarSeries`, `toLineSeries`, `toLineType`, `toValueFormatter`, `toAxisEchartsOptions`) translating the Charts `dataConfig`/row data model to F0DataChart series
- refactor: `BarChartWidget`, `VerticalBarChartWidget`, `LineChartWidget`, `AreaChartWidget`, `PieChartWidget`, `RadialProgressWidget` render F0DataChart with unchanged public props — the 5 monorepo consumers migrate off Recharts with zero code changes

  <details>
  <summary>Privacy mode in AreaChartWidget</summary>

  The deprecated Charts AreaChart masked y-axis labels as "**" and hid the
  tooltip when `canBeBlurred` && privacy mode. The widget now reproduces
  that behavior itself (valueFormatter + echarts tooltip.show:false), so
  the Salary profile widget keeps its privacy semantics.
  </details>

- refactor: `CategoryBarSection` renders `<F0DataChart type="categoryBar" />`; legacy free-form color strings map to tokens (categorical-N by hue, raw CSS falls back to `smoke`)
- refactor: move `getColor`/`getCategoricalColor` to `lib/chart-colors` and update the 6 non-chart consumers (`F0SegmentedBar`, `MetadataValue`, `ProgressBarDuo`, value-display `progressBar`/`categoryBarChart`/`barSeries`); old path re-exports with `@deprecated`

🤖 Generated with [Claude Code](https://claude.com/claude-code)