### PR TITLE
fix(OneDataCollection): use column IDs for summary keys

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -873,7 +873,7 @@ export const TableCollection = <
                       )}
                       {columns.map((column, cellIndex) => (
                         <TableCell
-                          key={`summary-${String(column.label)}`}
+                          key={`summary-${column.id ?? String(column.label)}`}
                           firstCell={cellIndex === 0}
                           width={column.width}
                           sticky={getStickyPosition(cellIndex)}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
@@ -1233,6 +1233,50 @@ describe("TableCollection", () => {
       expect(within(salaryCell).queryByText("ROW")).not.toBeInTheDocument()
     })
 
+    it("uses column ids for summary cell keys when labels are duplicated", async () => {
+      const consoleError = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {})
+
+      render(
+        <TableCollection<
+          SummaryPerson,
+          TestFilters,
+          SortingsDefinition,
+          SummaryTestDefinitions,
+          ItemActionsDefinition<SummaryPerson>,
+          TestNavigationFilters,
+          GroupingDefinition<SummaryPerson>
+        >
+          columns={[
+            {
+              label: "Transport benefit",
+              id: "compensation-transport-benefit",
+              summary: "salary" as const,
+              render: (item: SummaryPerson) => item.salary ?? undefined,
+            },
+            {
+              label: "Transport benefit",
+              id: "payroll-result-transport-benefit",
+              summary: "salary" as const,
+              render: (item: SummaryPerson) => item.salary ?? undefined,
+            },
+          ]}
+          source={createSummarySource({ salarySummary: 100 })}
+          onSelectItems={vi.fn()}
+          onLoadData={vi.fn()}
+          onLoadError={vi.fn()}
+        />
+      )
+
+      await waitFor(() => {
+        expect(screen.getAllByText("Transport benefit")).toHaveLength(2)
+      })
+
+      expect(consoleError).not.toHaveBeenCalled()
+      consoleError.mockRestore()
+    })
+
     it("treats empty-string summaries as empty and shows the placeholder", async () => {
       render(
         <TableCollection<


### PR DESCRIPTION
## Description

Use stable column IDs for summary-row React keys so tables can safely render multiple columns with the same visible label.

## Type of change

- [x] Bug fix

## Implementation details

- fix: derive summary-cell keys from the column ID, preserving the label fallback
- test: cover duplicate labels with distinct column IDs and assert no React console error

## Verification

- Focused TableCollection unit suite passes: 42 tests
- Formatting, targeted linting, and TypeScript checks pass