### PR TITLE
feat(OneDataCollection): paginate search preview (infinite scroll) + focus first row for Enter-to-select

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
+++ b/packages/react/src/patterns/OneDataCollection/OneDatacollection.tsx
@@ -1700,6 +1700,9 @@ const OneDataCollectionComp = <
                     results={searchPreview.results}
                     resultsLoading={searchPreview.loading}
                     onResultSelect={searchPreview.onSelect}
+                    hasMore={searchPreview.hasMore}
+                    loadingMore={searchPreview.loadingMore}
+                    onLoadMore={searchPreview.onLoadMore}
                   />
                 )}
                 {visualizations && visualizations.length > 1 && (

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/graph.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/graph.stories.tsx
@@ -496,15 +496,26 @@ const queryEmployees = (input: {
     )
   })
 
-/** `searchEmployees(query)` — typeahead across the whole org. */
-const queryEmployeeSearch = (query: string): Promise<EmployeeNode[]> =>
+/** `searchEmployees(query, page)` — paginated typeahead across the whole org. */
+const SEARCH_PAGE_SIZE = 5
+const queryEmployeeSearch = (
+  query: string,
+  page: number
+): Promise<{ records: EmployeeNode[]; hasMore: boolean }> =>
   gqlRequest(() => {
     const normalized = query.toLowerCase()
-    return EMPLOYEES.filter(
+    const matches = EMPLOYEES.filter(
       (employee) =>
         employee.name.toLowerCase().includes(normalized) ||
         employee.title.toLowerCase().includes(normalized)
-    ).map(toEmployeeNode)
+    )
+    const start = page * SEARCH_PAGE_SIZE
+    return {
+      records: matches
+        .slice(start, start + SEARCH_PAGE_SIZE)
+        .map(toEmployeeNode),
+      hasMore: start + SEARCH_PAGE_SIZE < matches.length,
+    }
   })
 
 /** `ancestorPath(nodeId)` — root → … → node, for revealing on search. */

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/graph.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/graph.stories.tsx
@@ -500,7 +500,7 @@ const queryEmployees = (input: {
 const SEARCH_PAGE_SIZE = 5
 const queryEmployeeSearch = (
   query: string,
-  page: number
+  page = 0
 ): Promise<{ records: EmployeeNode[]; hasMore: boolean }> =>
   gqlRequest(() => {
     const normalized = query.toLowerCase()

--- a/packages/react/src/patterns/OneDataCollection/components/Search/Search.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/Search/Search.tsx
@@ -37,7 +37,9 @@ interface SearchProps {
   onResultSelect?: (id: string) => void
 }
 
-const MAX_PREVIEW_RESULTS = 5
+// Upper bound on how many preview rows we render. The dropdown shows a few at
+// a time and scrolls to reach the rest, so this stays generous rather than tiny.
+const MAX_PREVIEW_RESULTS = 25
 
 const IconComponent = ({ loading }: { loading: boolean }) => {
   return loading ? (
@@ -61,6 +63,7 @@ export const Search = ({
   const uniqueId = useId()
   const ref = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
+  const activeItemRef = useRef<HTMLButtonElement>(null)
   const i18n = useI18n()
 
   // Cap the preview to the top matches — it narrows as you keep typing.
@@ -68,10 +71,16 @@ export const Search = ({
   const resultsVisible =
     open && showResults && Boolean(value) && resultItems.length > 0
 
-  // Keep the active row in range as results change.
+  // Highlight the first row whenever results change, so a plain Enter jumps to
+  // the top match without the user having to arrow down or click first.
   useEffect(() => {
-    setActiveIndex(-1)
+    setActiveIndex((results ?? []).length > 0 ? 0 : -1)
   }, [results])
+
+  // Keep the highlighted row visible as the user arrows past the fold.
+  useEffect(() => {
+    activeItemRef.current?.scrollIntoView({ block: "nearest" })
+  }, [activeIndex])
 
   const handleClear = () => {
     onChange(undefined)
@@ -185,7 +194,7 @@ export const Search = ({
                     onChange={(e) => {
                       onChange(e.target.value)
                       setShowResults(true)
-                      setActiveIndex(-1)
+                      setActiveIndex(0)
                     }}
                     className="h-full w-full appearance-none rounded border-none bg-f1-background py-2 pl-7 text-base text-f1-foreground"
                     initial={{ opacity: 0 }}
@@ -279,10 +288,11 @@ export const Search = ({
               </motion.div>
             )}
             {resultsVisible ? (
-              <ul className="absolute right-0 top-full z-50 mt-2 max-h-96 w-72 overflow-auto rounded-xl border border-solid border-f1-border-secondary bg-f1-background p-1 shadow-md">
+              <ul className="absolute right-0 top-full z-50 mt-2 max-h-72 w-72 overflow-auto rounded-xl border border-solid border-f1-border-secondary bg-f1-background p-1 shadow-md">
                 {resultItems.map((result, index) => (
                   <li key={result.id}>
                     <button
+                      ref={index === activeIndex ? activeItemRef : null}
                       type="button"
                       onMouseDown={(e) => e.preventDefault()}
                       onMouseEnter={() => setActiveIndex(index)}

--- a/packages/react/src/patterns/OneDataCollection/components/Search/Search.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/Search/Search.tsx
@@ -35,11 +35,16 @@ interface SearchProps {
   resultsLoading?: boolean
   /** Fired when a preview result is selected. */
   onResultSelect?: (id: string) => void
+  /** Whether another page of results can be pulled via infinite scroll. */
+  hasMore?: boolean
+  /** Whether a further page is currently being appended. */
+  loadingMore?: boolean
+  /** Request the next page (fired when the list is scrolled near the bottom). */
+  onLoadMore?: () => void
 }
 
-// Upper bound on how many preview rows we render. The dropdown shows a few at
-// a time and scrolls to reach the rest, so this stays generous rather than tiny.
-const MAX_PREVIEW_RESULTS = 25
+// Trigger the next page when the user scrolls within this many px of the bottom.
+const LOAD_MORE_SCROLL_MARGIN = 56
 
 const IconComponent = ({ loading }: { loading: boolean }) => {
   return loading ? (
@@ -56,6 +61,9 @@ export const Search = ({
   results,
   resultsLoading = false,
   onResultSelect,
+  hasMore = false,
+  loadingMore = false,
+  onLoadMore,
 }: SearchProps) => {
   const [open, setOpen] = useState(false)
   const [showResults, setShowResults] = useState(false)
@@ -66,10 +74,21 @@ export const Search = ({
   const activeItemRef = useRef<HTMLButtonElement>(null)
   const i18n = useI18n()
 
-  // Cap the preview to the top matches — it narrows as you keep typing.
-  const resultItems = (results ?? []).slice(0, MAX_PREVIEW_RESULTS)
+  // Render every loaded row; growth is bounded by paginated loading, not a cap.
+  const resultItems = results ?? []
   const resultsVisible =
     open && showResults && Boolean(value) && resultItems.length > 0
+
+  const handleResultsScroll = (e: React.UIEvent<HTMLUListElement>) => {
+    if (!hasMore || loadingMore || !onLoadMore) return
+    const el = e.currentTarget
+    if (
+      el.scrollHeight - el.scrollTop - el.clientHeight <=
+      LOAD_MORE_SCROLL_MARGIN
+    ) {
+      onLoadMore()
+    }
+  }
 
   // Highlight the first row whenever results change, so a plain Enter jumps to
   // the top match without the user having to arrow down or click first.
@@ -137,9 +156,13 @@ export const Search = ({
 
     if (e.key === "ArrowDown") {
       e.preventDefault()
-      setActiveIndex((index) =>
-        index < resultItems.length - 1 ? index + 1 : index
-      )
+      if (activeIndex < resultItems.length - 1) {
+        setActiveIndex(activeIndex + 1)
+      } else if (hasMore && !loadingMore) {
+        // At the end of the loaded rows — pull the next page so keyboard users
+        // can page through as well, not just scrollers.
+        onLoadMore?.()
+      }
     } else if (e.key === "ArrowUp") {
       e.preventDefault()
       setActiveIndex((index) => (index > 0 ? index - 1 : 0))
@@ -288,7 +311,10 @@ export const Search = ({
               </motion.div>
             )}
             {resultsVisible ? (
-              <ul className="absolute right-0 top-full z-50 mt-2 max-h-72 w-72 overflow-auto rounded-xl border border-solid border-f1-border-secondary bg-f1-background p-1 shadow-md">
+              <ul
+                className="absolute right-0 top-full z-50 mt-2 max-h-72 w-72 overflow-auto rounded-xl border border-solid border-f1-border-secondary bg-f1-background p-1 shadow-md"
+                onScroll={handleResultsScroll}
+              >
                 {resultItems.map((result, index) => (
                   <li key={result.id}>
                     <button
@@ -319,6 +345,14 @@ export const Search = ({
                     </button>
                   </li>
                 ))}
+                {loadingMore ? (
+                  <li
+                    className="flex items-center justify-center py-2 text-f1-icon"
+                    aria-hidden
+                  >
+                    <F0Icon icon={Spinner} className="animate-spin" />
+                  </li>
+                ) : null}
               </ul>
             ) : null}
           </motion.div>

--- a/packages/react/src/patterns/OneDataCollection/components/Search/useSearchPreview.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/components/Search/useSearchPreview.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, it, vi } from "vitest"
 
 import type { RecordType } from "@/hooks/datasource"
 
-import type { SearchPreview } from "../../hooks/useDataCollectionSource/types"
+import type {
+  SearchPreview,
+  SearchPreviewPage,
+} from "../../hooks/useDataCollectionSource/types"
 import { useSearchPreview } from "./useSearchPreview"
 
 type Person = RecordType & { id: string; name: string; role: string }
@@ -20,6 +23,37 @@ const buildPreview = (
     people.filter((person) =>
       person.name.toLowerCase().includes(query.toLowerCase())
     )
+  ),
+  getId: (person) => person.id,
+  render: (person) => ({ title: person.name, subtitle: person.role }),
+  onSelect,
+})
+
+// A larger corpus for pagination tests: 12 people all matching "person".
+const manyPeople: Person[] = Array.from({ length: 12 }, (_unused, index) => ({
+  id: String(index + 1),
+  name: `Person ${index + 1}`,
+  role: "Role",
+}))
+
+const PAGE_SIZE = 5
+
+// A paginated preview: `search(query, page)` returns one window of matches plus
+// a `hasMore` flag, mirroring how a real consumer pages over its own corpus.
+const buildPaginatedPreview = (
+  onSelect: (record: Person) => void = vi.fn()
+): SearchPreview<Person> => ({
+  search: vi.fn(
+    async (query: string, page = 0): Promise<SearchPreviewPage<Person>> => {
+      const matches = manyPeople.filter((person) =>
+        person.name.toLowerCase().includes(query.toLowerCase())
+      )
+      const start = page * PAGE_SIZE
+      return {
+        records: matches.slice(start, start + PAGE_SIZE),
+        hasMore: start + PAGE_SIZE < matches.length,
+      }
+    }
   ),
   getId: (person) => person.id,
   render: (person) => ({ title: person.name, subtitle: person.role }),
@@ -105,5 +139,140 @@ describe("useSearchPreview", () => {
 
     rerender({ query: "" })
     await waitFor(() => expect(result.current.results).toHaveLength(0))
+  })
+
+  it("loads the first page and reports there is more to load", async () => {
+    const preview = buildPaginatedPreview()
+    const { result, rerender } = renderHook(
+      ({ query }) => useSearchPreview(preview, query),
+      { initialProps: { query: "" as string | undefined } }
+    )
+
+    rerender({ query: "person" })
+
+    await waitFor(() => expect(result.current.results).toHaveLength(PAGE_SIZE))
+    expect(result.current.hasMore).toBe(true)
+    expect(result.current.loadingMore).toBe(false)
+  })
+
+  it("appends the next page on onLoadMore until exhausted", async () => {
+    const preview = buildPaginatedPreview()
+    const { result, rerender } = renderHook(
+      ({ query }) => useSearchPreview(preview, query),
+      { initialProps: { query: "" as string | undefined } }
+    )
+
+    rerender({ query: "person" })
+    await waitFor(() => expect(result.current.results).toHaveLength(5))
+
+    act(() => result.current.onLoadMore())
+    await waitFor(() => expect(result.current.results).toHaveLength(10))
+    expect(result.current.hasMore).toBe(true)
+
+    act(() => result.current.onLoadMore())
+    await waitFor(() => expect(result.current.results).toHaveLength(12))
+    // Last page reached — no further pages.
+    expect(result.current.hasMore).toBe(false)
+    // Rows stay unique across pages (no duplication when appending).
+    expect(new Set(result.current.results.map((r) => r.id)).size).toBe(12)
+  })
+
+  it("does not fetch again when there are no more pages", async () => {
+    const preview = buildPaginatedPreview()
+    const { result, rerender } = renderHook(
+      ({ query }) => useSearchPreview(preview, query),
+      { initialProps: { query: "" as string | undefined } }
+    )
+
+    rerender({ query: "person" })
+    await waitFor(() => expect(result.current.results).toHaveLength(5))
+    act(() => result.current.onLoadMore())
+    await waitFor(() => expect(result.current.results).toHaveLength(10))
+    act(() => result.current.onLoadMore())
+    await waitFor(() => expect(result.current.hasMore).toBe(false))
+
+    const callsBefore = (preview.search as ReturnType<typeof vi.fn>).mock.calls
+      .length
+    act(() => result.current.onLoadMore())
+    expect((preview.search as ReturnType<typeof vi.fn>).mock.calls.length).toBe(
+      callsBefore
+    )
+    expect(result.current.results).toHaveLength(12)
+  })
+
+  it("resets to the first page when the query changes", async () => {
+    const preview = buildPaginatedPreview()
+    const { result, rerender } = renderHook(
+      ({ query }) => useSearchPreview(preview, query),
+      { initialProps: { query: "" as string | undefined } }
+    )
+
+    rerender({ query: "person" })
+    await waitFor(() => expect(result.current.results).toHaveLength(5))
+    act(() => result.current.onLoadMore())
+    await waitFor(() => expect(result.current.results).toHaveLength(10))
+
+    // A new query starts fresh at page 0 (results replaced, not appended).
+    rerender({ query: "person 1" })
+    await waitFor(() =>
+      expect(result.current.results.length).toBeLessThanOrEqual(PAGE_SIZE)
+    )
+    expect(
+      result.current.results.every((r) => r.title.startsWith("Person 1"))
+    ).toBe(true)
+  })
+
+  it("treats a bare array as a single non-paginated page", async () => {
+    const preview = buildPreview(vi.fn())
+    const { result, rerender } = renderHook(
+      ({ query }) => useSearchPreview(preview, query),
+      { initialProps: { query: "" as string | undefined } }
+    )
+
+    rerender({ query: "a" })
+    await waitFor(() => expect(result.current.results).toHaveLength(2))
+    expect(result.current.hasMore).toBe(false)
+
+    const callsBefore = (preview.search as ReturnType<typeof vi.fn>).mock.calls
+      .length
+    act(() => result.current.onLoadMore())
+    // No `hasMore`, so load-more is a no-op — no extra fetch.
+    expect((preview.search as ReturnType<typeof vi.fn>).mock.calls.length).toBe(
+      callsBefore
+    )
+  })
+
+  it("drops a stale response when the query changes before it resolves", async () => {
+    const resolvers: Record<string, (page: SearchPreviewPage<Person>) => void> =
+      {}
+    const preview: SearchPreview<Person> = {
+      search: vi.fn(
+        (query: string) =>
+          new Promise<SearchPreviewPage<Person>>((resolve) => {
+            resolvers[query] = resolve
+          })
+      ),
+      getId: (person) => person.id,
+      render: (person) => ({ title: person.name, subtitle: person.role }),
+      onSelect: vi.fn(),
+    }
+
+    const { result, rerender } = renderHook(
+      ({ query }) => useSearchPreview(preview, query),
+      { initialProps: { query: "ada" as string | undefined } }
+    )
+
+    // Switch query before the "ada" request resolves.
+    rerender({ query: "alan" })
+
+    // Resolve the current ("alan") request first — this one should win.
+    act(() => resolvers["alan"]?.({ records: [people[1]!], hasMore: false }))
+    await waitFor(() => expect(result.current.results).toHaveLength(1))
+    expect(result.current.results[0]?.id).toBe("2")
+
+    // Now the stale ("ada") request resolves late — it must be ignored.
+    act(() => resolvers["ada"]?.({ records: [people[0]!], hasMore: false }))
+    expect(result.current.results).toHaveLength(1)
+    expect(result.current.results[0]?.id).toBe("2")
   })
 })

--- a/packages/react/src/patterns/OneDataCollection/components/Search/useSearchPreview.ts
+++ b/packages/react/src/patterns/OneDataCollection/components/Search/useSearchPreview.ts
@@ -2,12 +2,22 @@ import { useEffect, useRef, useState } from "react"
 
 import type { RecordType } from "@/hooks/datasource"
 
-import type { SearchPreview } from "../../hooks/useDataCollectionSource/types"
+import type {
+  SearchPreview,
+  SearchPreviewPage,
+} from "../../hooks/useDataCollectionSource/types"
 import type { SearchResultItem } from "./Search"
 
 type UseSearchPreviewReturn = {
   results: SearchResultItem[]
+  /** Initial page (page 0) is loading for the current query. */
   loading: boolean
+  /** A further page is being appended via infinite scroll. */
+  loadingMore: boolean
+  /** Whether another page can be pulled for the current query. */
+  hasMore: boolean
+  /** Request the next page (no-op while already loading or when exhausted). */
+  onLoadMore: () => void
   onSelect: (id: string) => void
   /**
    * Increments on every result selection. Consumers derive their own state
@@ -19,11 +29,17 @@ type UseSearchPreviewReturn = {
   selectionNonce: number
 }
 
+const normalizePage = <R extends RecordType>(
+  found: R[] | SearchPreviewPage<R>
+): SearchPreviewPage<R> =>
+  Array.isArray(found) ? { records: found, hasMore: false } : found
+
 /**
  * Drives the shared header-search preview from `source.searchPreview`: runs the
- * consumer's `search(query)` for the current (debounced) query and maps the
- * records to preview rows. Returns the rows, a loading flag, and an `onSelect`
- * that forwards the picked record to `searchPreview.onSelect`.
+ * consumer's `search(query, page)` for the current (debounced) query, maps the
+ * records to preview rows, and appends further pages on demand (infinite
+ * scroll). Returns the rows, loading flags, `hasMore`/`onLoadMore` for
+ * pagination, and an `onSelect` that forwards the picked record.
  */
 export function useSearchPreview<R extends RecordType>(
   searchPreview: SearchPreview<R> | undefined,
@@ -31,37 +47,83 @@ export function useSearchPreview<R extends RecordType>(
 ): UseSearchPreviewReturn {
   const [results, setResults] = useState<SearchResultItem[]>([])
   const [loading, setLoading] = useState(false)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [hasMore, setHasMore] = useState(false)
   const [selectionNonce, setSelectionNonce] = useState(0)
   const recordsRef = useRef<R[]>([])
+  const pageRef = useRef(0)
+  // Bumped on every new query so stale in-flight page responses are dropped.
+  const requestIdRef = useRef(0)
+  // Synchronous guard against a scroll burst firing loadMore twice in a tick.
+  const loadingMoreRef = useRef(false)
   const searchPreviewRef = useRef(searchPreview)
   searchPreviewRef.current = searchPreview
 
+  const trimmed = query?.trim() ?? ""
+
+  const toResultItems = (preview: SearchPreview<R>, records: R[]) =>
+    records.map((record) => ({
+      id: preview.getId(record),
+      ...preview.render(record),
+    }))
+
+  // Reset and load page 0 whenever the query changes.
   useEffect(() => {
     const preview = searchPreviewRef.current
-    const trimmed = query?.trim() ?? ""
+    const requestId = ++requestIdRef.current
+    pageRef.current = 0
+    loadingMoreRef.current = false
+    setLoadingMore(false)
     if (!preview || trimmed.length === 0) {
       recordsRef.current = []
       setResults([])
       setLoading(false)
+      setHasMore(false)
       return
     }
-    let active = true
     setLoading(true)
-    void preview.search(trimmed).then((found) => {
-      if (!active) return
-      recordsRef.current = found
-      setResults(
-        found.map((record) => ({
-          id: preview.getId(record),
-          ...preview.render(record),
-        }))
-      )
+    void Promise.resolve(preview.search(trimmed, 0)).then((found) => {
+      if (requestId !== requestIdRef.current) return
+      const page = normalizePage(found)
+      recordsRef.current = page.records
+      setResults(toResultItems(preview, page.records))
+      setHasMore(page.hasMore)
       setLoading(false)
     })
-    return () => {
-      active = false
+  }, [trimmed])
+
+  const onLoadMore = () => {
+    const preview = searchPreviewRef.current
+    if (
+      !preview ||
+      loadingMoreRef.current ||
+      loading ||
+      !hasMore ||
+      trimmed.length === 0
+    ) {
+      return
     }
-  }, [query])
+    const requestId = requestIdRef.current
+    const nextPage = pageRef.current + 1
+    loadingMoreRef.current = true
+    setLoadingMore(true)
+    void Promise.resolve(preview.search(trimmed, nextPage))
+      .then((found) => {
+        if (requestId !== requestIdRef.current) return
+        const page = normalizePage(found)
+        pageRef.current = nextPage
+        recordsRef.current = [...recordsRef.current, ...page.records]
+        setResults((prev) => [...prev, ...toResultItems(preview, page.records)])
+        setHasMore(page.hasMore)
+        loadingMoreRef.current = false
+        setLoadingMore(false)
+      })
+      .catch(() => {
+        if (requestId !== requestIdRef.current) return
+        loadingMoreRef.current = false
+        setLoadingMore(false)
+      })
+  }
 
   const onSelect = (id: string) => {
     const preview = searchPreviewRef.current
@@ -78,5 +140,13 @@ export function useSearchPreview<R extends RecordType>(
     }
   }
 
-  return { results, loading, onSelect, selectionNonce }
+  return {
+    results,
+    loading,
+    loadingMore,
+    hasMore,
+    onLoadMore,
+    onSelect,
+    selectionNonce,
+  }
 }

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionSource/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionSource/types.ts
@@ -104,13 +104,28 @@ export type SearchPreviewResultData = {
 }
 
 /**
+ * One page of search-preview results. `hasMore` tells the dropdown whether to
+ * keep pulling further pages as the user scrolls (infinite scroll).
+ */
+export type SearchPreviewPage<R extends RecordType> = {
+  records: R[]
+  hasMore: boolean
+}
+
+/**
  * Optional rich search preview shown in the shared Data Collection search.
  * When provided, typing in the header search renders a results dropdown with
  * avatar + title + subtitle, consistent across every visualization. Selecting a
  * result calls `onSelect` (e.g. the graph view reveals/centers the node).
  */
 export type SearchPreview<R extends RecordType> = {
-  search: (query: string) => Promise<R[]>
+  /**
+   * Fetch one page of matches for `query`. `page` starts at 0 and increments as
+   * the user scrolls the dropdown to the bottom. Return a bare array for a
+   * single, non-paginated page (treated as `hasMore: false`), or a
+   * `SearchPreviewPage` to drive infinite scroll across pages.
+   */
+  search: (query: string, page: number) => Promise<R[] | SearchPreviewPage<R>>
   getId: (record: R) => string
   render: (record: R) => SearchPreviewResultData
   onSelect: (record: R) => void

--- a/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionSource/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/hooks/useDataCollectionSource/types.ts
@@ -121,11 +121,12 @@ export type SearchPreviewPage<R extends RecordType> = {
 export type SearchPreview<R extends RecordType> = {
   /**
    * Fetch one page of matches for `query`. `page` starts at 0 and increments as
-   * the user scrolls the dropdown to the bottom. Return a bare array for a
-   * single, non-paginated page (treated as `hasMore: false`), or a
-   * `SearchPreviewPage` to drive infinite scroll across pages.
+   * the user scrolls the dropdown to the bottom; it is optional so existing
+   * non-paginated consumers keep the plain `(query) => Promise<R[]>` shape.
+   * Return a bare array for a single, non-paginated page (treated as
+   * `hasMore: false`), or a `SearchPreviewPage` to drive infinite scroll.
    */
-  search: (query: string, page: number) => Promise<R[] | SearchPreviewPage<R>>
+  search: (query: string, page?: number) => Promise<R[] | SearchPreviewPage<R>>
   getId: (record: R) => string
   render: (record: R) => SearchPreviewResultData
   onSelect: (record: R) => void


### PR DESCRIPTION
## What

Reworks the OneDataCollection **Search** preview dropdown (the shared "buscador" used across data collections, incl. the new Org Chart V3 / F0Graph finder). From QA round 2 on the new org chart.

Two goals:
1. **Paginate the results** — the preview was hard-capped (first 5, later 25) so extra matches were unreachable. Now it pages with **infinite scroll**, matching the employee-filter search UX (`OneFilterPicker` `InFilter` + `ScrollArea onScrollBottom`).
2. **Focus the first result** so a plain **Enter** jumps to the top match, no click.

## Changes

**Contract** (`useDataCollectionSource/types.ts`)
- New `SearchPreviewPage<R> = { records, hasMore }`.
- `searchPreview.search` is now `(query, page) => Promise<R[] | SearchPreviewPage<R>>`. Returning a bare array still works as a single, non-paginated page — **back-compatible** with existing consumers.

**Hook** (`useSearchPreview.ts`)
- Accumulates pages, tracks `hasMore` / `loadingMore`, drops stale responses across queries (request-id guard) and duplicate load-more bursts (ref guard), exposes `onLoadMore`.

**Component** (`Search.tsx`)
- Loads the next page on **scroll-near-bottom** (`onScroll`, 56px margin) and on **ArrowDown past the last loaded row** (keyboard paging), with a spinner row while appending.
- Renders all loaded rows (no hard cap); dropdown height ~5 rows (`max-h-72`) so it scrolls.
- **Highlights the first result by default** (`activeIndex = 0`) → Enter selects the top match; `scrollIntoView` keeps the active row visible under keyboard nav.

**Wiring** (`OneDatacollection.tsx`): passes `hasMore` / `loadingMore` / `onLoadMore` to `<Search>`.

**Story** (`graph.stories.tsx`): the demo typeahead now paginates (page size 5) to exercise infinite scroll in Storybook.

## Consumer follow-up

The factorial org chart adopts the paged `search(query, page)` (client-side paging over the in-memory skeleton). That change **requires an `@factorialco/f0-react` bump** to the version shipping this PR — companion: factorialco/factorial#107450.

## Testing

- `oxlint` + `oxfmt` clean; `tsc` (build:types) **0 errors**.
- Manual Storybook verification of infinite scroll + focus/Enter pending.

### Before

https://github.com/user-attachments/assets/6b8493f3-e161-4f81-9e12-511d7530b59d


### After


https://github.com/user-attachments/assets/09d2a1d6-2d92-48ed-b4ce-eef3c1e857f0

