### PR TITLE
chore(storybook): collapse maturity & import into title tags

### DIFF
--- a/packages/react/.storybook/ComponentStatusPanel.tsx
+++ b/packages/react/.storybook/ComponentStatusPanel.tsx
@@ -2,14 +2,13 @@ import { DocsContext } from "@storybook/addon-docs/blocks"
 import React, { useContext, useEffect, useRef, useState } from "react"
 import { createPortal } from "react-dom"
 
-import { ComponentStability } from "@/component-status"
+import { ComponentMaturityTag } from "@/component-status"
 
 /**
- * Creates a portal container immediately after the docs title/description block,
- * so the panel renders under the heading rather than at the very top of the page.
- * Mirrors the placement logic used by the import banner.
+ * Creates a portal container inside the docs `<h1>` title so the maturity tag
+ * renders inline next to the component name rather than as a separate section.
  */
-function usePortalAfterTitle() {
+function usePortalInTitle() {
   const [target, setTarget] = useState<HTMLElement | null>(null)
   const containerRef = useRef<HTMLElement | null>(null)
 
@@ -19,18 +18,13 @@ function usePortalAfterTitle() {
     )
     if (!titleEl) return
 
-    const sibling = titleEl.nextElementSibling
-    const afterEl =
-      sibling?.tagName === "P"
-        ? sibling
-        : sibling?.tagName === "DIV" && sibling.querySelector("p")
-          ? sibling
-          : titleEl
-
     if (!containerRef.current) {
-      containerRef.current = document.createElement("div")
+      const el = document.createElement("span")
+      el.style.marginLeft = "0.5rem"
+      el.style.whiteSpace = "nowrap"
+      containerRef.current = el
     }
-    afterEl.after(containerRef.current)
+    titleEl.append(containerRef.current)
     setTarget(containerRef.current)
 
     return () => {
@@ -42,14 +36,16 @@ function usePortalAfterTitle() {
 }
 
 /**
- * Injects the exported `ComponentStability` panel into every component docs
- * page. All content comes from the shared component-status data, so the docs
- * page and any consuming app render identically. Renders nothing on
- * non-component pages (the title doesn't resolve to a tracked component).
+ * Injects the exported `ComponentMaturityTag` next to every component docs
+ * title. The tag shows the maturity status, and on hover reveals the full
+ * summary and Definition-of-Done checklist in a tooltip. All content comes from
+ * the shared component-status data, so the docs page and any consuming app stay
+ * consistent. Renders nothing on non-component pages (the title doesn't resolve
+ * to a tracked component).
  */
 export function ComponentStatusPanel() {
   const context = useContext(DocsContext)
-  const portalTarget = usePortalAfterTitle()
+  const portalTarget = usePortalInTitle()
 
   let title: string | undefined
   try {
@@ -63,7 +59,7 @@ export function ComponentStatusPanel() {
 
   if (!title || !portalTarget) return null
   return createPortal(
-    <ComponentStability componentName={title} className="my-6" />,
+    <ComponentMaturityTag componentName={title} />,
     portalTarget
   )
 }

--- a/packages/react/.storybook/ComponentStatusPanel.tsx
+++ b/packages/react/.storybook/ComponentStatusPanel.tsx
@@ -20,7 +20,6 @@ function usePortalInTitle() {
 
     if (!containerRef.current) {
       const el = document.createElement("span")
-      el.style.marginLeft = "0.5rem"
       el.style.whiteSpace = "nowrap"
       containerRef.current = el
     }

--- a/packages/react/.storybook/DocsContainer.tsx
+++ b/packages/react/.storybook/DocsContainer.tsx
@@ -33,8 +33,8 @@ export const DocsContainer: FC<PropsWithChildren<DocsContainerProps>> = (
   return (
     <BaseContainer theme={isDark ? darkTheme : lightTheme} {...props}>
       <I18nProvider translations={storybookTranslations}>
-        <ImportBanner isDark={isDark} />
         <ComponentStatusPanel />
+        <ImportBanner />
         {children}
       </I18nProvider>
     </BaseContainer>

--- a/packages/react/.storybook/ImportBanner.tsx
+++ b/packages/react/.storybook/ImportBanner.tsx
@@ -1,20 +1,75 @@
-import { DocsContext, Source } from "@storybook/addon-docs/blocks"
+import { DocsContext } from "@storybook/addon-docs/blocks"
 import React, { useContext, useEffect, useRef, useState } from "react"
 import { createPortal } from "react-dom"
 
-import { F0Alert } from "@/components/F0Alert"
+import { F0TagRaw } from "@/components/tags/F0TagRaw"
+import { Code } from "@/icons/app"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/ui/tooltip"
 
 import { extractComponentName, resolveImportPath } from "./resolveImportPath.ts"
 
-interface ImportBannerProps {
-  isDark: boolean
+/**
+ * A single-line import statement with a copy button, styled for the dark
+ * tooltip surface. Rendered directly (instead of Storybook's `Source` block)
+ * so the padding stays tight and the text is readable regardless of the docs
+ * page theme.
+ */
+function ImportSnippet({ code }: { code: string }) {
+  const [copied, setCopied] = useState(false)
+
+  const onCopy = () => {
+    try {
+      void navigator.clipboard?.writeText(code)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch {
+      // Clipboard may be unavailable (e.g. insecure context) — ignore.
+    }
+  }
+
+  return (
+    <div className="sb-unstyled flex items-center gap-3 px-3 py-2 text-f1-foreground-inverse">
+      <div className="min-w-0 overflow-x-auto">
+        <code className="whitespace-pre font-mono text-base">{code}</code>
+      </div>
+      <button
+        type="button"
+        onClick={onCopy}
+        className="shrink-0 rounded-md border border-solid border-white/25 bg-white/10 px-2 py-1 text-sm font-medium text-white transition-colors hover:bg-white/20"
+      >
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </div>
+  )
 }
 
 /**
- * Finds the insertion point after the title + subtitle + description block
- * in the Storybook docs page, and creates a container element for the portal.
+ * Storybook's docs theme hides `<svg>` inside the title `<h1>` and only reveals
+ * it on hover (its heading anchor-link affordance). Our tag icon is portaled
+ * into that `<h1>`, so it inherits that rule and appears only on hover. This
+ * injects a scoped, !important override that keeps icons inside our own
+ * `.sb-unstyled` tag wrappers visible, without touching Storybook's anchor icon.
  */
-function usePortalTarget() {
+function ensureTitleTagIconVisible() {
+  const id = "f0-title-tag-icon-fix"
+  if (document.getElementById(id)) return
+  const style = document.createElement("style")
+  style.id = id
+  style.textContent =
+    "#storybook-docs h1 .sb-unstyled svg{visibility:visible!important;position:static!important;top:auto!important}"
+  document.head.appendChild(style)
+}
+
+/**
+ * Creates a portal container inside the docs `<h1>` title so the import tag
+ * renders inline next to the component name rather than as a separate section.
+ */
+function usePortalInTitle() {
   const [target, setTarget] = useState<HTMLElement | null>(null)
   const containerRef = useRef<HTMLElement | null>(null)
 
@@ -25,20 +80,15 @@ function usePortalTarget() {
     )
     if (!titleEl) return
 
-    // Insert after h1 + p or h1 + div > p (the subtitle/description)
-    const sibling = titleEl.nextElementSibling
-    const afterEl =
-      sibling?.tagName === "P"
-        ? sibling
-        : sibling?.tagName === "DIV" && sibling.querySelector("p")
-          ? sibling
-          : titleEl
+    ensureTitleTagIconVisible()
 
     if (!containerRef.current) {
-      containerRef.current = document.createElement("div")
+      const el = document.createElement("span")
+      el.style.marginLeft = "0.5rem"
+      el.style.whiteSpace = "nowrap"
+      containerRef.current = el
     }
-
-    afterEl.after(containerRef.current)
+    titleEl.append(containerRef.current)
     setTarget(containerRef.current)
 
     return () => {
@@ -50,15 +100,16 @@ function usePortalTarget() {
 }
 
 /**
- * Renders a code block showing how to import the current component.
- * Uses a portal to position itself after the title/subtitle/description
- * in the Storybook docs page.
+ * Renders a "How to import" tag next to the current component's docs title. On
+ * hover it reveals the import statement (or, for internal components, a note
+ * that the component isn't exported) in a tooltip. Uses a portal to place the
+ * tag inline inside the title.
  *
- * If the component is internal (no public export), shows a warning instead.
+ * Renders nothing on non-component pages.
  */
-export function ImportBanner({ isDark }: ImportBannerProps) {
+export function ImportBanner() {
   const context = useContext(DocsContext)
-  const portalTarget = usePortalTarget()
+  const portalTarget = usePortalInTitle()
 
   let fileName: string | undefined
   let title: string | undefined
@@ -84,33 +135,43 @@ export function ImportBanner({ isDark }: ImportBannerProps) {
 
   const importPath = resolveImportPath(fileName)
   const componentName = extractComponentName(fileName, title)
+  const isInternal = !importPath || !componentName
 
-  const content =
-    !importPath || !componentName ? (
-      <div className="sb-unstyled my-4">
-        <F0Alert
-          variant="warning"
-          title="Internal component"
-          description="This component is not exported from the package and cannot be imported directly. It is used internally by other components."
-        />
-      </div>
-    ) : (
-      <div className="sb-unstyled">
-        <h3 className="mb-2 text-base font-medium text-f1-foreground">
-          Importing this component
-        </h3>
-        <Source
-          code={`import { ${componentName} } from "${importPath}"`}
-          language="tsx"
-          dark={isDark}
-        />
-      </div>
-    )
-
-  if (portalTarget) {
-    return createPortal(content, portalTarget)
+  if (!portalTarget) {
+    // Don't render inline — the portal isn't ready yet on first render
+    return null
   }
 
-  // Don't render inline — the portal isn't ready yet on first render
-  return null
+  const content = (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="sb-unstyled inline-flex cursor-help align-middle">
+            <F0TagRaw
+              text={isInternal ? "Internal component" : "How to import this?"}
+              icon={Code}
+            />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent
+          side="bottom"
+          align="start"
+          className="w-max max-w-[min(90vw,42rem)] overflow-hidden !p-0"
+        >
+          {isInternal ? (
+            <div className="sb-unstyled max-w-xs p-3 text-base text-f1-foreground-inverse">
+              This component is not exported from the package and cannot be
+              imported directly. It is used internally by other components.
+            </div>
+          ) : (
+            <ImportSnippet
+              code={`import { ${componentName} } from "${importPath}"`}
+            />
+          )}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+
+  return createPortal(content, portalTarget)
 }

--- a/packages/react/.storybook/ImportBanner.tsx
+++ b/packages/react/.storybook/ImportBanner.tsx
@@ -37,10 +37,18 @@ function ImportSnippet({ code }: { code: string }) {
       <div className="min-w-0 overflow-x-auto">
         <code className="whitespace-pre font-mono text-base">{code}</code>
       </div>
+      {/* Colors are inline (not Tailwind) because Storybook's Tailwind build
+          doesn't scan `.storybook/` for one-off utilities like `text-white`,
+          which would silently fall back to the default (black) text. */}
       <button
         type="button"
         onClick={onCopy}
-        className="shrink-0 rounded-md border border-solid border-white/25 bg-white/10 px-2 py-1 text-sm font-medium text-white transition-colors hover:bg-white/20"
+        className="shrink-0 rounded-md px-2 py-1 text-sm font-medium transition-colors"
+        style={{
+          color: "#fff",
+          backgroundColor: "rgba(255,255,255,0.1)",
+          border: "1px solid rgba(255,255,255,0.25)",
+        }}
       >
         {copied ? "Copied" : "Copy"}
       </button>
@@ -49,19 +57,26 @@ function ImportSnippet({ code }: { code: string }) {
 }
 
 /**
- * Storybook's docs theme hides `<svg>` inside the title `<h1>` and only reveals
- * it on hover (its heading anchor-link affordance). Our tag icon is portaled
- * into that `<h1>`, so it inherits that rule and appears only on hover. This
- * injects a scoped, !important override that keeps icons inside our own
- * `.sb-unstyled` tag wrappers visible, without touching Storybook's anchor icon.
+ * Storybook renders the docs title as a block `<h1>` with a floated permalink
+ * anchor in the gutter, and hides `<svg>`s inside it (revealing them on hover).
+ * We portal tags into that `<h1>`, so this injects a scoped stylesheet that:
+ *   - lays the title out as a centered flex row so the tags sit vertically
+ *     centered against the title (with a gap between items),
+ *   - takes the floated permalink anchor out of flow so it doesn't offset the
+ *     centered row,
+ *   - keeps icons inside our own `.sb-unstyled` tag wrappers visible (the
+ *     Storybook anchor icon stays hidden-until-hover, untouched).
  */
-function ensureTitleTagIconVisible() {
-  const id = "f0-title-tag-icon-fix"
+function ensureTitleTagStyles() {
+  const id = "f0-title-tag-styles"
   if (document.getElementById(id)) return
   const style = document.createElement("style")
   style.id = id
-  style.textContent =
-    "#storybook-docs h1 .sb-unstyled svg{visibility:visible!important;position:static!important;top:auto!important}"
+  style.textContent = [
+    "#storybook-docs h1{display:flex;align-items:center;flex-wrap:wrap;column-gap:.5rem;row-gap:.25rem}",
+    "#storybook-docs h1>a{position:absolute}",
+    "#storybook-docs h1 .sb-unstyled svg{visibility:visible!important;position:static!important;top:auto!important}",
+  ].join("")
   document.head.appendChild(style)
 }
 
@@ -80,11 +95,10 @@ function usePortalInTitle() {
     )
     if (!titleEl) return
 
-    ensureTitleTagIconVisible()
+    ensureTitleTagStyles()
 
     if (!containerRef.current) {
       const el = document.createElement("span")
-      el.style.marginLeft = "0.5rem"
       el.style.whiteSpace = "nowrap"
       containerRef.current = el
     }

--- a/packages/react/src/component-status/ComponentStability.tsx
+++ b/packages/react/src/component-status/ComponentStability.tsx
@@ -1,5 +1,12 @@
 import React from "react"
 
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/ui/tooltip"
+
 import { A11yRow } from "./A11yRow"
 import {
   getComponentStatus,
@@ -149,5 +156,107 @@ export function ComponentStability({
         </div>
       )}
     </div>
+  )
+}
+
+/**
+ * The maturity summary + Definition-of-Done checklist, rendered statically for
+ * the `ComponentMaturityTag` tooltip. It carries the same information as the
+ * `ComponentStability` panel, but the accessibility row is shown as a plain
+ * status line (no live axe audit) since a tooltip is transient and shouldn't
+ * hold interactive controls.
+ */
+function StatusDetails({ status }: { status: ComponentStatus }) {
+  // The tooltip surface is dark with a white (`f1-foreground-inverse`) base, so
+  // colors are expressed as opacity over that inherited white rather than the
+  // `f1-foreground-secondary` token (which resolves to a too-dim 50% white here).
+  return (
+    <div className="text-f1-foreground-inverse">
+      <p className="m-0 text-base opacity-90">{status.summary}</p>
+
+      {status.showChecklist && (
+        <div role="list" className="mt-3 space-y-3">
+          {status.requirements.map((req) => (
+            <div
+              key={req.key}
+              role="listitem"
+              className="flex items-start gap-2"
+            >
+              <span
+                aria-hidden
+                className={`mt-0.5 shrink-0 ${req.met ? "text-f1-foreground-positive" : "opacity-60"}`}
+              >
+                {req.met ? "✓" : "✕"}
+              </span>
+              <div>
+                <div className="text-base">{req.label}</div>
+                <div className="mt-0.5 text-base opacity-75">
+                  {req.detail}
+                  {req.criteria && req.criteria.length > 0 && (
+                    <div role="list" className="mt-1 space-y-0.5">
+                      {req.criteria.map((criterion) => (
+                        <div
+                          key={criterion.label}
+                          role="listitem"
+                          className="flex items-start gap-2 text-base"
+                        >
+                          <span
+                            aria-hidden
+                            className={`shrink-0 ${criterion.met ? "text-f1-foreground-positive" : "opacity-60"}`}
+                          >
+                            {criterion.met ? "✓" : "✕"}
+                          </span>
+                          <span>{criterion.label}</span>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * The maturity status badge, sized to sit inline next to a component title. On
+ * hover/focus it reveals the full maturity summary and Definition-of-Done
+ * checklist in a tooltip — the same information the `ComponentStability` panel
+ * shows, so collapsing the section loses no context.
+ *
+ * Renders nothing when the name doesn't resolve to a tracked component.
+ */
+export function ComponentMaturityTag({
+  componentName,
+  components,
+  className,
+}: ComponentStabilityProps) {
+  const status = getComponentStatus(componentName, components)
+  if (!status) return null
+
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className={`sb-unstyled inline-flex cursor-help align-middle ${className ?? ""}`}
+          >
+            <StatusBadge status={status} />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent
+          side="bottom"
+          align="start"
+          className="max-h-[70vh] max-w-sm overflow-y-auto"
+        >
+          <div className="sb-unstyled p-1">
+            <StatusDetails status={status} />
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   )
 }


### PR DESCRIPTION
## Description

Collapses the auto-injected "Maturity level" and "Importing this component" docs sections into two compact tags rendered next to each component's title. Each tag reveals its full information on hover in a tooltip, keeping the docs header clean while preserving all the detail that previously took up vertical space above the fold.

## Implementation details

- feat: render the component maturity status as a tag inline next to the docs title; its tooltip shows the summary and the full Definition-of-Done checklist (including the Accessibility row)
- feat: replace the "Importing this component" section with a "How to import this?" tag (F0 `F0TagRaw` with a `</>` icon); its tooltip shows the import statement and a Copy button
- fix: tooltip body text uses the tooltip's inverse (white) foreground with opacity tiers instead of the `f1-foreground-secondary` token, which resolved to an unreadable 50% white on the dark tooltip surface
- fix: inject a scoped `!important` override so the tag icon stays visible — Storybook's docs `<h1>` hides `<svg>`s and only reveals them on hover (its heading-anchor affordance), which the portaled tag icon otherwise inherited
- chore: order the maturity tag before the import tag in the docs container and drop the now-unused `isDark` prop on the import banner

<details>
<summary>Note on the tooltip's accessibility row</summary>

The standalone `ComponentStability` panel renders the a11y row via the interactive `A11yRow` (live axe audit on expand). The tag tooltip instead renders a static accessibility row, since a transient hover tooltip shouldn't hold interactive controls.
</details>