### PR TITLE
feat(upselling-kit): allow UpsellingAlert to opt out of confirmation dialog

### DIFF
--- a/packages/react/src/sds/UpsellingKit/UpsellingAlert/index.stories.tsx
+++ b/packages/react/src/sds/UpsellingKit/UpsellingAlert/index.stories.tsx
@@ -70,6 +70,21 @@ export const WithIcon: Story = {
   },
 }
 
+export const WithoutConfirmation: Story = {
+  args: {
+    ...Default.args,
+    title: "Open the product details",
+    description:
+      "Use showConfirmation: false when the action only opens a modal or navigates, so no success dialog is shown for a request that was never sent.",
+    action: {
+      ...Default.args!.action!,
+      label: "Learn more",
+      showConfirmation: false,
+      onRequest: () => alert("Open product modal"),
+    },
+  },
+}
+
 export const Snapshot: Story = {
   parameters: withSnapshot({}),
   args: Default.args,

--- a/packages/react/src/sds/UpsellingKit/UpsellingAlert/index.tsx
+++ b/packages/react/src/sds/UpsellingKit/UpsellingAlert/index.tsx
@@ -12,6 +12,13 @@ type AlertAction = {
   loadingState: UpsellingButtonProps["loadingState"]
   nextSteps: UpsellingButtonProps["nextSteps"]
   closeLabel: UpsellingButtonProps["closeLabel"]
+  /**
+   * Whether to show the confirmation dialog after the request resolves.
+   * Defaults to `true`. Set to `false` when `onRequest` only opens a modal or
+   * navigates instead of creating an upselling request, so the success dialog
+   * ("request sent") is not shown for an action that sent nothing.
+   */
+  showConfirmation?: UpsellingButtonProps["showConfirmation"]
 }
 
 export interface UpsellingAlertProps {
@@ -80,6 +87,7 @@ function _UpsellingAlert({
               loadingState={action.loadingState}
               nextSteps={action.nextSteps}
               closeLabel={action.closeLabel}
+              showConfirmation={action.showConfirmation}
               variant="outlinePromote"
               size="sm"
             />


### PR DESCRIPTION
## 🚪 Why?

`UpsellingAlert` renders its action via `UpsellingButton`, which shows a success confirmation dialog once `onRequest` resolves (`showConfirmation` defaults to `true`). But `UpsellingAlert` never forwarded that prop, so there was **no way to turn the confirmation off**.

This breaks consumers whose `onRequest` only **opens a modal or navigates** instead of creating an upselling request. In Factorial's `upselling_kit` `UpsellAlert` wrapper, clicking the alert button ("Learn more") just opens a `ProductModal` — the handler resolves successfully and the button then shows a bogus **"Meeting requested! / One of our experts will contact you..."** confirmation for a request that was never made.

Reported from production: opening the Performance upsell from the Team status widget showed the product modal **and** a false "Meeting requested" confirmation behind it, without the user ever booking a meeting or sending a request.

## 🔑 What?

- Add an optional `showConfirmation` to the alert's `action` (typed from `UpsellingButtonProps["showConfirmation"]`).
- Forward it to `UpsellingButton`.
- Defaults to `true` → **existing behaviour is unchanged**. Consumers that only open a modal / navigate can now pass `showConfirmation: false`.
- Add a `WithoutConfirmation` story documenting the pattern.

This is what happened before this change: 
<img width="1753" height="1225" alt="image" src="https://github.com/user-attachments/assets/f9aa1210-c588-4192-8041-27b5f09585cc" />


## ✅ Verification

- `pnpm lint` + `pnpm format:check` clean on the changed files.
- `pnpm build:types` shows only pre-existing, unrelated errors (missing optional peer deps: `axe-core`, `docx-preview`, `react-virtuoso`, `maplibre-gl`); nothing in `UpsellingKit`.

## 📦 Follow-up (consumer side)

Once this releases and the version is bumped in the `factorial` monorepo, `frontend/src/modules/upselling_kit/components/UpsellAlert` should pass `showConfirmation: false` in its `action` (its `handleRequest` only opens the `ProductModal`). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)