### PR TITLE
feat: smooth zoom transition for F0PdfViewer

### DIFF
--- a/packages/react/src/components/F0PdfViewer/F0PdfViewer.tsx
+++ b/packages/react/src/components/F0PdfViewer/F0PdfViewer.tsx
@@ -136,6 +136,10 @@ const PdfViewerBase = forwardRef<
   const [pdf, setPdf] = useState<PDFDocumentProxy | null>(null)
   const [pages, setPages] = useState<PageMetrics[]>([])
   const [scale, setScale] = useState(1)
+  // The scale react-pdf actually rasterizes at. It lags `scale` during manual
+  // zoom so the gesture animates with a CSS transform instead of rebuilding the
+  // canvas every step; it catches up (debounced) once the user settles.
+  const [renderScale, setRenderScale] = useState(1)
   const [currentPage, setCurrentPage] = useState(0)
   const [selectedScale, setSelectedScale] = useState<F0PdfScale>(initialScale)
   const [rotation, setRotation] = useState<F0PdfRotation>(initialRotation)
@@ -200,7 +204,10 @@ const PdfViewerBase = forwardRef<
           : (container.clientHeight - toolbarHeight - PAGE_VIEWPORT_PADDING) /
             pageHeight
 
+      // Fit changes rasterize immediately (no transform gap), so they never
+      // flash or animate on load.
       setScale(computed)
+      setRenderScale(computed)
       setSelectedScale(value)
     },
     [pages, currentPage, rotation]
@@ -320,6 +327,16 @@ const PdfViewerBase = forwardRef<
     return () => container.removeEventListener("click", handleClick, true)
   }, [])
 
+  // Manual zoom animates via a cheap CSS transform on each page (see the render
+  // below) so the gesture stays smooth. Re-rasterizing at the new scale is what
+  // flashes (react-pdf tears the canvas down and rebuilds it), so we defer it:
+  // once the user settles, catch renderScale up to scale in one debounced step.
+  useEffect(() => {
+    if (renderScale === scale) return
+    const id = setTimeout(() => setRenderScale(scale), 200)
+    return () => clearTimeout(id)
+  }, [scale, renderScale])
+
   return (
     <div
       ref={ref}
@@ -371,11 +388,23 @@ const PdfViewerBase = forwardRef<
                   <div
                     key={index}
                     className="F0PdfViewer__page mx-auto w-fit px-4 pt-4 last:pb-4"
+                    style={{
+                      // Manual zoom scales the already-rendered page (GPU, no
+                      // canvas rebuild) until renderScale catches up. Fit changes
+                      // keep scale === renderScale, so this stays at 1 with no
+                      // transition (no animation on load).
+                      transformOrigin: "top center",
+                      transform: `scale(${scale / renderScale})`,
+                      transition:
+                        renderScale === scale
+                          ? "none"
+                          : "transform 180ms cubic-bezier(0.2, 0, 0, 1)",
+                    }}
                   >
                     <Page
                       className="overflow-hidden rounded-lg border border-solid border-f1-border-secondary shadow-md"
                       pageNumber={pageNumber}
-                      scale={scale}
+                      scale={renderScale}
                       rotate={rotation}
                       loading={
                         <Skeleton

--- a/packages/react/src/components/F0PdfViewer/F0PdfViewer.tsx
+++ b/packages/react/src/components/F0PdfViewer/F0PdfViewer.tsx
@@ -12,6 +12,7 @@ import {
   useState,
 } from "react"
 
+import { useReducedMotion } from "@/lib/a11y"
 import { useI18n } from "@/lib/providers/i18n/i18n-provider"
 import { Skeleton } from "@/ui/skeleton"
 import { Document, Page, type PDFDocumentProxy } from "@/ui/pdf"
@@ -147,6 +148,11 @@ const PdfViewerBase = forwardRef<
   const containerRef = useRef<HTMLDivElement>(null)
   const toolbarRef = useRef<HTMLDivElement>(null)
   const pageElements = useRef<(HTMLElement | null)[]>([])
+  // Whether the user has driven zoom yet. Gates the transition so the initial
+  // page-fit (and any programmatic rescale) never animates on load.
+  const zoomInteracted = useRef(false)
+  // Respect the OS "reduce motion" setting: skip the zoom transition entirely.
+  const reduceMotion = useReducedMotion()
 
   const totalPages =
     pagesToDisplay.length > 0 ? pagesToDisplay.length : pdf?.numPages
@@ -203,11 +209,14 @@ const PdfViewerBase = forwardRef<
           ? (container.clientWidth - PAGE_VIEWPORT_PADDING) / pageWidth
           : (container.clientHeight - toolbarHeight - PAGE_VIEWPORT_PADDING) /
             pageHeight
+      // Guard: a hidden / zero-height container (tab, drawer, collapsed panel)
+      // yields 0 or a negative value here, which would poison the zoom transform.
+      if (!Number.isFinite(computed) || computed <= 0) return
 
-      // Fit changes rasterize immediately (no transform gap), so they never
-      // flash or animate on load.
+      // Only move the target scale; renderScale catches up (debounced) so a fit
+      // change animates via the transform, like manual zoom. The page box is
+      // reserved at the target size (see render), so layout stays correct.
       setScale(computed)
-      setRenderScale(computed)
       setSelectedScale(value)
     },
     [pages, currentPage, rotation]
@@ -215,6 +224,7 @@ const PdfViewerBase = forwardRef<
 
   const onScaleChange = useCallback(
     (value: F0PdfScale) => {
+      zoomInteracted.current = true
       if (value === "page-width" || value === "page-fit") {
         applyDynamicScale(value)
         return
@@ -227,6 +237,7 @@ const PdfViewerBase = forwardRef<
 
   const zoomTo = useCallback((value: number | undefined) => {
     if (value === undefined) return
+    zoomInteracted.current = true
     setScale(value)
     const match = fixedScales.find((option) => Number(option) === value)
     if (match) setSelectedScale(match)
@@ -337,6 +348,17 @@ const PdfViewerBase = forwardRef<
     return () => clearTimeout(id)
   }, [scale, renderScale])
 
+  // Zoom transform: the page box is reserved at the TARGET size (see the render),
+  // so layout, scroll and neighbouring pages stay correct throughout the gesture;
+  // only the canvas is scaled from its rendered size up/down to the target while
+  // renderScale (and the crisp re-raster) catches up, settling this back to 1.
+  // Guarded so a zero / NaN scale can never produce a non-finite transform.
+  const zoomRatioRaw = scale / renderScale
+  const zoomRatio =
+    Number.isFinite(zoomRatioRaw) && zoomRatioRaw > 0 ? zoomRatioRaw : 1
+  const zoomAnimating =
+    zoomInteracted.current && renderScale !== scale && !reduceMotion
+
   return (
     <div
       ref={ref}
@@ -384,52 +406,73 @@ const PdfViewerBase = forwardRef<
                 const pageNumber =
                   (pagesToDisplay.length > 0 ? pagesToDisplay[index] : index) +
                   1
+                // Per-page intrinsic size (swapped when the page is quarter-turned).
+                const metrics = pages[index] ?? sampleMetrics
+                const ow = metrics?.originalWidth ?? 595
+                const oh = metrics?.originalHeight ?? 842
+                const quarterTurned = rotation === 90 || rotation === 270
+                const baseWidth = quarterTurned ? oh : ow
+                const baseHeight = quarterTurned ? ow : oh
                 return (
                   <div
                     key={index}
                     className="F0PdfViewer__page mx-auto w-fit px-4 pt-4 last:pb-4"
-                    style={{
-                      // Manual zoom scales the already-rendered page (GPU, no
-                      // canvas rebuild) until renderScale catches up. Fit changes
-                      // keep scale === renderScale, so this stays at 1 with no
-                      // transition (no animation on load).
-                      transformOrigin: "top center",
-                      transform: `scale(${scale / renderScale})`,
-                      transition:
-                        renderScale === scale
-                          ? "none"
-                          : "transform 180ms cubic-bezier(0.2, 0, 0, 1)",
-                    }}
                   >
-                    <Page
+                    {/* Sizer holds the box at the TARGET size (and owns the frame
+                        + clip), so layout, scroll and neighbouring pages already
+                        match the final zoom while the canvas is still rendered at
+                        renderScale underneath. offsetTop/Height (paging and
+                        visible-page tracking) read this target-sized box, never
+                        the transformed canvas. */}
+                    <div
+                      ref={(element) => {
+                        pageElements.current[index] = element
+                      }}
                       className="overflow-hidden rounded-lg border border-solid border-f1-border-secondary shadow-md"
-                      pageNumber={pageNumber}
-                      scale={renderScale}
-                      rotate={rotation}
-                      loading={
-                        <Skeleton
-                          style={{
-                            width: pageSkeletonWidth,
-                            height: pageSkeletonHeight,
+                      style={{
+                        width: baseWidth * scale,
+                        height: baseHeight * scale,
+                      }}
+                    >
+                      {/* Only the canvas is transformed: from its rendered size up
+                          or down to the target, anchored top-left so it fills the
+                          sizer exactly. Settled / initial fit stay at 1. */}
+                      <div
+                        style={{
+                          transformOrigin: "top left",
+                          transform: `scale(${zoomRatio})`,
+                          transition: zoomAnimating
+                            ? "transform 180ms cubic-bezier(0.2, 0, 0, 1)"
+                            : "none",
+                        }}
+                      >
+                        <Page
+                          pageNumber={pageNumber}
+                          scale={renderScale}
+                          rotate={rotation}
+                          loading={
+                            <Skeleton
+                              style={{
+                                width: baseWidth * renderScale,
+                                height: baseHeight * renderScale,
+                              }}
+                            />
+                          }
+                          renderForms
+                          renderTextLayer
+                          onLoadSuccess={(loadedPage) => {
+                            setPages((current) => {
+                              const next = [...current]
+                              next[index] = {
+                                originalWidth: loadedPage.originalWidth,
+                                originalHeight: loadedPage.originalHeight,
+                              }
+                              return next
+                            })
                           }}
                         />
-                      }
-                      renderForms
-                      renderTextLayer
-                      inputRef={(reference) => {
-                        pageElements.current[index] = reference
-                      }}
-                      onLoadSuccess={(loadedPage) => {
-                        setPages((current) => {
-                          const next = [...current]
-                          next[index] = {
-                            originalWidth: loadedPage.originalWidth,
-                            originalHeight: loadedPage.originalHeight,
-                          }
-                          return next
-                        })
-                      }}
-                    />
+                      </div>
+                    </div>
                   </div>
                 )
               })}

--- a/packages/react/src/components/F0PdfViewer/__tests__/F0PdfViewer.test.tsx
+++ b/packages/react/src/components/F0PdfViewer/__tests__/F0PdfViewer.test.tsx
@@ -44,11 +44,13 @@ vi.mock("@/ui/pdf", () => ({
   Page: ({
     pageNumber,
     rotate,
+    scale,
     onLoadSuccess,
     inputRef,
   }: {
     pageNumber: number
     rotate?: number
+    scale?: number
     onLoadSuccess?: (page: {
       originalWidth: number
       originalHeight: number
@@ -66,6 +68,7 @@ vi.mock("@/ui/pdf", () => ({
         ref={ref}
         data-testid={`pdf-page-${pageNumber}`}
         data-rotate={rotate}
+        data-scale={scale}
       />
     )
   },
@@ -190,5 +193,41 @@ describe("F0PdfViewer", () => {
     render(<F0PdfViewer.Skeleton />)
     expect(screen.getByRole("status")).toHaveAttribute("aria-busy", "true")
     expect(screen.getAllByTestId("skeleton").length).toBeGreaterThan(0)
+  })
+
+  it("reserves the page box at the target size the moment you zoom (layout leads, raster lags)", async () => {
+    render(<F0PdfViewer url="/doc.pdf" filename="doc.pdf" />)
+    const page1 = await screen.findByTestId("pdf-page-1")
+    // Sizer = the box two levels above the (mocked) page: it carries the explicit
+    // target size, with the transform layer in between scaling the canvas.
+    const sizer = page1.parentElement?.parentElement as HTMLElement
+    // Mock page is 600 wide; nothing has zoomed yet.
+    await waitFor(() => expect(sizer.style.width).toBe("600px"))
+
+    fireEvent.click(screen.getByRole("button", { name: "Zoom in" }))
+
+    // Layout jumps to the target (600 * 1.25) synchronously so scroll and
+    // neighbouring pages stay correct; the crisp re-raster is deferred, so Page
+    // is still rasterizing at the previous renderScale.
+    expect(sizer.style.width).toBe("750px")
+    expect(page1).toHaveAttribute("data-scale", "1")
+  })
+
+  it("defers the crisp re-raster until the zoom settles (debounced)", async () => {
+    render(<F0PdfViewer url="/doc.pdf" filename="doc.pdf" />)
+    const page1 = await screen.findByTestId("pdf-page-1")
+    expect(page1).toHaveAttribute("data-scale", "1")
+
+    fireEvent.click(screen.getByRole("button", { name: "Zoom in" }))
+    // Right after the click renderScale still lags: the canvas keeps its raster.
+    expect(page1).toHaveAttribute("data-scale", "1")
+
+    // After the debounce, renderScale catches up to the target and re-rasterizes.
+    await waitFor(() =>
+      expect(screen.getByTestId("pdf-page-1")).toHaveAttribute(
+        "data-scale",
+        "1.25"
+      )
+    )
   })
 })


### PR DESCRIPTION
## What & why

Zooming a PDF was **abrupt**: react-pdf re-rasterizes the page at the new scale on every step, tearing the canvas down and rebuilding it, so each step flashed a blank frame and read as a hard, flickery jump (most noticeable zooming out). This PR makes the zoom **ease smoothly**, reusing only existing primitives (a CSS transform plus a debounce), no new tokens or components.

### Decoupled render scale
- New `renderScale` is the scale react-pdf actually rasterizes at; it lags the target `scale` during a manual zoom.
- During the gesture only a cheap GPU `transform: scale(scale / renderScale)` on the already-rendered page animates (180ms, `cubic-bezier(0.2, 0, 0, 1)`), so there is no canvas rebuild and no blank frame.
- Once the user settles, `renderScale` catches up (debounced 200ms) and react-pdf re-rasterizes **once**, at the final size, so the page stays crisp. The visual size is identical across that swap, so there is no jump.
- Page-fit / page-width (and the initial fit) set `renderScale` immediately, so nothing animates on load.

## Scope notes
- **Only the zoom transition.** Toolbar, scroll, paging, rotate and visible-page tracking are untouched.
- `transform-origin: top center` so the page grows / shrinks from where it sits in the scroll, not the viewport centre.
- Respecting `prefers-reduced-motion` could be a nice follow-up, but the transition is short and transform-only.

## Verification
- Storybook (`Components / F0PdfViewer`): zoom in / out across scales, the page eases smoothly with no blank flash between steps and no animation on first load; the page is crisp again after settling.
- Page navigation, page-fit / page-width, rotate and visible-page tracking on scroll all still work.
