### PR TITLE
feat(EditableTable): support per-row dateConfig function for date cells

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/editable-table/editable-table.stories.tsx
@@ -1,5 +1,5 @@
 import { Meta, StoryObj } from "@storybook/react-vite"
-import { format } from "date-fns"
+import { format, parseISO } from "date-fns"
 import { useMemo, useRef, useState } from "react"
 import { action } from "storybook/actions"
 
@@ -1326,6 +1326,140 @@ export const EditableTableWithDateCellMinMax: Story = {
         ]}
         dataAdapter={dataAdapter}
         id="editable-table-date-min-max/v1"
+      />
+    )
+  },
+}
+
+export const EditableTableWithPerRowDateConfig: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "`dateConfig` as a per-row function `(item) => ({ minDate, maxDate })`. The End date picker's `minDate` — and therefore the month it opens on, since the picker's default month follows `minDate` — tracks each row's Start date, so an empty/unset End cell opens the calendar on that row's start. The Start date picker's `maxDate` tracks each row's End date. To test: the three rows have different start dates, so opening each End picker opens on a different month; then change a row's Start date and reopen its End picker — it now opens on the new start month, and earlier dates are disabled.",
+      },
+    },
+  },
+  render: () => {
+    type Hire = RecordType & {
+      name: string
+      email: string
+      department: (typeof import("@/mocks").DEPARTMENTS_MOCK)[number]
+      startDate: string
+      endDate: string
+    }
+
+    const initialItems: Hire[] = [
+      {
+        index: 0,
+        id: "hire-1",
+        name: "Ada Lovelace",
+        email: "",
+        department: "Engineering",
+        startDate: "2026-09-01",
+        endDate: "2027-08-31",
+      },
+      {
+        index: 1,
+        id: "hire-2",
+        name: "Alan Turing",
+        email: "",
+        department: "Engineering",
+        startDate: "2026-11-15",
+        endDate: "2027-11-14",
+      },
+      {
+        index: 2,
+        id: "hire-3",
+        name: "Grace Hopper",
+        email: "",
+        department: "Engineering",
+        startDate: "2027-02-01",
+        endDate: "2027-12-31",
+      },
+    ]
+
+    const [items, setItems] = useState<Hire[]>(initialItems)
+    const itemsRef = useRef(items)
+    itemsRef.current = items
+
+    const onCellChange = async ({ updatedItem }: { updatedItem: Hire }) => {
+      action("onCellChange")(updatedItem)
+      setItems((prev) =>
+        prev.map((i) => (i.id === updatedItem.id ? updatedItem : i))
+      )
+    }
+
+    const dataAdapter = useMemo(() => {
+      const adapter = createDataAdapter({
+        data: items,
+        paginationType: "pages",
+        perPage: 10,
+      })
+      adapter.fetchData = (fetchOptions: unknown) => {
+        const currentAdapter = createDataAdapter({
+          data: itemsRef.current,
+          paginationType: "pages",
+          perPage: 10,
+        })
+        return currentAdapter.fetchData(fetchOptions as never)
+      }
+      return adapter
+    }, [items])
+
+    const source = useDataCollectionSource<
+      Hire,
+      Record<string, never>,
+      never,
+      never,
+      never,
+      never,
+      never
+    >({
+      dataAdapter,
+    })
+
+    return (
+      <OneDataCollection
+        source={source}
+        visualizations={[
+          {
+            type: "editableTable" as const,
+            options: {
+              columns: [
+                {
+                  label: "Name",
+                  id: "name",
+                  width: 200,
+                  editType: () => "text" as const,
+                  render: (item: Hire) => item.name,
+                },
+                {
+                  label: "Start date (≤ end date)",
+                  id: "startDate",
+                  editType: () => "date" as const,
+                  inputPlaceholder: "DD/MM/YYYY",
+                  render: (item: Hire) => item.startDate,
+                  dateConfig: (item: Hire) => ({
+                    maxDate: parseISO(item.endDate),
+                  }),
+                },
+                {
+                  label: "End date (opens on start)",
+                  id: "endDate",
+                  editType: () => "date" as const,
+                  inputPlaceholder: "DD/MM/YYYY",
+                  render: (item: Hire) => item.endDate,
+                  dateConfig: (item: Hire) => ({
+                    minDate: parseISO(item.startDate),
+                  }),
+                },
+              ],
+              onCellChange,
+            },
+          },
+        ]}
+        id="editable-table-per-row-date-config/v1"
       />
     )
   },

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/DateCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/DateCell.test.tsx
@@ -65,4 +65,26 @@ describe("DateCell", () => {
     expect(pickerProps.minDate).toBe(minDate)
     expect(pickerProps.maxDate).toBe(maxDate)
   })
+
+  it("resolves a per-row dateConfig function against the current item", () => {
+    const startDate = "2026-06-15"
+
+    render(
+      <DateCell
+        {...defaultProps}
+        item={{ id: "1", startDate }}
+        editableColumn={makeEditableColumn({
+          dateConfig: (item) => ({
+            minDate: item.startDate ? new Date(item.startDate) : undefined,
+          }),
+        })}
+      />
+    )
+
+    const pickerProps = f0DatePickerMock.mock.calls.at(-1)?.[0] as {
+      minDate?: Date
+    }
+
+    expect(pickerProps.minDate).toEqual(new Date(startDate))
+  })
 })

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/DateCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/DateCell.tsx
@@ -22,8 +22,12 @@ export function DateCell<R extends RecordType>({
   isLastColumn,
   onChange,
   hint,
+  item,
 }: EditableCellProps<R>) {
-  const dateConfig = editableColumn.dateConfig
+  const dateConfig =
+    typeof editableColumn.dateConfig === "function"
+      ? editableColumn.dateConfig(item)
+      : editableColumn.dateConfig
 
   const datePickerValue = useMemo<DatePickerValue | undefined>(() => {
     if (!value) return undefined

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
@@ -185,8 +185,14 @@ export type EditableTableColumnDefinition<
   /**
    * Configuration for `"date"` cells. Accepts `minDate` / `maxDate` to
    * restrict the selectable date range in the picker.
+   *
+   * Can be a static object or a function that receives the current row item
+   * to return a per-row range (e.g. bound one date field by another field's
+   * value: `(item) => ({ minDate: parseISO(item.startDate) })`). The picker's
+   * default visible month follows `minDate`, so a per-row `minDate` also
+   * opens the calendar on that date.
    */
-  dateConfig?: DateCellConfig
+  dateConfig?: DateCellConfig | ((item: R) => DateCellConfig)
 
   /**
    * Called after this cell's value changes. Use to compute derived values


### PR DESCRIPTION
## Description

Lets an editable-table date column's `dateConfig` be a **function of the row item** (`(item) => DateCellConfig`) as well as a static object. This makes a date cell's `minDate`/`maxDate` able to depend on other fields in the same row — e.g. bounding an end date's lower bound by that row's start date — which the current static, per-column config can't express.

https://github.com/user-attachments/assets/bd96ae32-310c-4817-83c9-b11c1c10ccce

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)

## Implementation details

- `EditableTable/types.ts` — `dateConfig?: DateCellConfig | ((item: R) => DateCellConfig)`, mirroring the existing `numberConfig.units` static-or-function convention.
- `EditableTable/components/cells/DateCell.tsx` — resolves the config against the current row item before reading `minDate`/`maxDate`.
- The read-only cell only uses `dateConfig` as a truthy "is this a date column?" flag, so a function value works there unchanged.
- Added an interactive story (`EditableTableWithPerRowDateConfig`) with rows carrying different start/end dates, demonstrating per-row bounds.

Backward compatible — the static-object form is unchanged.
