### PR TITLE
feat(F0ProgressSeries): add multi-bar progress series component

### DIFF
--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -68,6 +68,10 @@ const config: StorybookConfig = {
       titlePrefix: "Components",
     },
     {
+      directory: "../src/experimental/F0ProgressSeries",
+      titlePrefix: "Components",
+    },
+    {
       directory: "../src/experimental/F0SegmentedBar",
       titlePrefix: "Components",
     },

--- a/packages/react/src/experimental/F0ProgressSeries/F0ProgressSeries.tsx
+++ b/packages/react/src/experimental/F0ProgressSeries/F0ProgressSeries.tsx
@@ -16,20 +16,22 @@ import {
 
 import {
   F0ProgressSeriesBar,
+  F0ProgressSeriesColor,
   F0ProgressSeriesProps,
   F0ProgressSeriesSize,
 } from "./types"
 
 export type {
   F0ProgressSeriesBar,
+  F0ProgressSeriesColor,
   F0ProgressSeriesOptions,
   F0ProgressSeriesProps,
   F0ProgressSeriesSize,
 } from "./types"
-export { f0ProgressSeriesSizes } from "./types"
+export { f0ProgressSeriesColors, f0ProgressSeriesSizes } from "./types"
 
 const DEFAULT_MAX_LABELS = 4
-const DEFAULT_COLOR = "categorical-1"
+const DEFAULT_COLOR: F0ProgressSeriesColor = "categorical-1"
 /** Opacity of the lighter "overachievement" shade drawn past the target. */
 const OVERACHIEVEMENT_OPACITY = 0.5
 /** Past this many bars the row switches to a tighter, squarer rhythm. */
@@ -86,7 +88,13 @@ function formatPair(
  *   percentage") — base color up to the target, then a lighter shade of the
  *   same color for the overachievement. E.g. 158% → ~63% solid + ~37% lighter.
  */
-function BarFill({ pct, color }: { pct: number; color: string }) {
+function BarFill({
+  pct,
+  color,
+}: {
+  pct: number
+  color: F0ProgressSeriesColor
+}) {
   const base = getColor(color)
 
   if (pct <= 100) {

--- a/packages/react/src/experimental/F0ProgressSeries/F0ProgressSeries.tsx
+++ b/packages/react/src/experimental/F0ProgressSeries/F0ProgressSeries.tsx
@@ -1,0 +1,312 @@
+import { forwardRef } from "react"
+
+import { getColor } from "@/kits/Charts/utils/colors"
+import { withDataTestId } from "@/lib/data-testid"
+import { experimentalComponent } from "@/lib/experimental"
+import { useI18n } from "@/lib/providers/i18n"
+import { TranslationsType } from "@/lib/providers/i18n/i18n-provider-defaults"
+import { cn, focusRing } from "@/lib/utils"
+import { Skeleton } from "@/ui/skeleton"
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/ui/tooltip"
+
+import {
+  F0ProgressSeriesBar,
+  F0ProgressSeriesProps,
+  F0ProgressSeriesSize,
+} from "./types"
+
+export type {
+  F0ProgressSeriesBar,
+  F0ProgressSeriesOptions,
+  F0ProgressSeriesProps,
+  F0ProgressSeriesSize,
+} from "./types"
+export { f0ProgressSeriesSizes } from "./types"
+
+const DEFAULT_MAX_LABELS = 4
+const DEFAULT_COLOR = "categorical-1"
+/** Opacity of the lighter "overachievement" shade drawn past the target. */
+const OVERACHIEVEMENT_OPACITY = 0.5
+/** Past this many bars the row switches to a tighter, squarer rhythm. */
+const DENSE_FROM = 4
+
+const HEIGHT_CLASS: Record<F0ProgressSeriesSize, string> = {
+  sm: "h-1.5",
+  md: "h-2",
+  lg: "h-3",
+}
+
+/** The label row scales with the bar, capped at `text-sm` (12px) — the size the
+ * `progressBar` value display uses. A taller bar doesn't warrant bigger text. */
+const LABEL_CLASS: Record<F0ProgressSeriesSize, string> = {
+  sm: "text-xs",
+  md: "text-sm",
+  lg: "text-sm",
+}
+
+const FILL_CLASS =
+  "h-full transition-all duration-300 ease-in-out motion-reduce:transition-none"
+/** Diagonal hatch so a cancelled bar reads as void, not merely empty. */
+const CANCELED_STRIPES_CLASS =
+  "[background-image:repeating-linear-gradient(45deg,transparent,transparent_3px,rgba(0,0,0,0.16)_3px,rgba(0,0,0,0.16)_6px)] dark:[background-image:repeating-linear-gradient(45deg,transparent,transparent_3px,rgba(255,255,255,0.2)_3px,rgba(255,255,255,0.2)_6px)]"
+
+function formatPct(pct: number): string {
+  return `${pct % 1 === 0 ? pct.toFixed(0) : pct.toFixed(1)}%`
+}
+
+const TRAILING_UNIT = /\D*$/
+
+/**
+ * `1.700 € / 3.400 €` repeats the unit; `1.700 / 3.400 €` reads better. So a
+ * trailing unit shared by both sides is dropped from the first number. Prefixed
+ * units (`$1,700`) are left alone — stripping those would read wrong.
+ */
+function formatPair(
+  value: number,
+  max: number,
+  formatValue: (value: number) => string
+): string {
+  const from = formatValue(value)
+  const to = formatValue(max)
+  const unit = to.match(TRAILING_UNIT)?.[0] ?? ""
+  const trimmed = unit && from.endsWith(unit) ? from.slice(0, -unit.length) : ""
+
+  return `${trimmed || from} / ${to}`
+}
+
+/**
+ * The coloured fill inside a bar.
+ * - At/under 100%: a single segment `pct%` wide, in the base color.
+ * - Over 100%: the bar is full and split at `100 / pct` (the "inverse
+ *   percentage") — base color up to the target, then a lighter shade of the
+ *   same color for the overachievement. E.g. 158% → ~63% solid + ~37% lighter.
+ */
+function BarFill({ pct, color }: { pct: number; color: string }) {
+  const base = getColor(color)
+
+  if (pct <= 100) {
+    return (
+      <div
+        className={FILL_CLASS}
+        style={{ width: `${Math.max(0, pct)}%`, backgroundColor: base }}
+      />
+    )
+  }
+
+  const baseWidth = (100 / pct) * 100
+  return (
+    <div className="flex h-full w-full">
+      <div
+        className={FILL_CLASS}
+        style={{ width: `${baseWidth}%`, backgroundColor: base }}
+      />
+      <div
+        className={FILL_CLASS}
+        style={{
+          width: `${100 - baseWidth}%`,
+          backgroundColor: getColor(color, OVERACHIEVEMENT_OPACITY),
+        }}
+      />
+    </div>
+  )
+}
+
+interface ResolvedBar {
+  bar: F0ProgressSeriesBar
+  isEmpty: boolean
+  pct: number
+  caption: string
+  /** Used both as the tooltip content and as the bar's accessible name, so the
+   * tooltip detail is never sighted-only. */
+  tooltip: string
+}
+
+function resolveBar(
+  bar: F0ProgressSeriesBar,
+  i18n: TranslationsType,
+  formatValue: (value: number) => string
+): ResolvedBar {
+  const max = bar.max ?? 100
+  const isEmpty =
+    bar.value === undefined ||
+    !Number.isFinite(bar.value) ||
+    !Number.isFinite(max) ||
+    max <= 0
+  const pct = isEmpty ? 0 : ((bar.value as number) / max) * 100
+
+  const detail = bar.canceled
+    ? i18n.progressSeries.canceled
+    : isEmpty
+      ? i18n.progressSeries.noData
+      : `${formatPair(bar.value as number, max, formatValue)} (${formatPct(pct)})`
+
+  return {
+    bar,
+    isEmpty,
+    pct,
+    caption:
+      bar.canceled || isEmpty
+        ? (bar.caption ?? "")
+        : (bar.caption ?? formatPct(pct)),
+    tooltip: bar.tooltip ?? (bar.label ? `${bar.label} · ${detail}` : detail),
+  }
+}
+
+function BarTrack({
+  resolved,
+  rounded,
+  hideTooltip,
+}: {
+  resolved: ResolvedBar
+  rounded: string
+  hideTooltip?: boolean
+}) {
+  const { bar, isEmpty, pct, tooltip } = resolved
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          role="img"
+          aria-label={tooltip}
+          tabIndex={0}
+          className={cn(
+            "pointer-events-auto relative h-full min-w-[3px] flex-1 cursor-default overflow-hidden",
+            focusRing(),
+            rounded,
+            bar.canceled
+              ? cn("bg-f1-foreground-disabled", CANCELED_STRIPES_CLASS)
+              : "bg-f1-background-secondary"
+          )}
+        >
+          {!isEmpty && !bar.canceled && (
+            <BarFill pct={pct} color={bar.color ?? DEFAULT_COLOR} />
+          )}
+        </div>
+      </TooltipTrigger>
+      {!hideTooltip && (
+        <TooltipContent className="text-sm">{tooltip}</TooltipContent>
+      )}
+    </Tooltip>
+  )
+}
+
+/** Label + caption under a bar. Hidden from screen readers: the bar's own
+ * `aria-label` already announces both. */
+function BarLabel({
+  label,
+  caption,
+  textClass,
+}: {
+  label?: string
+  caption: string
+  textClass: string
+}) {
+  if (!label && !caption) return null
+
+  return (
+    <div className={cn("flex items-center gap-1 truncate", textClass)}>
+      {label && <span className="text-f1-foreground">{label}</span>}
+      {caption && (
+        <span className="text-f1-foreground-secondary">{caption}</span>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Which bars carry a label: all of them when `count <= maxLabels`, otherwise
+ * `maxLabels` evenly-spread indices — `floor(i * count / maxLabels)` — e.g.
+ * 12 bars → 0, 3, 6, 9 (Jan, Apr, Jul, Oct).
+ */
+function labelIndices(count: number, maxLabels: number): number[] {
+  if (count <= 0 || maxLabels <= 0) return []
+  if (count <= maxLabels) return Array.from({ length: count }, (_, i) => i)
+  return Array.from({ length: maxLabels }, (_, i) =>
+    Math.floor((i * count) / maxLabels)
+  )
+}
+
+const F0ProgressSeriesBase = forwardRef<HTMLDivElement, F0ProgressSeriesProps>(
+  (
+    {
+      bars,
+      maxLabels = DEFAULT_MAX_LABELS,
+      hideTooltip,
+      formatValue = String,
+      size = "md",
+      loading,
+    },
+    ref
+  ) => {
+    const i18n = useI18n()
+
+    if (loading) {
+      return (
+        <div ref={ref} className="w-full" aria-busy="true" aria-live="polite">
+          <Skeleton className={cn("w-full rounded-2xs", HEIGHT_CLASS[size])} />
+        </div>
+      )
+    }
+
+    const dense = bars.length > DENSE_FROM
+    const gapClass = dense ? "gap-0.5" : "gap-1"
+    const rounded = dense ? "rounded-2xs" : "rounded-full"
+    const shown = new Set(labelIndices(bars.length, maxLabels))
+
+    const resolved = bars.map((bar) => resolveBar(bar, i18n, formatValue))
+    const showLabelRow = resolved.some(
+      (r, index) => shown.has(index) && (r.bar.label || r.caption)
+    )
+
+    return (
+      <div ref={ref} className="flex w-full flex-col gap-1">
+        <TooltipProvider>
+          <div className={cn("flex w-full", HEIGHT_CLASS[size], gapClass)}>
+            {resolved.map((r, index) => (
+              <BarTrack
+                key={`${r.bar.label}-${index}`}
+                resolved={r}
+                rounded={rounded}
+                hideTooltip={hideTooltip}
+              />
+            ))}
+          </div>
+
+          {showLabelRow && (
+            <div className={cn("flex w-full", gapClass)} aria-hidden="true">
+              {resolved.map((r, index) => (
+                <div
+                  key={`${r.bar.label}-${index}`}
+                  className="min-w-[3px] flex-1 overflow-hidden"
+                >
+                  {shown.has(index) && (
+                    <BarLabel
+                      label={r.bar.label}
+                      caption={r.caption}
+                      textClass={LABEL_CLASS[size]}
+                    />
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </TooltipProvider>
+      </div>
+    )
+  }
+)
+
+F0ProgressSeriesBase.displayName = "F0ProgressSeries"
+
+/**
+ * @experimental This is an experimental component, use it at your own risk.
+ */
+export const F0ProgressSeries = withDataTestId(
+  experimentalComponent("F0ProgressSeries", F0ProgressSeriesBase)
+)

--- a/packages/react/src/experimental/F0ProgressSeries/__stories__/F0ProgressSeries.mdx
+++ b/packages/react/src/experimental/F0ProgressSeries/__stories__/F0ProgressSeries.mdx
@@ -385,10 +385,13 @@ import { F0ProgressSeries } from "@factorialco/f0-react/experimental"
           <code>color</code>
         </td>
         <td>
-          <code>string</code>
+          <code>F0ProgressSeriesColor</code>
         </td>
         <td>
-          f0 colour token. Defaults to <code>"categorical-1"</code>.
+          One of the 11 chart tokens — <code>categorical-1..8</code>,{" "}
+          <code>feedback-positive</code>, <code>feedback-neutral</code>,{" "}
+          <code>feedback-negative</code>. Defaults to{" "}
+          <code>"categorical-1"</code>.
         </td>
       </tr>
       <tr>

--- a/packages/react/src/experimental/F0ProgressSeries/__stories__/F0ProgressSeries.mdx
+++ b/packages/react/src/experimental/F0ProgressSeries/__stories__/F0ProgressSeries.mdx
@@ -1,0 +1,475 @@
+import { Canvas, Meta, Controls, Unstyled } from "@storybook/addon-docs/blocks"
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
+import * as Stories from "./F0ProgressSeries.stories"
+
+<Meta of={Stories} />
+
+# F0ProgressSeries
+
+Renders a row of **independent** progress bars — one per period or segment —
+each with its own track, target and proportional fill. Use it when a single
+measure is split across several targets (Q1…Q4, Jan…Dec, H1/H2) and the reader
+needs to compare them at a glance.
+
+---
+
+# Overview
+
+## Purpose
+
+- Shows progress against **several targets at once**, side by side.
+- Encodes each segment's health through a consumer-chosen colour token.
+- Makes **overachievement** visible instead of clamping it away.
+- Keeps the row compact enough to live inside a data-collection cell.
+
+## Anatomy
+
+<Canvas of={Stories.Default} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Element</th>
+        <th className="text-left">Description</th>
+        <th className="text-left">Required</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>Bar</code>
+        </td>
+        <td>
+          One independent track per entry in <code>bars</code>.
+        </td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>
+          <code>Fill</code>
+        </td>
+        <td>
+          The coloured portion, <code>value / max</code> wide.
+        </td>
+        <td>No</td>
+      </tr>
+      <tr>
+        <td>
+          <code>Label</code>
+        </td>
+        <td>
+          Title under the bar (e.g. <code>Q1</code>).
+        </td>
+        <td>No</td>
+      </tr>
+      <tr>
+        <td>
+          <code>Caption</code>
+        </td>
+        <td>Short text next to the label; defaults to the percentage.</td>
+        <td>No</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+## Variants
+
+The component has no visual variants beyond `size`: its appearance comes from
+the data (`bars`) and the colour tokens the consumer picks.
+
+### Consumer-mapped colours
+
+<Canvas of={Stories.WithStatusColors} />
+
+### Sizes
+
+<Canvas of={Stories.Sizes} />
+
+## States
+
+<Canvas of={Stories.Overachievement} />
+<Canvas of={Stories.Canceled} />
+<Canvas of={Stories.Loading} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">State</th>
+        <th className="text-left">Description</th>
+        <th className="text-left">Visual indicator</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>Empty</code>
+        </td>
+        <td>
+          <code>value</code> is <code>undefined</code>/non-finite, or{" "}
+          <code>max &lt;= 0</code>.
+        </td>
+        <td>Track only; announced as "No data".</td>
+      </tr>
+      <tr>
+        <td>
+          <code>Partial</code>
+        </td>
+        <td>
+          <code>0 &lt; value &lt; max</code>.
+        </td>
+        <td>
+          Fill <code>value / max</code> wide in the chosen token.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>Overachieved</code>
+        </td>
+        <td>
+          <code>value &gt; max</code>.
+        </td>
+        <td>
+          Full bar split at <code>100 / pct</code> — base colour, then a lighter
+          shade for the excess. The percentage is never clamped.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>Canceled</code>
+        </td>
+        <td>
+          <code>canceled</code> is set.
+        </td>
+        <td>Grey bar with a diagonal hatch; announced as "Canceled".</td>
+      </tr>
+      <tr>
+        <td>
+          <code>Loading</code>
+        </td>
+        <td>
+          <code>loading</code> is set.
+        </td>
+        <td>Skeleton the same height as the loaded bar.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+---
+
+# Guidelines
+
+## Design Best Practices
+
+### When to use
+
+- A measure broken into consecutive targets (quarterly, monthly, half-yearly).
+- When each segment has **its own target**, so a shared scale would be wrong.
+- Inside a table cell where several periods must fit on one row.
+
+### When NOT to use
+
+- Single value toward a single target: use `Progress` instead.
+- Parts of one whole (a gender or department split): use the `categoryBarChart`
+  value-display cell.
+- A short ordinal rating (1–5): use `F0SegmentedBar`.
+- Vertical columns over time: use `barSeries`.
+
+### How to use
+
+- Map your domain to a colour token on the consumer side — the component runs no
+  status → colour logic.
+- Keep the bar count at 12 or fewer; past four bars the row tightens
+  automatically (smaller gap, squarer ends).
+- Pass `formatValue` whenever the numbers carry a unit, so tooltips read
+  `1.700 / 3.400 €` rather than `1700 / 3400`.
+
+## Content Best Practices
+
+- `label` names the segment (`Q1`, `Jan`, `2026`) — keep it to a few characters,
+  it shares a narrow column with the caption.
+- `caption` defaults to the percentage; override it only when a different figure
+  is more useful, and pass `""` to drop it.
+
+<DoDonts
+  do={{
+    description:
+      "Map each period's status to a meaningful token (positive/neutral/negative) and let the caption show the percentage.",
+  }}
+  dont={{
+    description:
+      "Write tooltips by hand per bar, or pack more than twelve bars into one row.",
+  }}
+/>
+
+## Layout
+
+- Always `w-full`: the component never caps its own width. Whatever contains it
+  — a table cell, a card, a sidebar — owns that decision.
+- Bars are equal width (`flex-1`); `size` scales the bar height (`sm` → `h-1.5`,
+  `md` → `h-2`, `lg` → `h-3`). The label row follows but caps at `text-sm`
+  (12px): only `sm` steps down, to `text-xs`.
+- Up to four bars: `gap-1` and pill ends. More: `gap-0.5` and `rounded-2xs`.
+- Fill changes animate with a short ease-in-out transition.
+
+<Canvas of={Stories.Constrained} />
+
+## Accessibility
+
+- Every bar is a `role="img"` with an `aria-label` carrying the same text as the
+  tooltip, so the detail is never sighted-only.
+- Bars are focusable (`tabIndex={0}`), so the tooltip is reachable by keyboard.
+- The label row is `aria-hidden`: the bar already announces label and value.
+- "No data" and "Canceled" resolve through `useI18n()` (`progressSeries.*`).
+
+---
+
+# Code
+
+## Import
+
+```tsx
+import { F0ProgressSeries } from "@factorialco/f0-react/experimental"
+```
+
+## Props
+
+<Canvas of={Stories.Default} />
+
+<Controls of={Stories.Default} />
+
+### Props Reference
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Prop</th>
+        <th className="text-left">Type</th>
+        <th className="text-left">Default</th>
+        <th className="text-left">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>bars</code> <span className="text-red-500">*</span>
+        </td>
+        <td>
+          <code>F0ProgressSeriesBar[]</code>
+        </td>
+        <td>-</td>
+        <td>One entry per period/segment (up to 12).</td>
+      </tr>
+      <tr>
+        <td>
+          <code>size</code>
+        </td>
+        <td>
+          <code>"sm" | "md" | "lg"</code>
+        </td>
+        <td>
+          <code>"md"</code>
+        </td>
+        <td>Bar height.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>maxLabels</code>
+        </td>
+        <td>
+          <code>number</code>
+        </td>
+        <td>
+          <code>4</code>
+        </td>
+        <td>
+          Labels rendered under the row; spread evenly when there are more bars
+          (12 → Jan, Apr, Jul, Oct).
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>formatValue</code>
+        </td>
+        <td>
+          <code>{"(value: number) => string"}</code>
+        </td>
+        <td>
+          <code>String</code>
+        </td>
+        <td>
+          Formats value/max in the tooltip. A trailing unit shared by both sides
+          is printed once (<code>1.700 / 3.400 €</code>).
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>hideTooltip</code>
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>
+          <code>false</code>
+        </td>
+        <td>
+          Suppresses the per-bar tooltip; bars stay focusable and labelled.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>loading</code>
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>
+          <code>false</code>
+        </td>
+        <td>Renders a skeleton instead of the series.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>dataTestId</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>-</td>
+        <td>
+          Test identifier forwarded by <code>withDataTestId</code>.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+### `F0ProgressSeriesBar`
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Field</th>
+        <th className="text-left">Type</th>
+        <th className="text-left">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>value</code> <span className="text-red-500">*</span>
+        </td>
+        <td>
+          <code>number | undefined</code>
+        </td>
+        <td>
+          Attained value. <code>undefined</code> renders an empty bar.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>max</code>
+        </td>
+        <td>
+          <code>number</code>
+        </td>
+        <td>Target for this bar. Defaults to 100.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>color</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>
+          f0 colour token. Defaults to <code>"categorical-1"</code>.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>canceled</code>
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>Renders the hatched grey state.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>label</code> / <code>caption</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>
+          Title and short text under the bar. <code>caption</code> defaults to
+          the percentage; <code>""</code> hides it.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>tooltip</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>Replaces the generated tooltip and accessible name.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+---
+
+# Examples
+
+## Basic usage
+
+<Canvas of={Stories.Default} />
+
+```tsx
+<F0ProgressSeries
+  bars={[
+    { value: 100, max: 100, label: "Q1" },
+    { value: 50, max: 100, label: "Q2" },
+    { value: undefined, label: "Q3" },
+    { value: undefined, label: "Q4" },
+  ]}
+/>
+```
+
+## Status colours and units
+
+<Canvas of={Stories.WithStatusColors} />
+
+```tsx
+<F0ProgressSeries
+  formatValue={(value) => `${value.toLocaleString("de-DE")} €`}
+  bars={[
+    { value: 6800, max: 3400, label: "Q1", color: "feedback-positive" },
+    { value: 1700, max: 3400, label: "Q2", color: "feedback-neutral" },
+  ]}
+/>
+```
+
+## Twelve months
+
+<Canvas of={Stories.Monthly} />
+
+## Inside a data collection
+
+The `progressSeries` value-display cell renders this component, so the same data
+works in an `OneDataCollection` column:
+
+```tsx
+render: () => ({
+  type: "progressSeries",
+  value: { bars, formatValue },
+})
+```

--- a/packages/react/src/experimental/F0ProgressSeries/__stories__/F0ProgressSeries.stories.tsx
+++ b/packages/react/src/experimental/F0ProgressSeries/__stories__/F0ProgressSeries.stories.tsx
@@ -1,0 +1,155 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
+
+import { F0ProgressSeries } from "../index"
+import { F0ProgressSeriesBar, f0ProgressSeriesSizes } from "../types"
+
+const quarters: F0ProgressSeriesBar[] = [
+  { value: 100, max: 100, label: "Q1" },
+  { value: 50, max: 100, label: "Q2" },
+  { value: undefined, label: "Q3" },
+  { value: undefined, label: "Q4" },
+]
+
+const statusQuarters: F0ProgressSeriesBar[] = [
+  { value: 6800, max: 3400, label: "Q1", color: "feedback-positive" },
+  { value: 1700, max: 3400, label: "Q2", color: "feedback-neutral" },
+  { value: 500, max: 3400, label: "Q3", color: "feedback-negative" },
+  { value: undefined, label: "Q4" },
+]
+
+const canceledQuarters: F0ProgressSeriesBar[] = [
+  { value: 100, max: 100, label: "Q1", color: "feedback-positive" },
+  { value: 40, max: 100, canceled: true, label: "Q2" },
+  { value: undefined, label: "Q3" },
+  { value: undefined, label: "Q4" },
+]
+
+const monthlyBars: F0ProgressSeriesBar[] = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+].map((label, i) => ({ value: i < 7 ? 60 : undefined, max: 100, label }))
+
+const euros = (value: number) => `${value.toLocaleString("de-DE")} €`
+
+const meta = {
+  title: "F0ProgressSeries",
+  component: F0ProgressSeries,
+  tags: ["experimental"],
+  parameters: { layout: "padded" },
+  argTypes: {
+    size: { control: "inline-radio", options: f0ProgressSeriesSizes },
+  },
+  args: { bars: quarters },
+} satisfies Meta<typeof F0ProgressSeries>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {
+  tags: ["!dev"],
+}
+
+/**
+ * The consumer maps its own domain to a colour token and passes `formatValue`
+ * so the tooltip reads `Q2 · 1.700 / 3.400 € (50%)` — no manual tooltip strings.
+ */
+export const WithStatusColors: Story = {
+  tags: ["!dev"],
+  args: { bars: statusQuarters, formatValue: euros },
+}
+
+/**
+ * Past the target the bar fills completely and splits at `100 / pct`: the base
+ * colour up to the target, then a lighter shade for the excess.
+ */
+export const Overachievement: Story = {
+  tags: ["!dev"],
+  args: {
+    bars: [
+      { value: 158, max: 100, label: "Q1", color: "feedback-positive" },
+      { value: 92, max: 100, label: "Q2", color: "feedback-neutral" },
+    ],
+  },
+}
+
+/** A `canceled` bar is hatched, so it reads as void rather than merely empty. */
+export const Canceled: Story = {
+  tags: ["!dev"],
+  args: { bars: canceledQuarters },
+}
+
+/** 12 monthly bars: only 4 labels are shown, evenly spaced (Jan, Apr, Jul, Oct). */
+export const Monthly: Story = {
+  tags: ["!dev"],
+  args: { bars: monthlyBars },
+}
+
+/** A single bar behaves like the `Progress` primitive — one bar, one label. */
+export const Single: Story = {
+  tags: ["!dev"],
+  args: { bars: [{ value: 50, max: 100, label: "2026" }] },
+}
+
+/** `size` scales the bar height; the label row caps at `text-sm`. */
+export const Sizes: Story = {
+  tags: ["!dev"],
+  render: (args) => (
+    <div className="flex flex-col gap-6">
+      {f0ProgressSeriesSizes.map((size) => (
+        <F0ProgressSeries key={size} {...args} size={size} />
+      ))}
+    </div>
+  ),
+}
+
+/**
+ * The component is always `w-full` — the width belongs to whatever contains it.
+ * Constrain the parent, not the series.
+ */
+export const Constrained: Story = {
+  tags: ["!dev"],
+  render: (args) => (
+    <div className="w-64 rounded-md border border-f1-border-secondary p-3">
+      <F0ProgressSeries {...args} />
+    </div>
+  ),
+}
+
+export const HiddenTooltip: Story = {
+  tags: ["!dev"],
+  args: { hideTooltip: true, bars: quarters },
+}
+
+export const Loading: Story = {
+  tags: ["!dev"],
+  args: { bars: [], loading: true },
+}
+
+export const Snapshot: Story = {
+  parameters: withSnapshot({}),
+  render: () => (
+    <div className="flex w-full flex-col gap-6">
+      <F0ProgressSeries bars={quarters} />
+      <F0ProgressSeries bars={statusQuarters} formatValue={euros} />
+      <F0ProgressSeries bars={canceledQuarters} />
+      <F0ProgressSeries bars={monthlyBars} />
+      {f0ProgressSeriesSizes.map((size) => (
+        <F0ProgressSeries key={size} bars={quarters} size={size} />
+      ))}
+      <F0ProgressSeries bars={[{ value: 50, max: 100, label: "2026" }]} />
+      <F0ProgressSeries bars={[]} loading />
+    </div>
+  ),
+}

--- a/packages/react/src/experimental/F0ProgressSeries/__tests__/F0ProgressSeries.test.tsx
+++ b/packages/react/src/experimental/F0ProgressSeries/__tests__/F0ProgressSeries.test.tsx
@@ -1,0 +1,260 @@
+import { describe, expect, it } from "vitest"
+
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { F0ProgressSeries } from "../index"
+import { F0ProgressSeriesBar } from "../types"
+
+const getBars = () => screen.getAllByRole("img")
+
+const quarters: F0ProgressSeriesBar[] = [
+  { value: 100, max: 100, label: "Q1" },
+  { value: 50, max: 100, label: "Q2" },
+  { value: undefined, label: "Q3" },
+  { value: undefined, label: "Q4" },
+]
+
+const months = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+]
+
+describe("F0ProgressSeries", () => {
+  it("renders one bar per data point", () => {
+    render(<F0ProgressSeries bars={quarters} />)
+
+    expect(getBars()).toHaveLength(4)
+  })
+
+  it("fills proportionally to value / max", () => {
+    render(<F0ProgressSeries bars={[{ value: 50, max: 100 }]} />)
+
+    expect(getBars()[0].querySelector("div")?.getAttribute("style")).toContain(
+      "width: 50%"
+    )
+  })
+
+  it("defaults max to 100", () => {
+    render(<F0ProgressSeries bars={[{ value: 25 }]} />)
+
+    expect(getBars()[0].getAttribute("aria-label")).toBe("25 / 100 (25%)")
+  })
+
+  it("splits the bar at 100/pct on overachievement and reports the real %", () => {
+    render(<F0ProgressSeries bars={[{ value: 158, max: 100, label: "Q1" }]} />)
+
+    const bar = getBars()[0]
+    expect(bar.getAttribute("aria-label")).toContain("158%")
+
+    // Full bar split at 100/158 ≈ 63.29% (base) + ≈ 36.71% (lighter overflow).
+    const widths = Array.from(bar.querySelectorAll("[style*='width']")).map(
+      (el) => el.getAttribute("style") ?? ""
+    )
+    expect(widths).toHaveLength(2)
+    expect(widths.some((w) => w.includes("width: 63.29"))).toBe(true)
+    expect(widths.some((w) => w.includes("width: 36.70"))).toBe(true)
+  })
+
+  it("applies the color token to the fill, defaulting to categorical-1", () => {
+    render(
+      <F0ProgressSeries
+        bars={[
+          { value: 40, max: 100, color: "feedback-positive" },
+          { value: 40, max: 100 },
+        ]}
+      />
+    )
+
+    for (const bar of getBars()) {
+      expect(bar.querySelector("div")?.getAttribute("style")).toContain(
+        "background-color"
+      )
+    }
+  })
+
+  it("renders a canceled bar as a hatched grey bar with no fill", () => {
+    render(
+      <F0ProgressSeries
+        bars={[{ value: 30, max: 100, canceled: true, label: "Q1" }]}
+      />
+    )
+
+    const bar = getBars()[0]
+    expect(bar).toHaveClass("bg-f1-foreground-disabled")
+    expect(bar.className).toContain("repeating-linear-gradient")
+    expect(bar.querySelector("div")).toBeNull()
+    expect(bar.getAttribute("aria-label")).toBe("Q1 · Canceled")
+  })
+
+  it("renders an empty/future bar with track only and announces no data", () => {
+    render(<F0ProgressSeries bars={[{ value: undefined, label: "Q3" }]} />)
+
+    const bar = getBars()[0]
+    expect(bar).toHaveClass("bg-f1-background-secondary")
+    expect(bar.querySelector("div")).toBeNull()
+    expect(bar.getAttribute("aria-label")).toBe("Q3 · No data")
+  })
+
+  it("builds an accessible name with value / max and the percentage", () => {
+    render(
+      <F0ProgressSeries bars={[{ value: 1700, max: 3400, label: "Q2" }]} />
+    )
+
+    expect(getBars()[0].getAttribute("aria-label")).toBe(
+      "Q2 · 1700 / 3400 (50%)"
+    )
+  })
+
+  it("formats value / max through formatValue, printing a trailing unit once", () => {
+    render(
+      <F0ProgressSeries
+        bars={[{ value: 1700, max: 3400, label: "Q2" }]}
+        formatValue={(value) => `${value.toLocaleString("de-DE")} €`}
+      />
+    )
+
+    expect(getBars()[0].getAttribute("aria-label")).toBe(
+      "Q2 · 1.700 / 3.400 € (50%)"
+    )
+  })
+
+  it("keeps a prefixed unit on both sides", () => {
+    render(
+      <F0ProgressSeries
+        bars={[{ value: 1700, max: 3400 }]}
+        formatValue={(value) => `$${value}`}
+      />
+    )
+
+    expect(getBars()[0].getAttribute("aria-label")).toBe("$1700 / $3400 (50%)")
+  })
+
+  it("lets the consumer override the tooltip text", () => {
+    render(
+      <F0ProgressSeries
+        bars={[{ value: 1700, max: 3400, label: "Q2", tooltip: "Custom" }]}
+      />
+    )
+
+    expect(getBars()[0].getAttribute("aria-label")).toBe("Custom")
+  })
+
+  it.each([
+    ["NaN value", { value: NaN, max: 100 }],
+    ["Infinite value", { value: Infinity, max: 100 }],
+    ["NaN max", { value: 50, max: NaN }],
+    ["zero max", { value: 50, max: 0 }],
+  ])("treats a bar with %s as empty, never leaking NaN", (_case, bar) => {
+    render(<F0ProgressSeries bars={[{ ...bar, label: "Q1" }]} />)
+
+    const rendered = getBars()[0]
+    expect(rendered.querySelector("div")).toBeNull()
+    expect(rendered.getAttribute("aria-label")).toBe("Q1 · No data")
+    expect(rendered.outerHTML).not.toContain("NaN")
+  })
+
+  it("shows a label under every bar when count <= maxLabels, with % as the default caption", () => {
+    render(<F0ProgressSeries bars={quarters} />)
+
+    expect(screen.getByText("Q1")).toBeInTheDocument()
+    expect(screen.getByText("Q4")).toBeInTheDocument()
+    expect(screen.getByText("100%")).toBeInTheDocument()
+    expect(screen.getByText("50%")).toBeInTheDocument()
+  })
+
+  it("shows only maxLabels labels, evenly spaced, when there are more bars (12 → 0,3,6,9)", () => {
+    render(
+      <F0ProgressSeries
+        bars={months.map((label) => ({ value: 50, max: 100, label }))}
+      />
+    )
+
+    for (const shown of ["Jan", "Apr", "Jul", "Oct"]) {
+      expect(screen.getByText(shown)).toBeInTheDocument()
+    }
+    for (const hidden of ["Feb", "Mar", "May", "Dec"]) {
+      expect(screen.queryByText(hidden)).not.toBeInTheDocument()
+    }
+  })
+
+  it("spreads labels evenly when the count is not a multiple of maxLabels", () => {
+    render(
+      <F0ProgressSeries
+        bars={["A", "B", "C", "D", "E", "F"].map((label) => ({
+          value: 50,
+          max: 100,
+          label,
+        }))}
+      />
+    )
+
+    // floor(i * 6 / 4) → 0, 1, 3, 4 — spread across the row, not bunched left.
+    for (const shown of ["A", "B", "D", "E"]) {
+      expect(screen.getByText(shown)).toBeInTheDocument()
+    }
+    for (const hidden of ["C", "F"]) {
+      expect(screen.queryByText(hidden)).not.toBeInTheDocument()
+    }
+  })
+
+  it("honours an explicit maxLabels", () => {
+    render(<F0ProgressSeries bars={quarters} maxLabels={2} />)
+
+    expect(screen.getByText("Q1")).toBeInTheDocument()
+    expect(screen.getByText("Q3")).toBeInTheDocument()
+    expect(screen.queryByText("Q2")).not.toBeInTheDocument()
+  })
+
+  it("hides the caption when passed as an empty string", () => {
+    render(
+      <F0ProgressSeries
+        bars={[{ value: 100, max: 100, label: "Q1", caption: "" }]}
+      />
+    )
+
+    expect(screen.getByText("Q1")).toBeInTheDocument()
+    expect(screen.queryByText("100%")).not.toBeInTheDocument()
+  })
+
+  it("still renders bars when hideTooltip is true", () => {
+    render(<F0ProgressSeries bars={[{ value: 50, max: 100 }]} hideTooltip />)
+
+    expect(getBars()).toHaveLength(1)
+  })
+
+  it("renders a skeleton with aria-busy while loading", () => {
+    render(<F0ProgressSeries bars={[]} loading />)
+
+    expect(screen.getByTestId("skeleton")).toBeInTheDocument()
+    expect(screen.getByTestId("skeleton").parentElement).toHaveAttribute(
+      "aria-busy"
+    )
+  })
+
+  it.each([
+    ["sm", "h-1.5", "text-xs"],
+    ["md", "h-2", "text-sm"],
+    // The label caps at text-sm: a taller bar doesn't warrant bigger text.
+    ["lg", "h-3", "text-sm"],
+  ] as const)(
+    "scales the bar height and the label row for size %s",
+    (size, height, text) => {
+      render(
+        <F0ProgressSeries bars={[{ value: 50, label: "Q1" }]} size={size} />
+      )
+
+      expect(getBars()[0].parentElement).toHaveClass(height)
+      expect(screen.getByText("Q1").parentElement).toHaveClass(text)
+    }
+  )
+})

--- a/packages/react/src/experimental/F0ProgressSeries/index.tsx
+++ b/packages/react/src/experimental/F0ProgressSeries/index.tsx
@@ -1,0 +1,1 @@
+export * from "./F0ProgressSeries"

--- a/packages/react/src/experimental/F0ProgressSeries/types.ts
+++ b/packages/react/src/experimental/F0ProgressSeries/types.ts
@@ -1,0 +1,65 @@
+import { WithDataTestIdProps } from "@/lib/data-testid"
+
+export const f0ProgressSeriesSizes = ["sm", "md", "lg"] as const
+export type F0ProgressSeriesSize = (typeof f0ProgressSeriesSizes)[number]
+
+/**
+ * One progress bar in the series — e.g. a period (Q1, Jan, 2026…). Each bar is
+ * an independent progress bar (its own track + proportional fill), unlike a
+ * category bar where the segments are parts of a single whole.
+ */
+export interface F0ProgressSeriesBar {
+  /**
+   * Attained value. `undefined` (or a non-finite value / `max <= 0`) renders an
+   * empty/future bar: track only, no fill.
+   */
+  value: number | undefined
+  /** Target. Defaults to 100. */
+  max?: number
+  /**
+   * f0 color token for the fill (resolved via `getColor`). Defaults to
+   * `"categorical-1"`. Ignored when `canceled` is set.
+   */
+  color?: string
+  /** Renders a hatched grey bar (e.g. a cancelled period). */
+  canceled?: boolean
+  /** Title shown under the bar (e.g. "Q1", "Jan", "2026"). Optional. */
+  label?: string
+  /**
+   * Short text shown under the bar next to the label. Optional; defaults to the
+   * computed percentage (which may exceed 100%). Pass "" to hide it.
+   */
+  caption?: string
+  /** Tooltip text. Defaults to `label · value / max (percentage)`. */
+  tooltip?: string
+}
+
+/** Shared by the component and the `progressSeries` value-display cell. */
+export interface F0ProgressSeriesOptions {
+  /** 1..N bars (N up to 12: half-yearly = 2, quarterly = 4, monthly = 12). */
+  bars: F0ProgressSeriesBar[]
+  /**
+   * Max labels rendered under the row. When there are more bars than this, the
+   * labels are spread evenly (e.g. 12 bars → indices 0, 3, 6, 9). Defaults to 4.
+   */
+  maxLabels?: number
+  /** Hide the per-bar tooltips. */
+  hideTooltip?: boolean
+  /**
+   * Formats `value`/`max` in the default tooltip — the component only knows raw
+   * numbers, so pass this to render currencies, separators, units…
+   * Defaults to `String(value)`.
+   */
+  formatValue?: (value: number) => string
+  /**
+   * Renders a skeleton (same height as the loaded bar) instead of the series
+   * while the data is still loading.
+   */
+  loading?: boolean
+}
+
+export interface F0ProgressSeriesProps
+  extends F0ProgressSeriesOptions, WithDataTestIdProps {
+  /** Bar height. Defaults to `"md"`. */
+  size?: F0ProgressSeriesSize
+}

--- a/packages/react/src/experimental/F0ProgressSeries/types.ts
+++ b/packages/react/src/experimental/F0ProgressSeries/types.ts
@@ -4,6 +4,27 @@ export const f0ProgressSeriesSizes = ["sm", "md", "lg"] as const
 export type F0ProgressSeriesSize = (typeof f0ProgressSeriesSizes)[number]
 
 /**
+ * The `--chart-*` tokens `getColor` can resolve (see `f0-core`'s `base.css`).
+ * Same set as `F0SegmentedBar`'s `SegmentColorToken`; the two are not shared yet
+ * because `kits/F0DataChart` already owns the `ChartColorToken` name for a
+ * different palette (`baseColors`). Unifying them is tracked separately.
+ */
+export const f0ProgressSeriesColors = [
+  "categorical-1",
+  "categorical-2",
+  "categorical-3",
+  "categorical-4",
+  "categorical-5",
+  "categorical-6",
+  "categorical-7",
+  "categorical-8",
+  "feedback-positive",
+  "feedback-neutral",
+  "feedback-negative",
+] as const
+export type F0ProgressSeriesColor = (typeof f0ProgressSeriesColors)[number]
+
+/**
  * One progress bar in the series — e.g. a period (Q1, Jan, 2026…). Each bar is
  * an independent progress bar (its own track + proportional fill), unlike a
  * category bar where the segments are parts of a single whole.
@@ -17,10 +38,10 @@ export interface F0ProgressSeriesBar {
   /** Target. Defaults to 100. */
   max?: number
   /**
-   * f0 color token for the fill (resolved via `getColor`). Defaults to
-   * `"categorical-1"`. Ignored when `canceled` is set.
+   * f0 chart color token for the fill. Defaults to `"categorical-1"`. Ignored
+   * when `canceled` is set.
    */
-  color?: string
+  color?: F0ProgressSeriesColor
   /** Renders a hatched grey bar (e.g. a cancelled period). */
   canceled?: boolean
   /** Title shown under the bar (e.g. "Q1", "Jan", "2026"). Optional. */

--- a/packages/react/src/experimental/exports.ts
+++ b/packages/react/src/experimental/exports.ts
@@ -24,6 +24,7 @@ export * from "../kits/Charts/exports"
  */
 export * from "../components/F0ActionBar"
 export * from "./F0CardHorizontal"
+export * from "./F0ProgressSeries"
 export * from "./F0SegmentedBar"
 export * from "./F0VersionHistory"
 export * from "./Forms/exports"

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -625,6 +625,10 @@ export const defaultTranslations = {
       description: "Try a different date or fewer filters",
     },
   },
+  progressSeries: {
+    noData: "No data",
+    canceled: "Canceled",
+  },
   select: {
     noResults: "No results found",
     loadingMore: "Loading...",

--- a/packages/react/src/ui/value-display/renderers.tsx
+++ b/packages/react/src/ui/value-display/renderers.tsx
@@ -22,6 +22,7 @@ import { NumberCell } from "./types/number"
 import { PercentageCell } from "./types/percentage"
 import { PersonCell } from "./types/person"
 import { ProgressBarCell } from "./types/progressBar"
+import { ProgressSeriesCell } from "./types/progressSeries"
 import { StatusCell } from "./types/status"
 import { SummaryCell } from "./types/summary"
 import { TagCell } from "./types/tag"
@@ -55,6 +56,7 @@ export const valueDisplayRenderers = {
   person: PersonCell,
   percentage: PercentageCell,
   progressBar: ProgressBarCell,
+  progressSeries: ProgressSeriesCell,
   barSeries: BarSeriesCell,
   categoryBarChart: CategoryBarChartCell,
   hourDistribution: HourDistributionCell,

--- a/packages/react/src/ui/value-display/types/progressSeries/__stories__/progressSeries.mdx
+++ b/packages/react/src/ui/value-display/types/progressSeries/__stories__/progressSeries.mdx
@@ -20,7 +20,7 @@ type value = {
   bars: Array<{
     value: number | undefined  // attained; undefined / non-finite (or max <= 0) → empty bar (track only)
     max?: number               // target; defaults to 100
-    color?: string             // f0 color token for the fill; defaults to "categorical-1"
+    color?: ProgressSeriesColor // chart token: categorical-1..8 | feedback-positive|neutral|negative
     canceled?: boolean         // hatched grey bar (e.g. a cancelled period)
     label?: string             // title shown under the bar (e.g. "Q1"); optional
     caption?: string           // short text under the bar; defaults to the computed %; pass "" to hide

--- a/packages/react/src/ui/value-display/types/progressSeries/__stories__/progressSeries.mdx
+++ b/packages/react/src/ui/value-display/types/progressSeries/__stories__/progressSeries.mdx
@@ -1,0 +1,105 @@
+import { Canvas, Meta } from "@storybook/addon-docs/blocks"
+import * as ProgressSeriesStories from "./progressSeries.stories"
+
+<Meta of={ProgressSeriesStories} />
+
+### progressSeries
+
+Renders the `F0ProgressSeries` component inside a data collection: a row of
+**independent** progress bars — one per period/segment — each with its own
+track, target and proportional fill.
+
+Not to be confused with `categoryBarChart` (segments are parts of a single
+whole) or `barSeries` (vertical columns). For the full API, the standalone
+component and its design guidelines, see the **F0ProgressSeries** docs.
+
+#### Value type
+
+```
+type value = {
+  bars: Array<{
+    value: number | undefined  // attained; undefined / non-finite (or max <= 0) → empty bar (track only)
+    max?: number               // target; defaults to 100
+    color?: string             // f0 color token for the fill; defaults to "categorical-1"
+    canceled?: boolean         // hatched grey bar (e.g. a cancelled period)
+    label?: string             // title shown under the bar (e.g. "Q1"); optional
+    caption?: string           // short text under the bar; defaults to the computed %; pass "" to hide
+    tooltip?: string           // overrides the default `label · value / max (%)`
+  }>
+  size?: "sm" | "md" | "lg"    // bar height; defaults to "md"
+  maxLabels?: number           // max labels shown, spread evenly when there are more bars; defaults to 4
+  hideTooltip?: boolean        // when true, suppresses per-bar tooltips
+  formatValue?: (value: number) => string  // formats value/max in the tooltip (currency, units…)
+  loading?: boolean            // when true, renders a skeleton until data arrives
+}
+```
+
+- **Overachievement**: past 100 % the bar fills completely and splits at
+  `100 / pct` — the base colour up to the target, then a lighter shade of the
+  same colour for the excess (158 % → ~63 % + ~37 %). The reported percentage is
+  never clamped.
+- **Labels**: at most `maxLabels` (default 4) are shown. With more bars they are
+  spread evenly — 12 bars → indices 0, 3, 6, 9 (e.g. Jan, Apr, Jul, Oct). Bars
+  without a visible label still expose their value through the tooltip and
+  accessible name.
+- **Tooltip**: built automatically as `label · value / max (percentage)`. The
+  cell only receives raw numbers, so pass `formatValue` for currencies or units
+  (a trailing unit shared by both sides is printed once: `1.700 / 3.400 €`), or
+  `tooltip` to replace the string entirely. The same text is the bar's
+  accessible name, so the detail is never sighted-only.
+- **Colour** is a generic f0 token per bar. The consumer maps its own domain to
+  a token — e.g. Goals maps period status to `feedback-positive` /
+  `feedback-neutral` / `feedback-negative`.
+- **Translations**: the "No data" and "Canceled" states come from the i18n
+  provider (`progressSeries.*`).
+
+#### Quarterly
+
+<Canvas of={ProgressSeriesStories.Quarterly} />
+
+#### WithStatusColors
+
+The Goals consumer maps each period's status to a colour token and passes
+`formatValue` so the tooltip reads `Q2 · 1.700 / 3.400 € (50%)`.
+
+<Canvas of={ProgressSeriesStories.WithStatusColors} />
+
+#### Overflow
+
+The bar fills completely and splits at the target; the caption and tooltip show
+the real percentage.
+
+<Canvas of={ProgressSeriesStories.Overflow} />
+
+#### Single
+
+A single bar behaves like the `progressBar` (Progress) value display.
+
+<Canvas of={ProgressSeriesStories.Single} />
+
+#### Monthly
+
+12 monthly bars: only 4 labels are shown, evenly spaced (Jan, Apr, Jul, Oct).
+
+<Canvas of={ProgressSeriesStories.Monthly} />
+
+#### Canceled
+
+A `canceled` bar renders as a hatched grey bar, distinct from an empty
+(track-only) bar.
+
+<Canvas of={ProgressSeriesStories.Canceled} />
+
+#### HiddenTooltip
+
+Set `hideTooltip: true` to suppress the per-bar tooltip. Bars still render and
+stay focusable.
+
+<Canvas of={ProgressSeriesStories.HiddenTooltip} />
+
+#### Loading
+
+Set `loading: true` while the row's data is still loading. The cell renders a
+skeleton the same size as the loaded bar.
+
+<Canvas of={ProgressSeriesStories.Loading} />

--- a/packages/react/src/ui/value-display/types/progressSeries/__stories__/progressSeries.stories.tsx
+++ b/packages/react/src/ui/value-display/types/progressSeries/__stories__/progressSeries.stories.tsx
@@ -1,0 +1,216 @@
+import { Meta, StoryObj } from "@storybook/react-vite"
+
+import { Cell, mockItem } from "../../../__stories__/shared"
+
+const meta = {
+  title: "Value Display/ProgressSeries",
+  component: Cell,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "Renders the `F0ProgressSeries` component inside a data collection: a row of **independent** progress bars, one per period/segment, each with its own target.\n\n- **Overachievement**: past 100% the bar fills fully and splits at `100 / pct` — base colour up to the target, then a lighter shade for the excess (158% → ~63% + ~37%).\n- **Labels**: at most `maxLabels` (default 4) are shown, spread evenly when there are more bars (12 → Jan, Apr, Jul, Oct).\n- **Tooltip**: built automatically as `label · value / max (percentage)`; pass `formatValue` for currencies or units.\n- **Colour** is a generic f0 token per bar (default `categorical-1`); the consumer maps its own domain (e.g. goal status) → token.\n- See the `F0ProgressSeries` docs for the full API and for standalone usage outside a data collection.",
+      },
+    },
+  },
+} satisfies Meta
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Quarterly: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Progress",
+      render: () => ({
+        type: "progressSeries",
+        value: {
+          bars: [
+            { value: 100, max: 100, label: "Q1" },
+            { value: 50, max: 100, label: "Q2" },
+            { value: undefined, label: "Q3" },
+            { value: undefined, label: "Q4" },
+          ],
+        },
+      }),
+    },
+  },
+}
+
+export const WithStatusColors: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Progress",
+      render: () => ({
+        type: "progressSeries",
+        value: {
+          formatValue: (value: number) => `${value.toLocaleString("de-DE")} €`,
+          bars: [
+            { value: 6800, max: 3400, label: "Q1", color: "feedback-positive" },
+            { value: 1700, max: 3400, label: "Q2", color: "feedback-neutral" },
+            { value: 500, max: 3400, label: "Q3", color: "feedback-negative" },
+            { value: undefined, label: "Q4" },
+          ],
+        },
+      }),
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The Goals consumer maps each period's status to an f0 colour token and passes `formatValue`, so the tooltip reads `Q2 · 1.700 / 3.400 € (50%)` — no manual tooltip strings needed.",
+      },
+    },
+  },
+}
+
+export const Overflow: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Progress",
+      render: () => ({
+        type: "progressSeries",
+        value: {
+          bars: [
+            { value: 158, max: 100, label: "Q1", color: "feedback-positive" },
+            { value: 92, max: 100, label: "Q2", color: "feedback-neutral" },
+          ],
+        },
+      }),
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "When a value exceeds its target the bar **fills completely and splits at `100 / pct`**: the base colour up to the target, then a lighter shade of the same colour for the excess. The caption and tooltip show the real percentage (158 %).",
+      },
+    },
+  },
+}
+
+export const Single: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Progress",
+      render: () => ({
+        type: "progressSeries",
+        value: { bars: [{ value: 50, max: 100, label: "2026" }] },
+      }),
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A single bar behaves like the `progressBar` (Progress) value display — one bar, one label.",
+      },
+    },
+  },
+}
+
+export const Monthly: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Progress",
+      render: () => ({
+        type: "progressSeries",
+        value: {
+          bars: [
+            "Jan",
+            "Feb",
+            "Mar",
+            "Apr",
+            "May",
+            "Jun",
+            "Jul",
+            "Aug",
+            "Sep",
+            "Oct",
+            "Nov",
+            "Dec",
+          ].map((label, i) => ({
+            value: i < 7 ? 60 : undefined,
+            max: 100,
+            label,
+          })),
+        },
+      }),
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "12 monthly bars: only 4 labels are shown, evenly spaced (Jan, Apr, Jul, Oct). Bars use a tighter gap and smaller radius to stay legible.",
+      },
+    },
+  },
+}
+
+export const Canceled: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Progress",
+      render: () => ({
+        type: "progressSeries",
+        value: {
+          bars: [
+            { value: 100, max: 100, label: "Q1", color: "feedback-positive" },
+            { value: 40, max: 100, canceled: true, label: "Q2" },
+            { value: undefined, label: "Q3" },
+            { value: undefined, label: "Q4" },
+          ],
+        },
+      }),
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "A `canceled` bar renders as a grey bar with a diagonal hatch, so it reads as void rather than merely empty (compare Q2 with the empty Q3/Q4).",
+      },
+    },
+  },
+}
+
+export const HiddenTooltip: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Progress",
+      render: () => ({
+        type: "progressSeries",
+        value: {
+          hideTooltip: true,
+          bars: [
+            { value: 100, max: 100, label: "Q1" },
+            { value: 50, max: 100, label: "Q2" },
+          ],
+        },
+      }),
+    },
+  },
+}
+
+export const Loading: Story = {
+  args: {
+    item: mockItem,
+    property: {
+      label: "Progress",
+      render: () => ({
+        type: "progressSeries",
+        value: { bars: [], loading: true },
+      }),
+    },
+  },
+}

--- a/packages/react/src/ui/value-display/types/progressSeries/index.tsx
+++ b/packages/react/src/ui/value-display/types/progressSeries/index.tsx
@@ -1,0 +1,1 @@
+export * from "./progressSeries"

--- a/packages/react/src/ui/value-display/types/progressSeries/progressSeries.test.tsx
+++ b/packages/react/src/ui/value-display/types/progressSeries/progressSeries.test.tsx
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest"
+
+import { defaultTranslations } from "@/lib/providers/i18n/i18n-provider-defaults"
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { ValueDisplayRendererContext } from "../../renderers"
+import { ProgressSeriesCell, ProgressSeriesCellValue } from "./progressSeries"
+
+const defaultMeta: ValueDisplayRendererContext = {
+  visualization: "table",
+  i18n: defaultTranslations,
+}
+
+/** The cell only wires `F0ProgressSeries` into a data collection — the bar
+ * behaviour itself is covered in `F0ProgressSeries`' own tests. */
+function renderCell(value: ProgressSeriesCellValue) {
+  return render(ProgressSeriesCell(value, defaultMeta))
+}
+
+describe("ProgressSeriesCell", () => {
+  it("renders a fallback dash when bars is empty", () => {
+    renderCell({ bars: [] })
+
+    expect(screen.getByText("–")).toBeInTheDocument()
+    expect(screen.getByText("–").closest("[data-cell-type]")).toHaveAttribute(
+      "data-cell-type",
+      "progressSeries"
+    )
+  })
+
+  it("renders a fallback dash when bars is undefined", () => {
+    renderCell({ bars: undefined as unknown as [] })
+
+    expect(screen.getByText("–")).toBeInTheDocument()
+  })
+
+  it("renders the series, tagged as a progressSeries cell", () => {
+    renderCell({
+      bars: [
+        { value: 100, max: 100, label: "Q1" },
+        { value: 50, max: 100, label: "Q2" },
+      ],
+    })
+
+    expect(screen.getAllByRole("img")).toHaveLength(2)
+    expect(
+      screen.getByLabelText("Q2 · 50 / 100 (50%)").closest("[data-cell-type]")
+    ).toHaveAttribute("data-cell-type", "progressSeries")
+  })
+
+  it("renders the skeleton with aria-busy while loading, without the dash", () => {
+    renderCell({ bars: [], loading: true })
+
+    expect(screen.getByTestId("skeleton")).toBeInTheDocument()
+    expect(screen.queryByText("–")).not.toBeInTheDocument()
+    expect(
+      screen.getByTestId("skeleton").closest("[data-cell-type]")
+    ).toHaveAttribute("aria-busy", "true")
+  })
+})

--- a/packages/react/src/ui/value-display/types/progressSeries/progressSeries.tsx
+++ b/packages/react/src/ui/value-display/types/progressSeries/progressSeries.tsx
@@ -11,6 +11,7 @@ import { ValueDisplayRendererContext } from "../../renderers"
 
 export type {
   F0ProgressSeriesBar as ProgressSeriesBar,
+  F0ProgressSeriesColor as ProgressSeriesColor,
   F0ProgressSeriesSize as ProgressSeriesSize,
 } from "@/experimental/F0ProgressSeries"
 

--- a/packages/react/src/ui/value-display/types/progressSeries/progressSeries.tsx
+++ b/packages/react/src/ui/value-display/types/progressSeries/progressSeries.tsx
@@ -1,0 +1,59 @@
+import { CSSProperties } from "react"
+
+import {
+  F0ProgressSeries,
+  F0ProgressSeriesProps,
+} from "@/experimental/F0ProgressSeries"
+import { cn } from "@/lib/utils"
+
+import { tableDisplayClassNames } from "../../const"
+import { ValueDisplayRendererContext } from "../../renderers"
+
+export type {
+  F0ProgressSeriesBar as ProgressSeriesBar,
+  F0ProgressSeriesSize as ProgressSeriesSize,
+} from "@/experimental/F0ProgressSeries"
+
+/** Same surface as `F0ProgressSeries`, minus the testing-only props. */
+export type ProgressSeriesCellValue = Omit<F0ProgressSeriesProps, "dataTestId">
+
+const CELL_MIN_HEIGHT_PX = 40
+const CELL_MIN_WIDTH_PX = 80
+
+function cellStyle(meta: ValueDisplayRendererContext): CSSProperties {
+  return meta.visualization === "table"
+    ? { minWidth: CELL_MIN_WIDTH_PX }
+    : { minHeight: CELL_MIN_HEIGHT_PX, minWidth: CELL_MIN_WIDTH_PX }
+}
+
+export const ProgressSeriesCell = (
+  args: ProgressSeriesCellValue,
+  meta: ValueDisplayRendererContext
+) => {
+  const bars = args?.bars
+
+  if (!args?.loading && (!Array.isArray(bars) || bars.length === 0)) {
+    return (
+      <div
+        className={cn(
+          "text-f1-foreground-secondary",
+          meta.visualization === "table" && tableDisplayClassNames.text
+        )}
+        data-cell-type="progressSeries"
+      >
+        –
+      </div>
+    )
+  }
+
+  return (
+    <div
+      className="flex w-full items-center"
+      style={cellStyle(meta)}
+      data-cell-type="progressSeries"
+      aria-busy={args.loading || undefined}
+    >
+      <F0ProgressSeries {...args} bars={bars ?? []} />
+    </div>
+  )
+}


### PR DESCRIPTION
## Description

Adds **`F0ProgressSeries`**, an experimental component that renders N independent progress bars — one per period or segment (Q1…Q4, Jan…Dec, H1/H2) — each with its own track and its own target, plus a **`progressSeries` value display** that reuses it inside `OneDataCollection`.

The existing `progressBar` covers *one* value against *one* target. Goals needs a measure broken into several targets with a different status per period, which no current value display models: `categoryBarChart` composes parts of a single whole and `barSeries` draws vertical columns.

## Type of change

- [x] New component (aligned in #f0-support, lands in `experimental/`)
- [x] Component enhancement / variant (existing component, no breaking change)

## Lifecycle phase (if applicable)

- Linked #f0-support thread: <!-- pending -->
- Phase exit criteria met: lands in `experimental/` behind `experimentalComponent()`; no promotion requested.

## Screenshots (if applicable)

Storybook → **Components / F0ProgressSeries** (component) and **Components / Value Display / ProgressSeries** (cell).

## Implementation details

**Where it lives.** `experimental/F0ProgressSeries/` owns all the rendering; `ui/value-display/types/progressSeries/` is a ~55-line delegate that only adds the `data-cell-type` wrapper and the table min-width. This mirrors how `progressBar` delegates to `Progress`, so the same component works standalone (e.g. a detail view) and inside a data collection.

**Behaviour worth calling out:**

- **Overachievement is shown, not clamped.** Past the target the bar fills completely and splits at `100 / pct` — base colour up to the target, then a lighter shade of the same colour for the excess (158% → ~63% + ~37%). The reported percentage is never capped.
- **Cancelled periods** render as a grey bar with a diagonal hatch (a Tailwind arbitrary class with a `dark:` variant, so it is theme-aware and assertable in unit tests), distinct from an empty/future bar which is track-only.
- **Labels are budgeted.** At most `maxLabels` (default 4) are rendered; with more bars they are spread evenly via `floor(i * count / maxLabels)` — 12 bars → Jan, Apr, Jul, Oct. Bars without a visible label still expose their value through the tooltip and accessible name.
- **Tooltips are generated**, as `label · value / max (pct)`. Since the component only receives raw numbers, `formatValue` handles currencies and units, and a trailing unit shared by both sides is printed once (`Q2 · 1.700 / 3.400 € (50%)`) rather than twice. That same string is the bar's `aria-label`, so the detail is never sighted-only — and it is unit-testable without simulating hover.
- **Generic by design.** Colour is an f0 token per bar (default `categorical-1`); the consumer maps its own domain (Goals maps period status to `feedback-positive` / `feedback-neutral` / `feedback-negative`). No status → colour logic lives in f0.
- **`size`** (`sm` / `md` / `lg`) scales the bar height; the label row follows but caps at `text-sm` (12px), matching `progressBar`'s label. The component is always `w-full` and never caps its own width — the container owns that.

**Non-obvious guards** (each covered by a test): non-finite `value`/`max` and `max <= 0` fall back to the empty state instead of leaking `width: NaN%`; `caption: ""` hides the caption; `tooltip` replaces the generated string entirely.

**i18n.** New `progressSeries.{noData,canceled}` keys in `i18n-provider-defaults.ts`, read through `useI18n()`.

**a11y.** `role="img"` per bar with the tooltip text as accessible name (same contract as `categoryBarChart`), `focusRing()` on the focusable track, `aria-busy` + `aria-live="polite"` on the skeleton, `motion-reduce:transition-none` on the fill, and the label row `aria-hidden` since the bar already announces both parts.

## Checks

`pnpm format` · `pnpm lint` (0 warnings, 0 errors) · `pnpm vitest` (29 tests) · `pnpm tsc` — all green.

<img width="920" height="136" alt="image" src="https://github.com/user-attachments/assets/6ca97e3d-2058-4b3c-ab06-f8131ca02539" />
<img width="904" height="131" alt="image" src="https://github.com/user-attachments/assets/455ca48c-6d4e-4de8-863a-93c36afb42d3" />
<img width="914" height="134" alt="image" src="https://github.com/user-attachments/assets/638c12aa-00fa-4371-a8e2-b12cf7f928ad" />

