### PR TITLE
fix(ResourceHeader): use secondary border token for bottom rule

### DIFF
--- a/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
+++ b/packages/react/src/experimental/Information/Headers/BaseHeader/index.tsx
@@ -134,7 +134,8 @@ export function BaseHeader({
         // `border-0` zeroes all sides first so this renders bottom-only even in apps that
         // don't load the Tailwind preflight border reset (otherwise `border-solid` would
         // light up all four sides at the CSS-initial `medium` width).
-        showBottomBorder && "border-0 border-b border-solid border-f1-border"
+        showBottomBorder &&
+          "border-0 border-b border-solid border-f1-border-secondary"
       )}
     >
       <div


### PR DESCRIPTION
## Description

`showBottomBorder` on `BaseHeader`/`ResourceHeader` rendered the header's bottom rule with the primary `f1-border` token, which reads too heavy for a separator line. Every other separator in f0 (table rows, tabs, dropdown menu) already uses `f1-border-secondary`; this aligns the header's bottom rule with that convention. Reported in [FCT-59077](https://factorialmakers.atlassian.net/browse/FCT-59077) against the teams_v2 consumer, but the same token is shared by 6 call sites across the monolith (it_management, goals, teams_v2, ticketing, payroll_bundle) — one of them (`expenses`) had already worked around the heavy border by hand-rolling its own secondary-colored divider instead of using this prop.

## Screenshots 
Before (Left) vs After (Right)
<img width="1423" height="705" alt="Screenshot 2026-07-27 at 12 44 05" src="https://github.com/user-attachments/assets/c9214e96-172f-4462-a319-22a02d1dcbce" />

## Implementation details

- fix: swap the bottom border token on `BaseHeader` from `border-f1-border` to `border-f1-border-secondary` when `showBottomBorder` is set

  <details>
  <summary>Why this token and not a new variant prop?</summary>

  Considered adding a `variant="primary" | "secondary"` prop instead, but rejected it: nobody has asked for the primary/heavy border, two independent consumers (this ticket + the expenses workaround) independently wanted secondary, and a configurable prop would just let the 6 existing call sites drift instead of converging on one correct default. `f1-border` is used elsewhere for container borders (Card, badge, pagination); `f1-border-secondary` is used for separator rules (table, tabs, dropdown-menu) — this bottom rule is a separator, not a container edge.
  </details>

[FCT-59077]: https://factorialmakers.atlassian.net/browse/FCT-59077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ