### PR TITLE
feat(F0AiChatHeader): support header actions

### DIFF
--- a/packages/react/src/kits/ai/F0AiChatHeader/F0AiChatHeader.tsx
+++ b/packages/react/src/kits/ai/F0AiChatHeader/F0AiChatHeader.tsx
@@ -10,6 +10,7 @@ import ChevronDown from "@/icons/app/ChevronDown"
 import Cross from "@/icons/app/Cross"
 import Maximize from "@/icons/app/Maximize"
 import Minimize from "@/icons/app/Minimize"
+import { useReducedMotion } from "@/lib/a11y"
 import { OneEllipsis } from "@/lib/OneEllipsis"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
@@ -59,6 +60,7 @@ export const F0AiChatCreditsButton = CreditsPopoverPicker
  * - with-history: title acts as a thread selector (clickable) — the host
  *   wires `onOpenHistory` to mount its own history dialog.
  * - legacy: title is static; a "new chat" button is shown when `hasMessages`.
+ * Hosts can add actions that F0 renders alongside the built-in controls.
  *
  * Decoupled from CopilotKit and `useAiChat()` — everything via props.
  */
@@ -76,8 +78,10 @@ export const F0AiChatHeader = ({
   credits,
   employeeCredits,
   compact = false,
+  actions,
 }: F0AiChatHeaderProps) => {
   const translations = useI18n()
+  const shouldReduceMotion = useReducedMotion()
   const isSmallScreen = useMediaQuery(`(max-width: ${breakpoints.md}px)`, {
     initializeWithValue: true,
   })
@@ -104,10 +108,22 @@ export const F0AiChatHeader = ({
     />
   )
 
+  const actionButtons = actions?.map((action) => (
+    <ButtonInternal
+      key={action.id}
+      variant="ghost"
+      hideLabel
+      label={action.label}
+      icon={action.icon}
+      type="button"
+      onClick={action.onClick}
+    />
+  ))
+
   // Compact: the chat is hosted next to a sidebar that owns navigation (history,
   // new chat) and the credits/settings popover, so the header keeps only the
   // conversation title (plain text — the thread title, or "New chat") plus the
-  // expand + close controls.
+  // host actions, expand + close controls.
   if (compact) {
     return (
       <header
@@ -123,8 +139,12 @@ export const F0AiChatHeader = ({
           className="flex shrink-0 items-center"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
-          transition={{ duration: 0.2, ease: "easeOut" }}
+          transition={{
+            duration: shouldReduceMotion ? 0 : 0.2,
+            ease: "easeOut",
+          }}
         >
+          {actionButtons}
           {expandButton}
           {closeButton}
         </motion.div>
@@ -160,12 +180,16 @@ export const F0AiChatHeader = ({
           className="flex shrink-0 items-center"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
-          transition={{ duration: 0.2, ease: "easeOut" }}
+          transition={{
+            duration: shouldReduceMotion ? 0 : 0.2,
+            ease: "easeOut",
+          }}
         >
           <CreditsPopoverPicker
             credits={credits}
             employeeCredits={employeeCredits}
           />
+          {actionButtons}
           {expandButton}
           {closeButton}
         </motion.div>
@@ -182,7 +206,10 @@ export const F0AiChatHeader = ({
         className="flex items-center"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
-        transition={{ duration: 0.2, ease: "easeOut" }}
+        transition={{
+          duration: shouldReduceMotion ? 0 : 0.2,
+          ease: "easeOut",
+        }}
       >
         {hasMessages && !lockVisualizationMode && (
           <ButtonInternal
@@ -197,6 +224,7 @@ export const F0AiChatHeader = ({
           credits={credits}
           employeeCredits={employeeCredits}
         />
+        {actionButtons}
         {expandButton}
         {closeButton}
       </motion.div>

--- a/packages/react/src/kits/ai/F0AiChatHeader/F0AiChatHeader.tsx
+++ b/packages/react/src/kits/ai/F0AiChatHeader/F0AiChatHeader.tsx
@@ -22,8 +22,8 @@ import { CreditsPopover } from "./components/CreditsPopover"
 import { EmployeeCreditsPopover } from "./components/EmployeeCreditsPopover"
 
 /**
- * Picks the right credits popover to render based on which prop the host
- * provided. `employeeCredits` (employee-only) takes precedence; otherwise
+ * Picks the right credits popover to render based on which prop was provided.
+ * `employeeCredits` (employee-only) takes precedence; otherwise
  * falls back to the classic `credits` popover. Renders nothing when neither
  * is set.
  */
@@ -57,10 +57,10 @@ export const F0AiChatCreditsButton = CreditsPopoverPicker
  * Headless chat header. Renders a top bar with title (or thread selector),
  * credits popover, fullscreen toggle and close button. Has two visual
  * variants:
- * - with-history: title acts as a thread selector (clickable) — the host
- *   wires `onOpenHistory` to mount its own history dialog.
+ * - with-history: title acts as a thread selector (clickable) —
+ *   `onOpenHistory` opens the application's history dialog.
  * - legacy: title is static; a "new chat" button is shown when `hasMessages`.
- * Hosts can add actions that F0 renders alongside the built-in controls.
+ * Applications can add actions that F0 renders alongside the built-in controls.
  *
  * Decoupled from CopilotKit and `useAiChat()` — everything via props.
  */
@@ -120,10 +120,10 @@ export const F0AiChatHeader = ({
     />
   ))
 
-  // Compact: the chat is hosted next to a sidebar that owns navigation (history,
+  // Compact: the chat sits next to a sidebar that owns navigation (history,
   // new chat) and the credits/settings popover, so the header keeps only the
   // conversation title (plain text — the thread title, or "New chat") plus the
-  // host actions, expand + close controls.
+  // header actions, expand + close controls.
   if (compact) {
     return (
       <header

--- a/packages/react/src/kits/ai/F0AiChatHeader/F0AiChatHeader.tsx
+++ b/packages/react/src/kits/ai/F0AiChatHeader/F0AiChatHeader.tsx
@@ -22,8 +22,8 @@ import { CreditsPopover } from "./components/CreditsPopover"
 import { EmployeeCreditsPopover } from "./components/EmployeeCreditsPopover"
 
 /**
- * Picks the right credits popover to render based on which prop was provided.
- * `employeeCredits` (employee-only) takes precedence; otherwise
+ * Picks the right credits popover to render based on which prop the host
+ * provided. `employeeCredits` (employee-only) takes precedence; otherwise
  * falls back to the classic `credits` popover. Renders nothing when neither
  * is set.
  */
@@ -57,10 +57,10 @@ export const F0AiChatCreditsButton = CreditsPopoverPicker
  * Headless chat header. Renders a top bar with title (or thread selector),
  * credits popover, fullscreen toggle and close button. Has two visual
  * variants:
- * - with-history: title acts as a thread selector (clickable) —
- *   `onOpenHistory` opens the application's history dialog.
+ * - with-history: title acts as a thread selector (clickable) — the host
+ *   wires `onOpenHistory` to mount its own history dialog.
  * - legacy: title is static; a "new chat" button is shown when `hasMessages`.
- * Applications can add actions that F0 renders alongside the built-in controls.
+ * Hosts can add header actions that F0 renders alongside the built-in controls.
  *
  * Decoupled from CopilotKit and `useAiChat()` — everything via props.
  */
@@ -120,7 +120,7 @@ export const F0AiChatHeader = ({
     />
   ))
 
-  // Compact: the chat sits next to a sidebar that owns navigation (history,
+  // Compact: the chat is hosted next to a sidebar that owns navigation (history,
   // new chat) and the credits/settings popover, so the header keeps only the
   // conversation title (plain text — the thread title, or "New chat") plus the
   // header actions, expand + close controls.

--- a/packages/react/src/kits/ai/F0AiChatHeader/__stories__/F0AiChatHeader.mdx
+++ b/packages/react/src/kits/ai/F0AiChatHeader/__stories__/F0AiChatHeader.mdx
@@ -1,0 +1,426 @@
+import { Canvas, Meta, Controls, Unstyled } from "@storybook/addon-docs/blocks"
+import * as Stories from "./F0AiChatHeader.stories"
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
+
+<Meta of={Stories} />
+
+# AI chat header
+
+Provides consistent conversation navigation, credits, host actions, fullscreen,
+and close controls for Factorial AI chat surfaces.
+
+## Anatomy
+
+<Canvas of={Stories.Legacy} />
+
+<Controls of={Stories.Legacy} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Prop</th>
+        <th className="text-left">Type</th>
+        <th className="text-left">Default</th>
+        <th className="text-left">Required</th>
+        <th className="text-left">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>historyEnabled</code>
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>
+          <code>false</code>
+        </td>
+        <td>—</td>
+        <td>Turns the title into a conversation-history selector.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>title</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>Static heading used by the legacy mode.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>currentThreadTitle</code>
+        </td>
+        <td>
+          <code>string | null</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>
+          Current conversation title. A null value displays “New conversation”.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>fullscreen</code>
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>
+          <code>false</code>
+        </td>
+        <td>—</td>
+        <td>Switches the panel control between expand and minimize.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>lockVisualizationMode</code>
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>
+          <code>false</code>
+        </td>
+        <td>—</td>
+        <td>Hides controls that change the current visualization mode.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>onToggleVisualizationMode</code>
+        </td>
+        <td>
+          <code>() =&gt; void</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>Handles the expand or minimize action.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>onClose</code>
+        </td>
+        <td>
+          <code>() =&gt; void</code>
+        </td>
+        <td>—</td>
+        <td>Yes</td>
+        <td>Closes the hosting chat surface.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>onNewChat</code>
+        </td>
+        <td>
+          <code>() =&gt; void</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>Starts a new conversation in legacy mode.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>onOpenHistory</code>
+        </td>
+        <td>
+          <code>() =&gt; void</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>Opens the host-owned conversation history.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>hasMessages</code>
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>
+          <code>false</code>
+        </td>
+        <td>—</td>
+        <td>Shows the new-conversation action in legacy mode.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>compact</code>
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>
+          <code>false</code>
+        </td>
+        <td>—</td>
+        <td>
+          Uses a minimal title and action layout for chats with external
+          navigation.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>credits</code>
+        </td>
+        <td>
+          <code>AiChatCredits</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>Configures the classic credits and settings popover.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>employeeCredits</code>
+        </td>
+        <td>
+          <code>AiChatEmployeeCredits</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>
+          Configures employee credits and takes precedence over{" "}
+          <code>credits</code>.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>actions</code>
+        </td>
+        <td>
+          <code>F0AiChatHeaderAction[]</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>Host actions rendered before the fullscreen and close controls.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+**Action fields**
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Field</th>
+        <th className="text-left">Type</th>
+        <th className="text-left">Required</th>
+        <th className="text-left">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>id</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>Yes</td>
+        <td>Stable identifier for the action.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>label</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>Yes</td>
+        <td>Already-localized accessible name and tooltip text.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>icon</code>
+        </td>
+        <td>
+          <code>IconType</code>
+        </td>
+        <td>Yes</td>
+        <td>Icon rendered inside the header action button.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>onClick</code>
+        </td>
+        <td>
+          <code>() =&gt; void</code>
+        </td>
+        <td>Yes</td>
+        <td>Command invoked when the action is activated.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+### Modes
+
+<Canvas of={Stories.WithHistory} />
+
+<Canvas of={Stories.Compact} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Mode</th>
+        <th className="text-left">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Legacy</td>
+        <td>Static title with an optional new-conversation action.</td>
+      </tr>
+      <tr>
+        <td>History</td>
+        <td>Clickable conversation title connected to host-owned history.</td>
+      </tr>
+      <tr>
+        <td>Compact</td>
+        <td>Plain conversation title with host actions and panel controls.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+## Guidelines
+
+### Design best practices
+
+**When to use**
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Situation</th>
+        <th className="text-left">Use F0AiChatHeader when</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Factorial AI conversation panel</td>
+        <td>The host needs consistent conversation and panel controls.</td>
+      </tr>
+      <tr>
+        <td>Product-specific chat destination</td>
+        <td>
+          A small host action must appear alongside the built-in controls.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+**When not to use**
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Situation</th>
+        <th className="text-left">Use instead</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Non-AI messaging</td>
+        <td>
+          <code>F0Chat</code> and its header actions.
+        </td>
+      </tr>
+      <tr>
+        <td>Rich custom header content</td>
+        <td>A product-owned header composed from F0 components.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+**Do's and don'ts**
+
+<DoDonts
+  do={{
+    description:
+      "Pass host actions through the actions prop so F0 owns their spacing, tooltip, and focus behavior.",
+  }}
+  dont={{
+    description:
+      "Do not position actions over the header or depend on its internal DOM structure.",
+  }}
+/>
+
+### Content best practices
+
+- Use short, destination-oriented action labels such as “Routines” or “History”.
+- Avoid generic or sentence-length action labels.
+- Keep conversation titles descriptive enough to distinguish them in history.
+
+### Behavior
+
+- WHEN <code>compact</code> is true → THEN the header displays a plain conversation title, host actions, expand, and close controls.
+- WHEN <code>historyEnabled</code> is true → THEN the conversation title opens host-owned history.
+- WHEN neither compact nor history mode is active → THEN the header displays the static legacy title.
+- WHEN <code>actions</code> are provided → THEN F0 renders them as icon-only ghost buttons immediately before the fullscreen and close controls.
+- WHEN <code>employeeCredits</code> is provided → THEN it replaces the classic <code>credits</code> popover.
+- WHEN <code>lockVisualizationMode</code> is true → THEN visualization-mode controls are hidden.
+- WHEN the viewport is small → THEN the fullscreen control is hidden.
+
+### Usage examples
+
+**Host-provided action**
+
+Use for a localized, icon-based destination or command owned by the chat host.
+
+<Canvas of={Stories.WithHostAction} />
+
+**Locked visualization**
+
+Use when the hosting surface controls whether the chat can change size.
+
+<Canvas of={Stories.LockedMode} />
+
+## Accessibility
+
+Every icon-only control receives its accessible name and tooltip from its label.
+Provide already-localized, unique labels for host actions.
+
+### Keyboard interaction
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Key</th>
+        <th className="text-left">Action</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <kbd>Tab</kbd>
+        </td>
+        <td>Moves focus through the title selector and header actions.</td>
+      </tr>
+      <tr>
+        <td>
+          <kbd>Enter</kbd> / <kbd>Space</kbd>
+        </td>
+        <td>Activates the focused header control.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+### Screen reader behavior
+
+- Host action icons are decorative; <code>action.label</code> provides the accessible name.
+- The current conversation title remains visible text in compact mode and an accessible button in history mode.

--- a/packages/react/src/kits/ai/F0AiChatHeader/__stories__/F0AiChatHeader.mdx
+++ b/packages/react/src/kits/ai/F0AiChatHeader/__stories__/F0AiChatHeader.mdx
@@ -6,7 +6,7 @@ import { DoDonts } from "@/lib/storybook-utils/do-donts"
 
 # AI chat header
 
-Provides consistent conversation navigation, credits, host actions, fullscreen,
+Provides consistent conversation navigation, credits, header actions, fullscreen,
 and close controls for Factorial AI chat surfaces.
 
 ## Anatomy
@@ -110,7 +110,7 @@ and close controls for Factorial AI chat surfaces.
         </td>
         <td>—</td>
         <td>Yes</td>
-        <td>Closes the hosting chat surface.</td>
+        <td>Closes the chat surface.</td>
       </tr>
       <tr>
         <td>
@@ -132,7 +132,7 @@ and close controls for Factorial AI chat surfaces.
         </td>
         <td>—</td>
         <td>—</td>
-        <td>Opens the host-owned conversation history.</td>
+        <td>Opens the conversation history provided by the application.</td>
       </tr>
       <tr>
         <td>
@@ -197,7 +197,9 @@ and close controls for Factorial AI chat surfaces.
         </td>
         <td>—</td>
         <td>—</td>
-        <td>Host actions rendered before the fullscreen and close controls.</td>
+        <td>
+          Additional actions rendered before the fullscreen and close controls.
+        </td>
       </tr>
     </tbody>
   </table>
@@ -281,11 +283,16 @@ and close controls for Factorial AI chat surfaces.
       </tr>
       <tr>
         <td>History</td>
-        <td>Clickable conversation title connected to host-owned history.</td>
+        <td>
+          Clickable conversation title connected to application-provided
+          history.
+        </td>
       </tr>
       <tr>
         <td>Compact</td>
-        <td>Plain conversation title with host actions and panel controls.</td>
+        <td>
+          Plain conversation title with header actions and panel controls.
+        </td>
       </tr>
     </tbody>
   </table>
@@ -308,12 +315,14 @@ and close controls for Factorial AI chat surfaces.
     <tbody>
       <tr>
         <td>Factorial AI conversation panel</td>
-        <td>The host needs consistent conversation and panel controls.</td>
+        <td>
+          The application needs consistent conversation and panel controls.
+        </td>
       </tr>
       <tr>
         <td>Product-specific chat destination</td>
         <td>
-          A small host action must appear alongside the built-in controls.
+          A small header action must appear alongside the built-in controls.
         </td>
       </tr>
     </tbody>
@@ -350,7 +359,7 @@ and close controls for Factorial AI chat surfaces.
 <DoDonts
   do={{
     description:
-      "Pass host actions through the actions prop so F0 owns their spacing, tooltip, and focus behavior.",
+      "Pass header actions through the actions prop so F0 owns their spacing, tooltip, and focus behavior.",
   }}
   dont={{
     description:
@@ -366,8 +375,8 @@ and close controls for Factorial AI chat surfaces.
 
 ### Behavior
 
-- WHEN <code>compact</code> is true → THEN the header displays a plain conversation title, host actions, expand, and close controls.
-- WHEN <code>historyEnabled</code> is true → THEN the conversation title opens host-owned history.
+- WHEN <code>compact</code> is true → THEN the header displays a plain conversation title, header actions, expand, and close controls.
+- WHEN <code>historyEnabled</code> is true → THEN the conversation title opens application-provided history.
 - WHEN neither compact nor history mode is active → THEN the header displays the static legacy title.
 - WHEN <code>actions</code> are provided → THEN F0 renders them as icon-only ghost buttons immediately before the fullscreen and close controls.
 - WHEN <code>employeeCredits</code> is provided → THEN it replaces the classic <code>credits</code> popover.
@@ -376,22 +385,22 @@ and close controls for Factorial AI chat surfaces.
 
 ### Usage examples
 
-**Host-provided action**
+**Additional header action**
 
-Use for a localized, icon-based destination or command owned by the chat host.
+Use for a localized, icon-based destination or command owned by the parent chat surface.
 
-<Canvas of={Stories.WithHostAction} />
+<Canvas of={Stories.WithHeaderAction} />
 
 **Locked visualization**
 
-Use when the hosting surface controls whether the chat can change size.
+Use when the parent chat surface controls whether the chat can change size.
 
 <Canvas of={Stories.LockedMode} />
 
 ## Accessibility
 
 Every icon-only control receives its accessible name and tooltip from its label.
-Provide already-localized, unique labels for host actions.
+Provide already-localized, unique labels for header actions.
 
 ### Keyboard interaction
 
@@ -422,5 +431,5 @@ Provide already-localized, unique labels for host actions.
 
 ### Screen reader behavior
 
-- Host action icons are decorative; <code>action.label</code> provides the accessible name.
+- Header action icons are decorative; <code>action.label</code> provides the accessible name.
 - The current conversation title remains visible text in compact mode and an accessible button in history mode.

--- a/packages/react/src/kits/ai/F0AiChatHeader/__stories__/F0AiChatHeader.mdx
+++ b/packages/react/src/kits/ai/F0AiChatHeader/__stories__/F0AiChatHeader.mdx
@@ -110,7 +110,7 @@ and close controls for Factorial AI chat surfaces.
         </td>
         <td>—</td>
         <td>Yes</td>
-        <td>Closes the chat surface.</td>
+        <td>Closes the hosting chat surface.</td>
       </tr>
       <tr>
         <td>
@@ -132,7 +132,7 @@ and close controls for Factorial AI chat surfaces.
         </td>
         <td>—</td>
         <td>—</td>
-        <td>Opens the conversation history provided by the application.</td>
+        <td>Opens the host-owned conversation history.</td>
       </tr>
       <tr>
         <td>
@@ -283,10 +283,7 @@ and close controls for Factorial AI chat surfaces.
       </tr>
       <tr>
         <td>History</td>
-        <td>
-          Clickable conversation title connected to application-provided
-          history.
-        </td>
+        <td>Clickable conversation title connected to host-owned history.</td>
       </tr>
       <tr>
         <td>Compact</td>
@@ -315,9 +312,7 @@ and close controls for Factorial AI chat surfaces.
     <tbody>
       <tr>
         <td>Factorial AI conversation panel</td>
-        <td>
-          The application needs consistent conversation and panel controls.
-        </td>
+        <td>The host needs consistent conversation and panel controls.</td>
       </tr>
       <tr>
         <td>Product-specific chat destination</td>
@@ -376,7 +371,7 @@ and close controls for Factorial AI chat surfaces.
 ### Behavior
 
 - WHEN <code>compact</code> is true → THEN the header displays a plain conversation title, header actions, expand, and close controls.
-- WHEN <code>historyEnabled</code> is true → THEN the conversation title opens application-provided history.
+- WHEN <code>historyEnabled</code> is true → THEN the conversation title opens host-owned history.
 - WHEN neither compact nor history mode is active → THEN the header displays the static legacy title.
 - WHEN <code>actions</code> are provided → THEN F0 renders them as icon-only ghost buttons immediately before the fullscreen and close controls.
 - WHEN <code>employeeCredits</code> is provided → THEN it replaces the classic <code>credits</code> popover.
@@ -387,13 +382,13 @@ and close controls for Factorial AI chat surfaces.
 
 **Additional header action**
 
-Use for a localized, icon-based destination or command owned by the parent chat surface.
+Use for a localized, icon-based destination or command owned by the chat host.
 
 <Canvas of={Stories.WithHeaderAction} />
 
 **Locked visualization**
 
-Use when the parent chat surface controls whether the chat can change size.
+Use when the hosting surface controls whether the chat can change size.
 
 <Canvas of={Stories.LockedMode} />
 

--- a/packages/react/src/kits/ai/F0AiChatHeader/__stories__/F0AiChatHeader.stories.tsx
+++ b/packages/react/src/kits/ai/F0AiChatHeader/__stories__/F0AiChatHeader.stories.tsx
@@ -82,7 +82,7 @@ export const WithCredits: Story = {
   },
 }
 
-export const WithHostAction: Story = {
+export const WithHeaderAction: Story = {
   args: {
     historyEnabled: true,
     currentThreadTitle: "Discussing perf reviews",
@@ -108,7 +108,7 @@ export const WithHostAction: Story = {
       )
     })
 
-    await step("Invokes the host action", async () => {
+    await step("Invokes the header action", async () => {
       await userEvent.click(action)
       await expect(openRoutines).toHaveBeenCalledOnce()
     })
@@ -174,7 +174,7 @@ export const Snapshot: Story = {
         <F0AiChatHeader {...WithCredits.args} />
       </div>
       <div className="rounded-md border border-solid border-f1-border">
-        <F0AiChatHeader {...WithHostAction.args} />
+        <F0AiChatHeader {...WithHeaderAction.args} />
       </div>
       <div className="rounded-md border border-solid border-f1-border">
         <F0AiChatHeader {...Compact.args} />

--- a/packages/react/src/kits/ai/F0AiChatHeader/__stories__/F0AiChatHeader.stories.tsx
+++ b/packages/react/src/kits/ai/F0AiChatHeader/__stories__/F0AiChatHeader.stories.tsx
@@ -1,4 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
+import { expect, fn, userEvent, within } from "storybook/test"
+
+import { Clock } from "@/icons/app"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import { F0AiChatHeader } from "../F0AiChatHeader"
 
@@ -8,7 +12,7 @@ const meta = {
   parameters: {
     layout: "centered",
   },
-  tags: ["autodocs"],
+  tags: ["!autodocs", "stable"],
   decorators: [
     (Story) => (
       <div className="w-[480px] rounded-md border border-solid border-f1-border bg-f1-background">
@@ -29,6 +33,8 @@ const SAMPLE_CREDITS = {
   planName: "Enterprise",
   upgradePlanUrl: "https://example.com/upgrade",
 }
+
+const openRoutines = fn()
 
 export const Legacy: Story = {
   args: {
@@ -76,6 +82,55 @@ export const WithCredits: Story = {
   },
 }
 
+export const WithHostAction: Story = {
+  args: {
+    historyEnabled: true,
+    currentThreadTitle: "Discussing perf reviews",
+    actions: [
+      {
+        id: "routines",
+        label: "Routines",
+        icon: Clock,
+        onClick: openRoutines,
+      },
+    ],
+    onClose: () => console.log("close"),
+    onOpenHistory: () => console.log("open history"),
+  },
+  play: async ({ canvasElement, step }) => {
+    const page = within(canvasElement.closest("body")!)
+    const action = page.getByRole("button", { name: "Routines" })
+
+    await step("Shows the localized action tooltip", async () => {
+      await userEvent.hover(action)
+      await expect(await page.findByRole("tooltip")).toHaveTextContent(
+        "Routines"
+      )
+    })
+
+    await step("Invokes the host action", async () => {
+      await userEvent.click(action)
+      await expect(openRoutines).toHaveBeenCalledOnce()
+    })
+  },
+}
+
+export const Compact: Story = {
+  args: {
+    compact: true,
+    currentThreadTitle: "Q3 employee review summary",
+    actions: [
+      {
+        id: "routines",
+        label: "Routines",
+        icon: Clock,
+        onClick: openRoutines,
+      },
+    ],
+    onClose: () => console.log("close"),
+  },
+}
+
 export const Fullscreen: Story = {
   args: {
     historyEnabled: true,
@@ -94,4 +149,42 @@ export const LockedMode: Story = {
     lockVisualizationMode: true,
     onClose: () => console.log("close"),
   },
+}
+
+export const Snapshot: Story = {
+  args: {
+    onClose: () => console.log("close"),
+  },
+  parameters: withSnapshot({}),
+  render: () => (
+    <div className="flex flex-col gap-3">
+      <div className="rounded-md border border-solid border-f1-border">
+        <F0AiChatHeader {...Legacy.args} />
+      </div>
+      <div className="rounded-md border border-solid border-f1-border">
+        <F0AiChatHeader {...LegacyWithMessages.args} />
+      </div>
+      <div className="rounded-md border border-solid border-f1-border">
+        <F0AiChatHeader {...WithHistory.args} />
+      </div>
+      <div className="rounded-md border border-solid border-f1-border">
+        <F0AiChatHeader {...WithHistoryNewConversation.args} />
+      </div>
+      <div className="rounded-md border border-solid border-f1-border">
+        <F0AiChatHeader {...WithCredits.args} />
+      </div>
+      <div className="rounded-md border border-solid border-f1-border">
+        <F0AiChatHeader {...WithHostAction.args} />
+      </div>
+      <div className="rounded-md border border-solid border-f1-border">
+        <F0AiChatHeader {...Compact.args} />
+      </div>
+      <div className="rounded-md border border-solid border-f1-border">
+        <F0AiChatHeader {...Fullscreen.args} />
+      </div>
+      <div className="rounded-md border border-solid border-f1-border">
+        <F0AiChatHeader {...LockedMode.args} />
+      </div>
+    </div>
+  ),
 }

--- a/packages/react/src/kits/ai/F0AiChatHeader/__tests__/F0AiChatHeader.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChatHeader/__tests__/F0AiChatHeader.test.tsx
@@ -1,11 +1,19 @@
+import { userEvent } from "@testing-library/user-event"
 import { describe, expect, it, vi } from "vitest"
 
+import { Clock } from "@/icons/app"
 import { zeroRender as render, screen } from "@/testing/test-utils"
-import React from "react"
 
 import { F0AiChatHeader } from "../F0AiChatHeader"
+import type { F0AiChatHeaderProps } from "../types"
 
-describe("F0AiChatHeader compact", () => {
+const modes: Array<[string, Partial<F0AiChatHeaderProps>]> = [
+  ["compact", { compact: true }],
+  ["history", { historyEnabled: true }],
+  ["legacy", {}],
+]
+
+describe("F0AiChatHeader", () => {
   it("renders only the close control (no new chat) in compact mode", () => {
     render(
       <F0AiChatHeader
@@ -62,5 +70,62 @@ describe("F0AiChatHeader compact", () => {
     expect(
       screen.getByRole("button", { name: /start new chat/i })
     ).toBeInTheDocument()
+  })
+
+  it("renders host actions using the built-in header controls", async () => {
+    const user = userEvent.setup()
+    const onClick = vi.fn()
+
+    render(
+      <F0AiChatHeader
+        historyEnabled
+        actions={[
+          {
+            id: "routines",
+            label: "Routines",
+            icon: Clock,
+            onClick,
+          },
+        ]}
+        onClose={vi.fn()}
+      />
+    )
+
+    const action = screen.getByRole("button", { name: "Routines" })
+    await user.hover(action)
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Routines")
+
+    await user.click(action)
+
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+
+  it.each(modes)("renders host actions in %s mode", (_mode, props) => {
+    render(
+      <F0AiChatHeader
+        {...props}
+        actions={[
+          {
+            id: "routines",
+            label: "Routines",
+            icon: Clock,
+            onClick: vi.fn(),
+          },
+        ]}
+        onClose={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: "Routines" })).toBeInTheDocument()
+  })
+
+  it("preserves the built-in controls when actions are omitted", () => {
+    render(<F0AiChatHeader historyEnabled onClose={vi.fn()} />)
+
+    expect(
+      screen.getByRole("button", { name: /close chat/i })
+    ).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "Routines" })).toBeNull()
   })
 })

--- a/packages/react/src/kits/ai/F0AiChatHeader/__tests__/F0AiChatHeader.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChatHeader/__tests__/F0AiChatHeader.test.tsx
@@ -72,7 +72,7 @@ describe("F0AiChatHeader", () => {
     ).toBeInTheDocument()
   })
 
-  it("renders host actions using the built-in header controls", async () => {
+  it("renders additional actions using the built-in header controls", async () => {
     const user = userEvent.setup()
     const onClick = vi.fn()
 
@@ -101,7 +101,7 @@ describe("F0AiChatHeader", () => {
     expect(onClick).toHaveBeenCalledOnce()
   })
 
-  it.each(modes)("renders host actions in %s mode", (_mode, props) => {
+  it.each(modes)("renders additional actions in %s mode", (_mode, props) => {
     render(
       <F0AiChatHeader
         {...props}

--- a/packages/react/src/kits/ai/F0AiChatHeader/components/EmployeeCreditsPopover.tsx
+++ b/packages/react/src/kits/ai/F0AiChatHeader/components/EmployeeCreditsPopover.tsx
@@ -26,7 +26,7 @@ type EmployeeCreditsPopoverProps = {
 /**
  * Employee-only credits popover.
  *
- * Rendered when the host passes `employeeCredits` to the AI provider.
+ * Rendered when the application passes `employeeCredits` to the AI provider.
  * Mutually exclusive with the classic {@link CreditsPopover}: when both
  * `credits` and `employeeCredits` are provided, this one wins.
  *
@@ -34,7 +34,7 @@ type EmployeeCreditsPopoverProps = {
  * (ConnectedChatHeader) reads the value from `useAiChat()` and forwards it.
  *
  * No company-level section, no upgrade CTA — just the logged-in employee's
- * monthly allocation. Hosts opt in by passing `employeeCredits` only for
+ * monthly allocation. Applications opt in by passing `employeeCredits` only for
  * employees who have a per-employee monthly allocation configured.
  */
 export function EmployeeCreditsPopover({

--- a/packages/react/src/kits/ai/F0AiChatHeader/components/EmployeeCreditsPopover.tsx
+++ b/packages/react/src/kits/ai/F0AiChatHeader/components/EmployeeCreditsPopover.tsx
@@ -26,7 +26,7 @@ type EmployeeCreditsPopoverProps = {
 /**
  * Employee-only credits popover.
  *
- * Rendered when the application passes `employeeCredits` to the AI provider.
+ * Rendered when the host passes `employeeCredits` to the AI provider.
  * Mutually exclusive with the classic {@link CreditsPopover}: when both
  * `credits` and `employeeCredits` are provided, this one wins.
  *
@@ -34,7 +34,7 @@ type EmployeeCreditsPopoverProps = {
  * (ConnectedChatHeader) reads the value from `useAiChat()` and forwards it.
  *
  * No company-level section, no upgrade CTA — just the logged-in employee's
- * monthly allocation. Applications opt in by passing `employeeCredits` only for
+ * monthly allocation. Hosts opt in by passing `employeeCredits` only for
  * employees who have a per-employee monthly allocation configured.
  */
 export function EmployeeCreditsPopover({

--- a/packages/react/src/kits/ai/F0AiChatHeader/index.ts
+++ b/packages/react/src/kits/ai/F0AiChatHeader/index.ts
@@ -1,2 +1,2 @@
 export { F0AiChatHeader, F0AiChatCreditsButton } from "./F0AiChatHeader"
-export type { F0AiChatHeaderProps } from "./types"
+export type { F0AiChatHeaderAction, F0AiChatHeaderProps } from "./types"

--- a/packages/react/src/kits/ai/F0AiChatHeader/types.ts
+++ b/packages/react/src/kits/ai/F0AiChatHeader/types.ts
@@ -1,4 +1,15 @@
+import type { IconType } from "@/components/F0Icon"
+
 import type { AiChatCredits, AiChatEmployeeCredits } from "../F0AiChat/types"
+
+export interface F0AiChatHeaderAction {
+  /** Stable identifier used as the React key. */
+  id: string
+  /** Already-localized accessible label and tooltip. */
+  label: string
+  icon: IconType
+  onClick: () => void
+}
 
 export type F0AiChatHeaderProps = {
   /**
@@ -40,9 +51,9 @@ export type F0AiChatHeaderProps = {
   hasMessages?: boolean
 
   /**
-   * Minimal header: render only the expand + close controls (no title, new
-   * chat or credits popover). Use when a sidebar owns the chat navigation and
-   * the credits/settings popover (see `F0AiChatCreditsButton`).
+   * Minimal header: render only host actions plus the expand and close controls
+   * (no title, new chat or credits popover). Use when a sidebar owns the chat
+   * navigation and the credits/settings popover (see `F0AiChatCreditsButton`).
    */
   compact?: boolean
 
@@ -55,4 +66,10 @@ export type F0AiChatHeaderProps = {
    * with `credits`). Hosts opt in per-employee.
    */
   employeeCredits?: AiChatEmployeeCredits
+
+  /**
+   * Host-provided actions rendered immediately before the fullscreen and close
+   * controls. F0 owns their presentation so they match the built-in actions.
+   */
+  actions?: F0AiChatHeaderAction[]
 }

--- a/packages/react/src/kits/ai/F0AiChatHeader/types.ts
+++ b/packages/react/src/kits/ai/F0AiChatHeader/types.ts
@@ -63,7 +63,7 @@ export type F0AiChatHeaderProps = {
   /**
    * Employee-level credits configuration. When present, an employee-only
    * popover is rendered **instead of** the classic one (mutually exclusive
-   * with `credits`). Applications opt in per employee.
+   * with `credits`). Hosts opt in per-employee.
    */
   employeeCredits?: AiChatEmployeeCredits
 

--- a/packages/react/src/kits/ai/F0AiChatHeader/types.ts
+++ b/packages/react/src/kits/ai/F0AiChatHeader/types.ts
@@ -51,7 +51,7 @@ export type F0AiChatHeaderProps = {
   hasMessages?: boolean
 
   /**
-   * Minimal header: render only host actions plus the expand and close controls
+   * Minimal header: render only header actions plus the expand and close controls
    * (no title, new chat or credits popover). Use when a sidebar owns the chat
    * navigation and the credits/settings popover (see `F0AiChatCreditsButton`).
    */
@@ -63,12 +63,12 @@ export type F0AiChatHeaderProps = {
   /**
    * Employee-level credits configuration. When present, an employee-only
    * popover is rendered **instead of** the classic one (mutually exclusive
-   * with `credits`). Hosts opt in per-employee.
+   * with `credits`). Applications opt in per employee.
    */
   employeeCredits?: AiChatEmployeeCredits
 
   /**
-   * Host-provided actions rendered immediately before the fullscreen and close
+   * Additional actions rendered immediately before the fullscreen and close
    * controls. F0 owns their presentation so they match the built-in actions.
    */
   actions?: F0AiChatHeaderAction[]


### PR DESCRIPTION
## Description

Enables Factorial to place the Routines action in the One chat header, beside the built-in fullscreen and close controls.

## Screenshots (if applicable)

<img width="386" height="179" alt="image" src="https://github.com/user-attachments/assets/6020f91f-a46a-4590-9955-257dbee4ab3d" />


[Link to Figma Design](https://www.figma.com/design/qeMk9mbKRa6yO6VeBOkab7/Routines?node-id=2005-5443&t=cafjoWXJ2sAW5zB1-0)

## Implementation details

- feat: add typed header actions rendered with F0’s internal header button
- feat: support header actions across legacy, history, and compact modes
- docs: add manual component documentation, interaction coverage, and consolidated visual snapshot
- fix: respect reduced-motion preferences for header control transitions
- test: cover action rendering, tooltip, callbacks, and backward-compatible omission

## Validation

- `pnpm --filter @factorialco/f0-react format:check src/kits/ai/F0AiChatHeader`
- `pnpm --filter @factorialco/f0-react tsc`
- `pnpm --filter @factorialco/f0-react lint src/kits/ai/F0AiChatHeader`
- `pnpm --filter @factorialco/f0-react vitest --run src/kits/ai/F0AiChatHeader/__tests__/F0AiChatHeader.test.tsx` (9 tests)
- `pnpm build-storybook`
- `pnpm --filter @factorialco/f0-react build`