### PR TITLE
fix(application-frame): decouple side panel

### DIFF
--- a/packages/react/src/kits/ai/F0AiChat/F0AiChat.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/F0AiChat.tsx
@@ -169,6 +169,7 @@ const F0AiChatComponent = ({
       <Skeleton
         role="status"
         aria-busy={true}
+        aria-label={translations.navigation.sidePanel.loading}
         className="h-full w-full rounded-none"
       />
     )
@@ -218,6 +219,7 @@ const F0AiChatComponent = ({
           : undefined
       }
       exitStyle={splitPanel && open ? "hold" : "shrink"}
+      withAiFeatures={!panelContent && !restoringPanelContentId}
     >
       {/* Simultaneous crossfade: the outgoing view fades out while the next
           fades in (both briefly mounted, stacked via `absolute inset-0` over the

--- a/packages/react/src/kits/ai/F0AiChat/__tests__/F0AiChat.panelContent.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/__tests__/F0AiChat.panelContent.test.tsx
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import {
   zeroRender as render,
@@ -15,8 +15,13 @@ import {
 } from "../providers/AiChatStateProvider"
 
 const Controls = () => {
-  const { setOpen, setPanelContent, clearPanelContent, setPanelSide } =
-    useAiChat()
+  const {
+    setOpen,
+    setPanelContent,
+    clearPanelContent,
+    setPanelSide,
+    openGame,
+  } = useAiChat()
   return (
     <div>
       <button type="button" onClick={() => setOpen(true)}>
@@ -39,6 +44,9 @@ const Controls = () => {
       </button>
       <button type="button" onClick={() => clearPanelContent()}>
         clear
+      </button>
+      <button type="button" onClick={() => openGame("pong")}>
+        open-pong
       </button>
     </div>
   )
@@ -69,6 +77,39 @@ describe("F0AiChat side-panel content", () => {
     await userEvent.click(screen.getByText("show-a"))
     expect(screen.getByText("FAKE A")).toBeInTheDocument()
     expect(screen.queryByText("CHAT MESSAGES")).not.toBeInTheDocument()
+  })
+
+  it("disables AI-only file drop while same-edge hosted content is visible", async () => {
+    render(
+      <AiChatStateProvider
+        enabled
+        chatMessages={<div>CHAT MESSAGES</div>}
+        fileAttachments={{ onUploadFiles: vi.fn() }}
+      >
+        <Controls />
+        <F0AiChat />
+      </AiChatStateProvider>
+    )
+
+    await userEvent.click(screen.getByText("open"))
+    expect(screen.getByText("Drop your files here")).toBeInTheDocument()
+
+    await userEvent.click(screen.getByText("show-a"))
+    expect(screen.getByText("FAKE A")).toBeInTheDocument()
+    expect(screen.queryByText("Drop your files here")).not.toBeInTheDocument()
+  })
+
+  it("hides the AI-only Pong overlay from same-edge hosted content", async () => {
+    renderChat()
+    await userEvent.click(screen.getByText("open"))
+    await userEvent.click(screen.getByText("open-pong"))
+    expect(await screen.findByText("Pong")).toBeInTheDocument()
+
+    await userEvent.click(screen.getByText("show-a"))
+    expect(screen.getByText("FAKE A")).toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.queryByText("Pong")).not.toBeInTheDocument()
+    )
   })
 
   it("swaps the content (unmounts the previous one) on a new selection", async () => {

--- a/packages/react/src/kits/ai/F0AiChat/components/layout/ChatWindow.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/components/layout/ChatWindow.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useMediaQuery } from "usehooks-ts"
 
 import { cn } from "@/lib/utils"
+import { useReducedMotion } from "@/lib/a11y"
 
 import { DropOverlay } from "../../../F0AiChatTextArea"
 import { F0AiPong } from "../../../F0AiPong"
@@ -18,6 +19,7 @@ export const SidebarWindow = ({
   visible,
   side,
   exitStyle = "shrink",
+  withAiFeatures = true,
 }: {
   children?: ReactNode
   /** Overrides the context `open` as the mount condition — lets the frame
@@ -32,6 +34,8 @@ export const SidebarWindow = ({
    * the panels feel like they were always there.
    */
   exitStyle?: "shrink" | "hold"
+  /** Enable AI-only overlays and file-drop behavior. */
+  withAiFeatures?: boolean
 }) => {
   const {
     open,
@@ -39,8 +43,10 @@ export const SidebarWindow = ({
     shouldPlayEntranceAnimation,
     setShouldPlayEntranceAnimation,
     resizable,
+    chatWidth,
     setChatWidth,
     resetChatWidth,
+    panelSide,
     fileAttachments,
     isClarifying,
     fileDragOver,
@@ -48,9 +54,9 @@ export const SidebarWindow = ({
     processDroppedFiles,
     activeGame,
     closeGame,
-    panelSide,
   } = useAiChat()
-  const isCanvasMode = visualizationMode === "canvas"
+  const shouldReduceMotion = useReducedMotion()
+  const isCanvasMode = withAiFeatures && visualizationMode === "canvas"
   // Hosts dock the whole panel left for a chat-first experience (communications);
   // the default is right. The AI chat follows the panel side too.
   const isLeft = (side ?? panelSide) === "left"
@@ -66,7 +72,8 @@ export const SidebarWindow = ({
   })
 
   const dragCounterRef = useRef(0)
-  const canDrop = fileAttachments?.onUploadFiles != null && !isClarifying
+  const canDrop =
+    withAiFeatures && fileAttachments?.onUploadFiles != null && !isClarifying
 
   const handleDragEnter = useCallback(
     (e: React.DragEvent) => {
@@ -125,11 +132,12 @@ export const SidebarWindow = ({
   )
 
   const wrapperTransition = useMemo(() => {
+    if (shouldReduceMotion) return { duration: 0 }
     if (isResizing) return { duration: 0 }
     if (shouldPlayEntranceAnimation)
       return { duration: 0.3, ease: [0, 0, 0.1, 1] as const }
     return { duration: 0.3, ease: [0, 0, 0.1, 1] as const }
-  }, [isResizing, shouldPlayEntranceAnimation])
+  }, [isResizing, shouldPlayEntranceAnimation, shouldReduceMotion])
 
   return (
     <AnimatePresence>
@@ -154,11 +162,13 @@ export const SidebarWindow = ({
             width: "100%",
           }}
           exit={
-            exitStyle === "hold"
-              ? // Swap: stay put while the main content slides over (300ms),
-                // then a blink of fade right before unmounting.
-                { opacity: 0, transition: { delay: 0.25, duration: 0.05 } }
-              : { opacity: 0, width: 0 }
+            shouldReduceMotion
+              ? { opacity: 0, transition: { duration: 0 } }
+              : exitStyle === "hold"
+                ? // Swap: stay put while the main content slides over (300ms),
+                  // then a blink of fade right before unmounting.
+                  { opacity: 0, transition: { delay: 0.25, duration: 0.05 } }
+                : { opacity: 0, width: 0 }
           }
           transition={wrapperTransition}
           style={{ transformOrigin: isLeft ? "left center" : "right center" }}
@@ -178,6 +188,9 @@ export const SidebarWindow = ({
               setIsResizing={setIsResizing}
               isCanvasMode={isCanvasMode}
               side="right"
+              value={chatWidth}
+              minValue={MIN_CHAT_WIDTH}
+              maxValue={MAX_CHAT_WIDTH}
             />
           )}
           <div
@@ -196,10 +209,10 @@ export const SidebarWindow = ({
                   : "xs:rounded-r-xl"
                 : "xs:rounded-xl"
             )}
-            onDragEnter={handleDragEnter}
-            onDragOver={handleDragOver}
-            onDragLeave={handleDragLeave}
-            onDrop={handleDrop}
+            onDragEnter={withAiFeatures ? handleDragEnter : undefined}
+            onDragOver={withAiFeatures ? handleDragOver : undefined}
+            onDragLeave={withAiFeatures ? handleDragLeave : undefined}
+            onDrop={withAiFeatures ? handleDrop : undefined}
           >
             <motion.div
               className="relative flex h-full w-full flex-col overflow-hidden"
@@ -207,9 +220,14 @@ export const SidebarWindow = ({
               animate={{ opacity: 1 }}
               exit={{ opacity: 0 }}
               transition={{
-                duration: shouldPlayEntranceAnimation ? 0.3 : 0.05,
+                duration: shouldReduceMotion
+                  ? 0
+                  : shouldPlayEntranceAnimation
+                    ? 0.3
+                    : 0.05,
                 ease: "easeOut",
-                delay: shouldPlayEntranceAnimation ? 0.2 : 0,
+                delay:
+                  shouldReduceMotion || !shouldPlayEntranceAnimation ? 0 : 0.2,
               }}
             >
               {children}
@@ -224,7 +242,9 @@ export const SidebarWindow = ({
                 }}
               />
             )}
-            {activeGame === "pong" && <F0AiPong onClose={closeGame} />}
+            {withAiFeatures && activeGame === "pong" && (
+              <F0AiPong onClose={closeGame} />
+            )}
           </div>
           {resizable && !fullscreen && !isSmallScreen && isLeft && (
             <ResizeHandle
@@ -234,6 +254,9 @@ export const SidebarWindow = ({
               setIsResizing={setIsResizing}
               isCanvasMode={isCanvasMode}
               side="left"
+              value={chatWidth}
+              minValue={MIN_CHAT_WIDTH}
+              maxValue={MAX_CHAT_WIDTH}
             />
           )}
         </motion.div>

--- a/packages/react/src/kits/ai/F0AiChat/components/layout/HostedPanelWindow.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/components/layout/HostedPanelWindow.tsx
@@ -2,6 +2,7 @@ import { AnimatePresence, motion } from "motion/react"
 import { useRef } from "react"
 
 import { useReducedMotion } from "@/lib/a11y"
+import { useI18n } from "@/lib/providers/i18n"
 import { Skeleton } from "@/ui/skeleton"
 
 import { useAiChat } from "../../providers/AiChatStateProvider"
@@ -18,6 +19,7 @@ export const HostedPanelWindow = () => {
   const { open, panelContent, panelContentSide, restoringPanelContentId } =
     useAiChat()
   const reducedMotion = useReducedMotion()
+  const translations = useI18n()
 
   // Keep the last content mounted through the swap-out: `panelContent` clears
   // immediately, but the window holds still (exitStyle "hold") while the main
@@ -35,6 +37,7 @@ export const HostedPanelWindow = () => {
             <Skeleton
               role="status"
               aria-busy={true}
+              aria-label={translations.navigation.sidePanel.loading}
               className="h-full w-full rounded-none"
             />
           ),
@@ -47,6 +50,7 @@ export const HostedPanelWindow = () => {
       visible={open && (panelContent !== null || restoring !== null)}
       side={panelContentSide}
       exitStyle={open ? "hold" : "shrink"}
+      withAiFeatures={false}
     >
       {/* Same simultaneous crossfade as F0AiChat's view switch: changing
           conversations fades the outgoing one out while the next fades in. */}

--- a/packages/react/src/kits/ai/F0AiChat/components/layout/ResizeHandle.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/components/layout/ResizeHandle.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useRef } from "react"
 
-import { cn } from "@/lib/utils"
+import { ButtonInternal } from "@/components/F0Button/internal"
+import Minus from "@/icons/app/Minus"
+import Plus from "@/icons/app/Plus"
+import { useI18n } from "@/lib/providers/i18n"
+import { cn, focusRing } from "@/lib/utils"
+
+const KEYBOARD_RESIZE_STEP = 16
 
 export const ResizeHandle = ({
   onResize,
@@ -9,6 +15,9 @@ export const ResizeHandle = ({
   setIsResizing,
   isCanvasMode,
   side = "right",
+  value,
+  minValue,
+  maxValue,
 }: {
   onResize: (deltaX: number) => void
   onReset: () => void
@@ -17,8 +26,15 @@ export const ResizeHandle = ({
   isCanvasMode?: boolean
   /** Edge the panel docks to. Determines which drag direction widens it. */
   side?: "left" | "right"
+  /** Current panel width in pixels. */
+  value: number
+  /** Minimum panel width in pixels. */
+  minValue: number
+  /** Maximum panel width in pixels. */
+  maxValue: number
 }) => {
   const startXRef = useRef(0)
+  const translations = useI18n()
 
   const handleMouseDown = useCallback(
     (e: React.MouseEvent) => {
@@ -62,6 +78,36 @@ export const ResizeHandle = ({
     }
   }, [isResizing, onResize, setIsResizing, side])
 
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      let delta: number
+      switch (event.key) {
+        case "ArrowLeft":
+          delta = side === "left" ? -KEYBOARD_RESIZE_STEP : KEYBOARD_RESIZE_STEP
+          break
+        case "ArrowRight":
+          delta = side === "left" ? KEYBOARD_RESIZE_STEP : -KEYBOARD_RESIZE_STEP
+          break
+        case "Home":
+          delta = minValue - value
+          break
+        case "End":
+          delta = maxValue - value
+          break
+        case "Enter":
+          event.preventDefault()
+          onReset()
+          return
+        default:
+          return
+      }
+
+      event.preventDefault()
+      onResize(delta)
+    },
+    [maxValue, minValue, onReset, onResize, side, value]
+  )
+
   return (
     // z-10 so the handle — and its invisible hit-area extension — paints
     // above the chat-content sibling (same flex row, later in DOM, no
@@ -70,32 +116,78 @@ export const ResizeHandle = ({
     // mouse events first.
     <div
       className={cn(
-        "group relative z-10 h-full flex-shrink-0 cursor-ew-resize w-1",
+        "group relative z-10 h-full w-1 flex-shrink-0",
         isCanvasMode &&
           "border border-solid border-x-0 border-f1-border-secondary bg-f1-special-page"
       )}
-      onMouseDown={handleMouseDown}
-      onDoubleClick={handleDoubleClick}
     >
-      {/* Invisible hit-area extension so the 1-pixel line stays comfortable
-          to grab with a mouse without widening the visible gap between
-          canvas and chat. Extends a few pixels into each neighbour. */}
-      <div aria-hidden className="absolute -inset-x-1 inset-y-0" />
-
-      {/* Visible divider. Absolutely positioned and centered so it can grow
-          on hover without pushing the surrounding layout. In canvas mode it
-          starts as a 1px hairline rule; in chat-only mode it starts hidden
-          and only reveals on hover / while dragging. */}
       <div
-        aria-hidden
-        className={cn(
-          "pointer-events-none absolute inset-y-0 left-1/2 -translate-x-1/2 rounded-full",
-          "transition-[width,background-color] duration-150 ease-out",
-          "w-px bg-transparent",
-          "group-hover:w-1 group-hover:bg-f1-background-secondary-hover",
-          isResizing && "!w-1 !bg-f1-background-secondary-hover"
+        className={focusRing(
+          "relative h-full w-full cursor-ew-resize rounded-sm"
         )}
-      />
+        role="separator"
+        aria-label={translations.navigation.sidePanel.resize}
+        aria-orientation="vertical"
+        aria-valuemin={minValue}
+        aria-valuemax={maxValue}
+        aria-valuenow={value}
+        aria-valuetext={translations.t("navigation.sidePanel.width", {
+          width: value,
+        })}
+        tabIndex={0}
+        onMouseDown={handleMouseDown}
+        onDoubleClick={handleDoubleClick}
+        onKeyDown={handleKeyDown}
+      >
+        {/* Invisible hit-area extension so the 1-pixel line stays comfortable
+            to grab with a mouse without widening the visible gap between
+            canvas and chat. Extends a few pixels into each neighbour. */}
+        <div aria-hidden className="absolute -inset-x-3 inset-y-0" />
+
+        {/* Visible divider. Absolutely positioned and centered so it can grow
+            on hover without pushing the surrounding layout. In canvas mode it
+            starts as a 1px hairline rule; in chat-only mode it starts hidden
+            and only reveals on hover / while dragging. */}
+        <div
+          aria-hidden
+          className={cn(
+            "pointer-events-none absolute inset-y-0 left-1/2 -translate-x-1/2 rounded-full",
+            "transition-[width,background-color] duration-150 ease-out motion-reduce:transition-none",
+            "w-px bg-transparent",
+            "group-hover:w-1 group-hover:bg-f1-background-secondary-hover",
+            isResizing && "!w-1 !bg-f1-background-secondary-hover"
+          )}
+        />
+      </div>
+
+      {/* Pointer alternative to dragging (WCAG 2.5.7). The controls stay out
+          of the resting layout and reveal on hover or keyboard focus. */}
+      <div
+        className={cn(
+          "absolute left-1/2 top-1/2 z-20 flex -translate-x-1/2 -translate-y-1/2 flex-col gap-1 rounded-lg border border-solid border-f1-border-secondary bg-f1-background p-1 opacity-0 shadow-sm",
+          "transition-opacity motion-reduce:transition-none",
+          "group-hover:opacity-100 group-focus-within:opacity-100"
+        )}
+      >
+        <ButtonInternal
+          variant="ghost"
+          size="sm"
+          hideLabel
+          label={translations.navigation.sidePanel.increaseWidth}
+          icon={Plus}
+          disabled={value >= maxValue}
+          onClick={() => onResize(KEYBOARD_RESIZE_STEP)}
+        />
+        <ButtonInternal
+          variant="ghost"
+          size="sm"
+          hideLabel
+          label={translations.navigation.sidePanel.decreaseWidth}
+          icon={Minus}
+          disabled={value <= minValue}
+          onClick={() => onResize(-KEYBOARD_RESIZE_STEP)}
+        />
+      </div>
     </div>
   )
 }

--- a/packages/react/src/kits/ai/F0AiChat/components/layout/__tests__/ResizeHandle.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/components/layout/__tests__/ResizeHandle.test.tsx
@@ -1,6 +1,12 @@
-import { fireEvent, render } from "@testing-library/react"
 import { useState } from "react"
 import { describe, expect, it, vi } from "vitest"
+
+import {
+  fireEvent,
+  screen,
+  userEvent,
+  zeroRender as render,
+} from "@/testing/test-utils"
 
 import { ResizeHandle } from "../ResizeHandle"
 
@@ -11,26 +17,31 @@ const noop = () => {}
 const Harness = ({
   side,
   onResize,
+  onReset = noop,
 }: {
   side: "left" | "right"
   onResize: (delta: number) => void
+  onReset?: () => void
 }) => {
   const [isResizing, setIsResizing] = useState(false)
   return (
     <ResizeHandle
       onResize={onResize}
-      onReset={noop}
+      onReset={onReset}
       isResizing={isResizing}
       setIsResizing={setIsResizing}
       side={side}
+      value={360}
+      minValue={300}
+      maxValue={712}
     />
   )
 }
 
 const dragBy = (side: "left" | "right", from: number, to: number) => {
   const onResize = vi.fn()
-  const { container } = render(<Harness side={side} onResize={onResize} />)
-  const handle = container.firstChild as HTMLElement
+  render(<Harness side={side} onResize={onResize} />)
+  const handle = screen.getByRole("separator")
 
   fireEvent.mouseDown(handle, { clientX: from })
   fireEvent.mouseMove(document, { clientX: to })
@@ -46,5 +57,64 @@ describe("ResizeHandle drag direction", () => {
   it("left-docked: dragging the handle rightward widens (positive delta)", () => {
     // Move right: clientX 500 -> 520 => clientX - startX = +20.
     expect(dragBy("left", 500, 520)).toHaveBeenCalledWith(20)
+  })
+
+  it("exposes the current width through an adjustable separator", () => {
+    render(<Harness side="right" onResize={vi.fn()} />)
+
+    const handle = screen.getByRole("separator", {
+      name: "Resize side panel",
+    })
+    expect(handle).toHaveAttribute("aria-orientation", "vertical")
+    expect(handle).toHaveAttribute("aria-valuemin", "300")
+    expect(handle).toHaveAttribute("aria-valuemax", "712")
+    expect(handle).toHaveAttribute("aria-valuenow", "360")
+    expect(handle).toHaveAttribute("aria-valuetext", "360 pixels")
+  })
+
+  it.each([
+    ["right", "ArrowLeft", 16],
+    ["right", "ArrowRight", -16],
+    ["left", "ArrowLeft", -16],
+    ["left", "ArrowRight", 16],
+    ["right", "Home", -60],
+    ["right", "End", 352],
+  ] as const)(
+    "%s-docked: %s resizes by %i pixels",
+    async (side, key, expectedDelta) => {
+      const onResize = vi.fn()
+      render(<Harness side={side} onResize={onResize} />)
+
+      const handle = screen.getByRole("separator")
+      handle.focus()
+      await userEvent.keyboard(`{${key}}`)
+
+      expect(onResize).toHaveBeenCalledWith(expectedDelta)
+    }
+  )
+
+  it("resets to the default width with Enter", async () => {
+    const onReset = vi.fn()
+    render(<Harness side="right" onResize={vi.fn()} onReset={onReset} />)
+
+    screen.getByRole("separator").focus()
+    await userEvent.keyboard("{Enter}")
+
+    expect(onReset).toHaveBeenCalledOnce()
+  })
+
+  it("offers increase and decrease buttons as pointer alternatives to dragging", async () => {
+    const onResize = vi.fn()
+    render(<Harness side="right" onResize={onResize} />)
+
+    await userEvent.click(
+      screen.getByRole("button", { name: "Increase side panel width" })
+    )
+    await userEvent.click(
+      screen.getByRole("button", { name: "Decrease side panel width" })
+    )
+
+    expect(onResize).toHaveBeenNthCalledWith(1, 16)
+    expect(onResize).toHaveBeenNthCalledWith(2, -16)
   })
 })

--- a/packages/react/src/kits/ai/F0AiChat/internal-types.ts
+++ b/packages/react/src/kits/ai/F0AiChat/internal-types.ts
@@ -186,27 +186,28 @@ export type AiChatProviderReturnValue = {
   /** Set the pending quote (pass null to clear). */
   setPendingQuote: React.Dispatch<React.SetStateAction<PendingQuote | null>>
   /**
-   * Content currently hosted in the side panel, or `null` to show the F0.ai
-   * chat. Only one is mounted at a time — see {@link SidePanelContent}.
+   * Content currently hosted in the side panel, or `null` when there is no
+   * hosted view. If the F0.ai chat is enabled, it is revealed instead.
+   * Only one hosted view is mounted at a time — see {@link SidePanelContent}.
    */
   panelContent: SidePanelContent | null
   /**
    * Mount `content` in the side panel (replacing whatever was there) and open
-   * the panel. Pass `null` to fall back to the AI chat. The previous content
-   * is unmounted thanks to the `id` key.
+   * the panel. Pass `null` to remove the hosted view. The previous content is
+   * unmounted thanks to the `id` key.
    */
   setPanelContent: (content: SidePanelContent | null) => void
-  /** Clear the custom panel content and fall back to the F0.ai chat. */
+  /** Clear the hosted panel content, revealing the F0.ai chat when enabled. */
   clearPanelContent: () => void
   /**
    * Id of the hosted content that was showing when the page last unloaded,
    * pending restoration. The panel holds a skeleton (no AI-chat flash) until
    * the host re-mounts it via `setPanelContent`, cancels via
    * `cancelPanelContentRestore` (content no longer accessible), or a safety
-   * timeout falls back to the AI chat.
+   * timeout removes the pending hosted view.
    */
   restoringPanelContentId: string | null
-  /** Give up on restoring the persisted panel content — show the AI chat. */
+  /** Give up on restoring the persisted hosted panel content. */
   cancelPanelContentRestore: () => void
   /**
    * Edge the whole side panel docks to — the AI chat, hosted content and the

--- a/packages/react/src/kits/ai/F0AiChat/providers/AiChatStateProvider.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/providers/AiChatStateProvider.tsx
@@ -41,8 +41,9 @@ const CHAT_WIDTH_MIN = 300
 const CHAT_WIDTH_MAX = 712
 
 /** How long a pending panel-content restore may wait for the host before
- * falling back to the AI chat — a host that never resolves (the conversation
- * is gone, or it isn't restore-aware) must not block the panel forever. */
+ * removing the pending hosted view — a host that never resolves (the
+ * conversation is gone, or it isn't restore-aware) must not block the panel
+ * forever. */
 const PANEL_RESTORE_TIMEOUT_MS = 5000
 
 const isPersistableVisualizationMode = (value: VisualizationMode): boolean =>
@@ -135,12 +136,6 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   const [initialMessage, setInitialMessage] = useState<
     string | string[] | undefined
   >(initialInitialMessage)
-
-  useEffect(() => {
-    if (open) {
-      tracking?.onVisibility?.()
-    }
-  }, [open])
 
   const [canvasContent, setCanvasContent] = useState<CanvasContent | null>(null)
 
@@ -271,21 +266,41 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   // Pending restore: the panel reopened (persisted `open`) while hosted
   // content was up on the last session. Until the host re-mounts it (via
   // `setPanelContent`) the panel shows a skeleton instead of flashing the AI
-  // chat. Cleared by the host (restore or cancel), by opening the AI chat
-  // (`clearPanelContent`), by closing the panel, or by the safety timeout.
+  // base panel view. Cleared by the host (restore or cancel), by clearing
+  // hosted content, by closing the panel, or by the safety timeout.
   const [restoringPanelContentId, setRestoringPanelContentId] = useState<
     string | null
   >(() => (open ? persistedPanelContentId : null))
+  const wasAiChatVisibleRef = useRef(false)
+
+  useEffect(() => {
+    const isAiChatVisible =
+      enabledInternal &&
+      open &&
+      panelContent === null &&
+      restoringPanelContentId === null
+    if (isAiChatVisible && !wasAiChatVisibleRef.current) {
+      tracking?.onVisibility?.()
+    }
+    wasAiChatVisibleRef.current = isAiChatVisible
+  }, [enabledInternal, open, panelContent, restoringPanelContentId, tracking])
 
   const setPanelContent = useCallback(
     (content: SidePanelContent | null) => {
       setPanelContentState(content)
       setRestoringPanelContentId(null)
-      if (content && !open) {
-        setOpen(true)
+      if (content) {
+        // Hosted content and the AI canvas use the same frame space. Entering
+        // a hosted view always leaves canvas mode so both can never overlap.
+        setVisualizationMode((current) =>
+          current === "canvas" ? "sidepanel" : current
+        )
+        if (!open) {
+          setOpen(true)
+        }
       }
     },
-    [open, setOpen]
+    [open, setOpen, setVisualizationMode]
   )
   const clearPanelContent = useCallback(() => {
     setPanelContentState(null)
@@ -305,13 +320,13 @@ export const AiChatStateProvider: FC<PropsWithChildren<AiChatState>> = ({
   }, [panelContent, restoringPanelContentId, setPersistedPanelContentId])
 
   // A restore only makes sense while the panel is open; closing it drops the
-  // pending id (the AI chat comes back normally on the next open).
+  // pending id (the base panel view comes back normally on the next open).
   useEffect(() => {
     if (!open) setRestoringPanelContentId(null)
   }, [open])
 
   // Safety net: a host that never resolves the restore must not block the
-  // panel — fall back to the AI chat.
+  // panel — remove the pending hosted view.
   useEffect(() => {
     if (!restoringPanelContentId) return
     const timer = setTimeout(
@@ -485,6 +500,81 @@ const NO_PROVIDER_CONTEXT = new Proxy({} as AiChatProviderReturnValue, {
     return noop
   },
 })
+
+export type ApplicationFrameSidePanelVisualizationMode =
+  | "sidepanel"
+  | "fullscreen"
+
+export type ApplicationFrameSidePanelReturnValue = {
+  /** Whether the shared panel shell is open. */
+  open: boolean
+  /** Open or close the shared panel shell. */
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>
+  /** Layout available to generic hosted content. */
+  visualizationMode: ApplicationFrameSidePanelVisualizationMode
+  /** Switch generic hosted content between docked and fullscreen layouts. */
+  setVisualizationMode: React.Dispatch<
+    React.SetStateAction<ApplicationFrameSidePanelVisualizationMode>
+  >
+  /** Content currently hosted in the panel. */
+  panelContent: SidePanelContent | null
+  /** Mount hosted content and open the panel. */
+  setPanelContent: (content: SidePanelContent | null) => void
+  /** Remove the hosted content without changing the open state. */
+  clearPanelContent: () => void
+  /** Persisted hosted-content id waiting for the host to restore it. */
+  restoringPanelContentId: string | null
+  /** Abandon a pending hosted-content restore. */
+  cancelPanelContentRestore: () => void
+}
+
+/**
+ * Read and control ApplicationFrame's generic side panel.
+ *
+ * Unlike `useAiChat`, this contract contains no AI state and remains available
+ * when ApplicationFrame enables its side panel without enabling the AI chat.
+ */
+export function useApplicationFrameSidePanel(): ApplicationFrameSidePanelReturnValue {
+  const {
+    open,
+    setOpen,
+    visualizationMode,
+    setVisualizationMode,
+    panelContent,
+    setPanelContent,
+    clearPanelContent,
+    restoringPanelContentId,
+    cancelPanelContentRestore,
+  } = useContext(AiChatStateContext) ?? NO_PROVIDER_CONTEXT
+  const sidePanelVisualizationMode =
+    visualizationMode === "fullscreen" ? "fullscreen" : "sidepanel"
+  const setSidePanelVisualizationMode = useCallback<
+    React.Dispatch<
+      React.SetStateAction<ApplicationFrameSidePanelVisualizationMode>
+    >
+  >(
+    (next) => {
+      setVisualizationMode((current) => {
+        const currentSidePanelMode =
+          current === "fullscreen" ? "fullscreen" : "sidepanel"
+        return typeof next === "function" ? next(currentSidePanelMode) : next
+      })
+    },
+    [setVisualizationMode]
+  )
+
+  return {
+    open,
+    setOpen,
+    visualizationMode: sidePanelVisualizationMode,
+    setVisualizationMode: setSidePanelVisualizationMode,
+    panelContent,
+    setPanelContent,
+    clearPanelContent,
+    restoringPanelContentId,
+    cancelPanelContentRestore,
+  }
+}
 
 /**
  * Read the AiChat context. Returns an inert fallback when no provider

--- a/packages/react/src/kits/ai/F0AiChat/providers/__tests__/AiChatStateProvider.panelContent.test.tsx
+++ b/packages/react/src/kits/ai/F0AiChat/providers/__tests__/AiChatStateProvider.panelContent.test.tsx
@@ -4,7 +4,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { TestProviders } from "@/testing/test-utils"
 
-import { AiChatStateProvider, useAiChat } from "../AiChatStateProvider"
+import {
+  AiChatStateProvider,
+  useAiChat,
+  useApplicationFrameSidePanel,
+} from "../AiChatStateProvider"
 
 const wrapper = ({ children }: { children: ReactNode }) => (
   <TestProviders>
@@ -129,6 +133,116 @@ describe("AiChatStateProvider panel content", () => {
       result.current.setPanelContentSide("right")
     })
     expect(result.current.panelContentSide).toBe("right")
+  })
+
+  it("keeps AI canvas state out of the generic side-panel contract", () => {
+    const { result } = renderHook(
+      () => ({
+        ai: useAiChat(),
+        sidePanel: useApplicationFrameSidePanel(),
+      }),
+      { wrapper }
+    )
+
+    act(() => {
+      result.current.ai.openCanvas({
+        type: "form",
+        title: "Example form",
+        description: "Example",
+        formName: "example",
+      })
+    })
+
+    expect(result.current.ai.visualizationMode).toBe("canvas")
+    expect(result.current.sidePanel.visualizationMode).toBe("sidepanel")
+
+    act(() => {
+      result.current.sidePanel.setPanelContent({
+        id: "conv",
+        content: <div>Conv</div>,
+      })
+    })
+
+    expect(result.current.ai.visualizationMode).toBe("sidepanel")
+    expect(result.current.ai.canvasContent).toBeNull()
+    expect(result.current.sidePanel.panelContent?.id).toBe("conv")
+  })
+})
+
+describe("AiChatStateProvider visibility tracking", () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  const trackingWrapper = (onVisibility: () => void, enabled = true) => {
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+      <TestProviders>
+        <AiChatStateProvider enabled={enabled} tracking={{ onVisibility }}>
+          {children}
+        </AiChatStateProvider>
+      </TestProviders>
+    )
+    return Wrapper
+  }
+
+  it("tracks each transition into the visible AI view", () => {
+    const onVisibility = vi.fn()
+    const { result } = renderHook(() => useAiChat(), {
+      wrapper: trackingWrapper(onVisibility),
+    })
+
+    act(() => {
+      result.current.setOpen(true)
+    })
+    expect(onVisibility).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      result.current.setPanelContent({
+        id: "conv",
+        content: <div>Conv</div>,
+      })
+    })
+    expect(onVisibility).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      result.current.clearPanelContent()
+    })
+    expect(onVisibility).toHaveBeenCalledTimes(2)
+  })
+
+  it("does not track a hosted panel while AI is disabled", () => {
+    const onVisibility = vi.fn()
+    const { result } = renderHook(() => useAiChat(), {
+      wrapper: trackingWrapper(onVisibility, false),
+    })
+
+    act(() => {
+      result.current.setPanelContent({
+        id: "conv",
+        content: <div>Conv</div>,
+      })
+    })
+
+    expect(result.current.open).toBe(true)
+    expect(onVisibility).not.toHaveBeenCalled()
+  })
+
+  it("waits for a pending restore to resolve before tracking AI visibility", () => {
+    localStorage.setItem("ONE-ai-chat-open", "true")
+    localStorage.setItem("ONE-ai-chat-panel-content-id", '"conv"')
+    const onVisibility = vi.fn()
+    const { result } = renderHook(() => useAiChat(), {
+      wrapper: trackingWrapper(onVisibility),
+    })
+
+    expect(result.current.restoringPanelContentId).toBe("conv")
+    expect(onVisibility).not.toHaveBeenCalled()
+
+    act(() => {
+      result.current.cancelPanelContentRestore()
+    })
+
+    expect(onVisibility).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/packages/react/src/kits/ai/F0AiChat/types.ts
+++ b/packages/react/src/kits/ai/F0AiChat/types.ts
@@ -218,10 +218,10 @@ export type AiChatMode = "chat" | "voice"
 export type VisualizationMode = "sidepanel" | "fullscreen" | "canvas"
 
 /**
- * A single piece of content hosted in the side panel — the same resizable +
- * fullscreen space the F0.ai chat lives in. Only one is mounted at a time:
- * the `id` keys the content so switching conversations unmounts the previous
- * one and mounts the new. `panelContent === null` falls back to the AI chat.
+ * A single piece of content hosted in ApplicationFrame's resizable and
+ * fullscreen side panel. Only one is mounted at a time: the `id` keys the
+ * content so switching views unmounts the previous one and mounts the new.
+ * When the AI chat is enabled, removing hosted content reveals it.
  */
 export type SidePanelContent = {
   id: string

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -30,6 +30,13 @@ export const defaultTranslations = {
         placeholder: "Select a company",
       },
     },
+    sidePanel: {
+      decreaseWidth: "Decrease side panel width",
+      increaseWidth: "Increase side panel width",
+      loading: "Loading side panel",
+      resize: "Resize side panel",
+      width: "{{width}} pixels",
+    },
     previous: "Previous",
     next: "Next",
   },

--- a/packages/react/src/patterns/ApplicationFrame/__tests__/ApplicationFrame.splitPanel.test.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/__tests__/ApplicationFrame.splitPanel.test.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from "react"
-import { beforeEach, describe, expect, it } from "vitest"
+import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { useAiPromotionChat } from "@/experimental/AiPromotionChat/providers/AiPromotionChatStateProvider"
 import { useAiChat } from "@/kits/ai/F0AiChat/providers/AiChatStateProvider"
 import {
   zeroRender as render,
@@ -9,7 +10,7 @@ import {
   waitFor,
 } from "@/testing/test-utils"
 
-import { ApplicationFrame } from ".."
+import { ApplicationFrame, useApplicationFrameSidePanel } from ".."
 
 // Drives the panel the way the real hosts do: the sidebar mounts a
 // conversation via setPanelContent; the page header's One switch clears it
@@ -34,6 +35,44 @@ const Probe = () => {
         }}
       >
         one-switch-on
+      </button>
+    </div>
+  )
+}
+
+const SidePanelProbe = () => {
+  const { setPanelContent } = useApplicationFrameSidePanel()
+  const { enabled: aiEnabled } = useAiChat()
+
+  return (
+    <div>
+      <div>AI ENABLED: {String(aiEnabled)}</div>
+      <button
+        type="button"
+        onClick={() =>
+          setPanelContent({ id: "conv", content: <div>CONVERSATION</div> })
+        }
+      >
+        open-conv
+      </button>
+    </div>
+  )
+}
+
+const PromotionProbe = () => {
+  const { setPanelContent } = useApplicationFrameSidePanel()
+  const { enabled: promotionEnabled } = useAiPromotionChat()
+
+  return (
+    <div>
+      <div>PROMOTION ENABLED: {String(promotionEnabled)}</div>
+      <button
+        type="button"
+        onClick={() =>
+          setPanelContent({ id: "conv", content: <div>CONVERSATION</div> })
+        }
+      >
+        open-conv
       </button>
     </div>
   )
@@ -99,6 +138,78 @@ describe("ApplicationFrame split panel (conversations left, AI chat right)", () 
     // docked right (the default side).
     const conversation = screen.getByText("CONVERSATION")
     expect(conversation.closest(".right-0")).not.toBeNull()
+  })
+
+  it("hosts content when the side panel is enabled and AI is disabled", async () => {
+    const onAiVisibility = vi.fn()
+
+    render(
+      <ApplicationFrame
+        ai={{
+          enabled: false,
+          chatMessages: <div>AI CHAT</div>,
+          fileAttachments: { onUploadFiles: vi.fn() },
+          tracking: { onVisibility: onAiVisibility },
+        }}
+        sidePanel={{ enabled: true, side: "left", resizable: true }}
+        sidebar={<div>SIDEBAR</div>}
+      >
+        <SidePanelProbe />
+      </ApplicationFrame>
+    )
+
+    expect(screen.getByText("AI ENABLED: false")).toBeInTheDocument()
+    await userEvent.click(screen.getByText("open-conv"))
+
+    const conversation = screen.getByText("CONVERSATION")
+    expect(conversation.closest(".left-0")).not.toBeNull()
+    const separator = screen.getByRole("separator", {
+      name: "Resize side panel",
+    })
+    expect(separator).toHaveAttribute("aria-valuenow", "360")
+    separator.focus()
+    await userEvent.keyboard("{ArrowRight}")
+    expect(separator).toHaveAttribute("aria-valuenow", "376")
+    expect(screen.queryByText("AI CHAT")).not.toBeInTheDocument()
+    expect(screen.queryByText("Drop your files here")).not.toBeInTheDocument()
+    expect(onAiVisibility).not.toHaveBeenCalled()
+  })
+
+  it("keeps the generic side panel available with AI promotion enabled", async () => {
+    render(
+      <ApplicationFrame
+        ai={{ enabled: false }}
+        sidePanel={{ enabled: true, side: "left" }}
+        aiPromotion={{ enabled: true }}
+        sidebar={<div>SIDEBAR</div>}
+      >
+        <PromotionProbe />
+      </ApplicationFrame>
+    )
+
+    expect(screen.getByText("PROMOTION ENABLED: true")).toBeInTheDocument()
+
+    await userEvent.click(screen.getByText("open-conv"))
+    expect(screen.getByText("CONVERSATION")).toBeInTheDocument()
+  })
+
+  it("does not reserve an empty gutter for persisted open state without content", () => {
+    localStorage.setItem("ONE-ai-chat-open", "true")
+
+    render(
+      <ApplicationFrame
+        ai={{ enabled: false }}
+        sidePanel={{ enabled: true, side: "left" }}
+        sidebar={<div>SIDEBAR</div>}
+      >
+        <div>PAGE</div>
+      </ApplicationFrame>
+    )
+
+    expect(screen.queryByRole("separator")).not.toBeInTheDocument()
+    const panelPaddingHost = screen.getByRole("main").parentElement
+    expect(panelPaddingHost).not.toHaveStyle({ paddingLeft: "360px" })
+    expect(panelPaddingHost).not.toHaveStyle({ paddingRight: "360px" })
   })
 
   it("restores the last conversation on reload without flashing the AI chat", async () => {

--- a/packages/react/src/patterns/ApplicationFrame/index.mdx
+++ b/packages/react/src/patterns/ApplicationFrame/index.mdx
@@ -1,0 +1,184 @@
+import { Canvas, Controls, Meta, Unstyled } from "@storybook/addon-docs/blocks"
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
+
+import * as ApplicationFrameStories from "./index.stories"
+
+<Meta of={ApplicationFrameStories} />
+
+# Application frame
+
+`ApplicationFrame` is the top-level application shell. It coordinates the main
+navigation, page content, banners, AI surfaces, and an optional generic side
+panel.
+
+## Anatomy
+
+<Canvas of={ApplicationFrameStories.Default} />
+
+<Controls of={ApplicationFrameStories.Default} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Prop</th>
+        <th className="text-left">Description</th>
+        <th className="text-left">Required</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>sidebar</code>
+        </td>
+        <td>Main application navigation rendered beside the page.</td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>
+          <code>children</code>
+        </td>
+        <td>Page content rendered in the frame's main landmark.</td>
+        <td>Yes</td>
+      </tr>
+      <tr>
+        <td>
+          <code>banner</code>
+        </td>
+        <td>Optional full-width content rendered above the shell.</td>
+        <td>No</td>
+      </tr>
+      <tr>
+        <td>
+          <code>sidePanel</code>
+        </td>
+        <td>
+          Enables a generic hosted panel independently from the AI assistant.
+        </td>
+        <td>No</td>
+      </tr>
+      <tr>
+        <td>
+          <code>ai</code>
+        </td>
+        <td>Configures the F0 AI chat and its connected content slots.</td>
+        <td>No</td>
+      </tr>
+      <tr>
+        <td>
+          <code>aiPromotion</code>
+        </td>
+        <td>Configures the promotional AI surface for non-enabled users.</td>
+        <td>No</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+### Generic side panel
+
+<Canvas of={ApplicationFrameStories.CommunicationsWithoutAi} />
+
+The `sidePanel` configuration has three fields:
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Field</th>
+        <th className="text-left">Behavior</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>enabled</code>
+        </td>
+        <td>Mounts the generic panel provider and shell.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>side</code>
+        </td>
+        <td>
+          Docks hosted content on <code>left</code> or <code>right</code>. It
+          falls back to <code>ai.panelContentSide</code>, then{" "}
+          <code>ai.side</code>, then <code>right</code>.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>resizable</code>
+        </td>
+        <td>
+          Enables the resize separator. It falls back to{" "}
+          <code>ai.resizable</code> when AI is configured, otherwise it is
+          disabled.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+Descendants control hosted content with `useApplicationFrameSidePanel()`. The
+hook exposes `open`, `setOpen`, `visualizationMode`,
+`setVisualizationMode`, `panelContent`, `setPanelContent`,
+`clearPanelContent`, `restoringPanelContentId`, and
+`cancelPanelContentRestore`. Generic content supports `sidepanel` and
+`fullscreen` layouts; AI-only canvas state is not part of this contract.
+
+## Guidelines
+
+- When a product needs contextual content beside the page, enable `sidePanel`
+  and mount that content with `setPanelContent`.
+- When `sidePanel.enabled` is true and `ai.enabled` is false, hosted content
+  remains fully operational without mounting AI UI or firing AI visibility
+  tracking.
+- When `setPanelContent` receives a view, the shell opens and replaces the
+  previously hosted view using its `id`.
+- When `clearPanelContent` runs, the generic view is removed. The AI chat is
+  revealed only when AI is enabled.
+- When AI and hosted content use opposite sides, the frame keeps them mutually
+  exclusive and moves the main page between the active edges.
+- When hosted content opens while an AI canvas is active, the frame exits
+  canvas mode before displaying the hosted view.
+- When `restoringPanelContentId` is set after reload, restore the matching view
+  with `setPanelContent` or call `cancelPanelContentRestore` when it is no
+  longer available.
+- When `aiPromotion` and `sidePanel` are enabled together, both providers remain
+  available; each surface keeps its own open state.
+
+<DoDonts
+  do={{
+    description: "Keep product-owned content independent from AI availability.",
+    guidelines: [
+      "Use sidePanel for conversations, inspectors, or other contextual views.",
+      "Use the neutral side-panel hook from product integrations.",
+      "Give each hosted view a stable id so reload restoration is deterministic.",
+    ],
+  }}
+  dont={{
+    description: "Do not couple generic panel behavior to the AI chat.",
+    guidelines: [
+      "Do not check useAiChat().enabled before opening product-owned content.",
+      "Do not use AI canvas or file-drop APIs from a hosted generic view.",
+      "Do not leave a pending restore unresolved when the content is unavailable.",
+    ],
+  }}
+/>
+
+## Accessibility
+
+- The frame provides a skip link to the main `content` landmark.
+- Resizable panels expose a focusable vertical separator with the current,
+  minimum, and maximum width.
+- With the resize separator focused, use Left Arrow or Right Arrow to adjust
+  the width, Home for the minimum, End for the maximum, and Enter to restore
+  the default width.
+- Pointer users can use the increase and decrease controls revealed on hover or
+  focus as an alternative to dragging the separator.
+- Panel and page transitions honor the user's reduced-motion preference.
+- A pending restored panel exposes a labelled loading status until the host
+  restores or cancels it.
+- Hosted content owns its internal landmarks, accessible name, focus movement,
+  and close controls. Opening the shell does not move focus automatically.

--- a/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { ComponentProps, useCallback, useEffect, useRef, useState } from "react"
+import { expect, within } from "storybook/test"
 
 import { F0Button } from "@/components/F0Button"
 import { F0Icon, IconType } from "@/components/F0Icon"
@@ -24,6 +25,7 @@ import { HomeLayout } from "@/layouts/HomeLayout"
 import * as HomeLayoutStories from "@/layouts/HomeLayout/index.stories"
 import { F0Box } from "@/lib/F0Box"
 import { mockTranscribe } from "@/lib/storybook-utils/ai-mocks"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
 import { Page } from "@/patterns/Navigation/Page"
 import * as PageStories from "@/patterns/Navigation/Page/index.stories"
 import { exampleActions } from "@/patterns/Navigation/Sidebar/Chats/index.stories"
@@ -81,7 +83,7 @@ import { SEED_BY_ID } from "@/sds/chat/F0Chat/mocks/mockSeeds"
 import { useDemoHeaderActions } from "@/sds/chat/F0Chat/mocks/useDemoHeaderActions"
 import { Action } from "@/ui/Action"
 
-import { ApplicationFrame } from "./index"
+import { ApplicationFrame, useApplicationFrameSidePanel } from "./index"
 
 /**
  * Mock people database for @mention search and entity resolution in Storybook.
@@ -516,10 +518,10 @@ const WelcomeCards = () => {
   return <WelcomeScreenCardsRow cards={cards} />
 }
 
-const meta: Meta<typeof ApplicationFrame> = {
+const meta = {
   title: "App shell/ApplicationFrame",
   component: ApplicationFrame,
-  tags: ["autodocs", "experimental"],
+  tags: ["!autodocs", "experimental"],
   parameters: {
     layout: "fullscreen",
   },
@@ -761,7 +763,7 @@ const meta: Meta<typeof ApplicationFrame> = {
     sidebar: <TabbedSidebar />,
     children: <Page {...PageStories.Default.args} />,
   } satisfies ComponentProps<typeof ApplicationFrame>,
-}
+} satisfies Meta<typeof ApplicationFrame>
 
 export default meta
 
@@ -797,15 +799,13 @@ export const Default: Story = {
       <MockChatAppProvider>
         <ApplicationFrame
           // Transitional communications layout: conversations dock LEFT
-          // (panelContentSide) while the AI chat keeps its classic right-side
+          // (sidePanel.side) while the AI chat keeps its classic right-side
           // panel, full header and history, toggled from the page header's One
           // switch. Opening one swaps the other out — only the main content
           // moves, uncovering the incoming panel in place.
-          ai={{
-            ...withMockChatSlots(args.ai),
-            panelContentSide: "left",
-          }}
+          ai={withMockChatSlots(args.ai)}
           aiPromotion={args.aiPromotion}
+          sidePanel={{ enabled: true, side: "left", resizable: true }}
           sidebar={
             <ConversationsSidebar
               withOneTab={false}
@@ -832,6 +832,64 @@ export const Default: Story = {
       </MockChatAppProvider>
     </MockAiChatRuntimeProvider>
   ),
+}
+
+/**
+ * Communications remains fully usable when One is unavailable. The hosted
+ * panel has its own configuration and context; `ai.enabled` stays false.
+ */
+export const CommunicationsWithoutAi: Story = {
+  name: "Communications — without AI",
+  render: () => (
+    <MockChatAppProvider>
+      <ApplicationFrame
+        ai={{ enabled: false }}
+        sidePanel={{ enabled: true, side: "left", resizable: true }}
+        sidebar={
+          <ConversationsSidebar
+            initialTab="messages"
+            autoOpenConvId="dm-eleanor"
+            withOneTab={false}
+          />
+        }
+      >
+        <DaytimePage
+          period="morning"
+          hideOneSwitch
+          header={{
+            employeeFirstName: "Jordan",
+            employeeLastName: "Avery",
+            title: "Good morning, Jordan!",
+            employeeAvatar: "/avatars/person05.jpg",
+          }}
+        >
+          <HomeLayout {...HomeLayoutStories.Default.args} />
+        </DaytimePage>
+      </ApplicationFrame>
+    </MockChatAppProvider>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const messages = await canvas.findAllByText(
+      "Hey Eleanor! Got 10 minutes today?"
+    )
+
+    await expect(
+      messages.some((message) => message.closest(".left-0") !== null)
+    ).toBe(true)
+    await expect(
+      canvas.queryByText("Ask anything about your company")
+    ).not.toBeInTheDocument()
+    await expect(
+      canvas.getByRole("separator", { name: "Resize side panel" })
+    ).toBeVisible()
+  },
+}
+
+export const Snapshot: Story = {
+  ...CommunicationsWithoutAi,
+  name: "Snapshot",
+  parameters: withSnapshot({}),
 }
 
 /**
@@ -961,7 +1019,7 @@ export const WithAiAssistant: Story = {
 /**
  * A fully-mocked conversation hosted in the side panel, driven by the shared
  * `MockChatApp` store (so reads/unreads stay in sync with the sidebar). Wires
- * fullscreen/close to the panel via `useAiChat()`.
+ * fullscreen/close to the panel via `useApplicationFrameSidePanel()`.
  */
 const MockChatPanel = ({ convId }: { convId: string }) => {
   const runtime = useConversationRuntime(convId)
@@ -980,7 +1038,7 @@ const MockChatPanel = ({ convId }: { convId: string }) => {
     setVisualizationMode,
     setOpen,
     clearPanelContent,
-  } = useAiChat()
+  } = useApplicationFrameSidePanel()
   const isFullscreen = visualizationMode === "fullscreen"
 
   return (
@@ -1298,8 +1356,8 @@ const OneHistoryTab = ({
  * Tabbed sidebar (mirrors `TabbedSidebar`) whose "Messages" conversations swap
  * the side-panel content, plus a "One" tab hosting the AI chat history grouped
  * by day. It lives inside the `F0AiChatProvider` that `ApplicationFrame`
- * mounts, so it can call `useAiChat()` directly. "Ask AI" clears the custom
- * content and falls back to the real chat.
+ * mounts, so it can call `useApplicationFrameSidePanel()` directly. "Ask AI"
+ * clears the custom content and falls back to the real chat.
  */
 const ConversationsSidebarInner = ({
   initialTab = "home",
@@ -1329,7 +1387,7 @@ const ConversationsSidebarInner = ({
     panelContent,
     restoringPanelContentId,
     cancelPanelContentRestore,
-  } = useAiChat()
+  } = useApplicationFrameSidePanel()
 
   // Clicking a conversation mounts it in the side panel (one at a time).
   const onSelect = useCallback(

--- a/packages/react/src/patterns/ApplicationFrame/index.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.tsx
@@ -5,7 +5,7 @@ import {
   motion,
   MotionConfig,
 } from "motion/react"
-import { Fragment, useEffect, useMemo, useRef, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { useMediaQuery } from "usehooks-ts"
 
 import {
@@ -32,10 +32,33 @@ import { FrameProvider, SidebarState, useSidebar } from "./FrameProvider"
 
 const CONTENT_TRANSITION = { duration: 0.3, ease: [0, 0, 0.1, 1] }
 
+export const applicationFrameSidePanelSides = ["left", "right"] as const
+export type ApplicationFrameSidePanelSide =
+  (typeof applicationFrameSidePanelSides)[number]
+
+export interface ApplicationFrameSidePanelConfig {
+  enabled: boolean
+  /**
+   * Edge hosted content docks to. Falls back to `ai.panelContentSide`, then
+   * `ai.side`, then `"right"`.
+   */
+  side?: ApplicationFrameSidePanelSide
+  /**
+   * Allow the shared panel shell to be resized. Falls back to `ai.resizable`
+   * when AI is configured, otherwise `false`.
+   */
+  resizable?: boolean
+}
+
 export interface ApplicationFrameProps {
   ai?: Omit<AiChatProviderProps, "children">
   aiPromotion?: Omit<AiPromotionChatProviderProps, "children">
   banner?: React.ReactNode
+  /**
+   * Generic hosted side panel. It can be enabled independently from `ai`.
+   * Use `useApplicationFrameSidePanel` from a descendant to control it.
+   */
+  sidePanel?: ApplicationFrameSidePanelConfig
   sidebar: React.ReactNode
   children: React.ReactNode
 }
@@ -46,12 +69,14 @@ function _ApplicationFrame({
   banner,
   ai,
   aiPromotion,
+  sidePanel,
 }: ApplicationFrameProps) {
   return (
     <FrameProvider>
       <ApplicationFrameWithProvider
         ai={ai}
         aiPromotion={aiPromotion}
+        sidePanel={sidePanel}
         sidebar={sidebar}
         banner={banner}
       >
@@ -62,7 +87,7 @@ function _ApplicationFrame({
 }
 
 /**
- * Intermediate component that wraps children with the appropriate AI provider.
+ * Composes the side-panel and AI-promotion providers enabled for this frame.
  */
 function ApplicationFrameWithProvider({
   children,
@@ -70,29 +95,49 @@ function ApplicationFrameWithProvider({
   banner,
   ai,
   aiPromotion,
+  sidePanel,
 }: ApplicationFrameProps) {
-  const AiProvider = ai?.enabled
-    ? F0AiChatProvider
-    : aiPromotion?.enabled
-      ? AiPromotionChatProvider
-      : Fragment
-  const aiProps = ai?.enabled
-    ? ai
-    : aiPromotion?.enabled
-      ? aiPromotion
-      : undefined
+  const panelContentSide = sidePanel?.enabled
+    ? (sidePanel.side ?? ai?.panelContentSide)
+    : ai?.panelContentSide
+  const panelResizable = sidePanel?.enabled
+    ? (sidePanel.resizable ?? ai?.resizable)
+    : ai?.resizable
+
+  const content = (
+    <ApplicationFrameContent
+      ai={ai}
+      aiPromotion={aiPromotion}
+      sidePanel={sidePanel}
+      sidebar={sidebar}
+      banner={banner}
+    >
+      {children}
+    </ApplicationFrameContent>
+  )
+
+  const contentWithSidePanel =
+    ai?.enabled || sidePanel?.enabled ? (
+      <F0AiChatProvider
+        {...ai}
+        enabled={Boolean(ai?.enabled)}
+        panelContentSide={panelContentSide}
+        resizable={panelResizable}
+      >
+        {content}
+      </F0AiChatProvider>
+    ) : (
+      content
+    )
+
+  if (ai?.enabled || !aiPromotion?.enabled) {
+    return contentWithSidePanel
+  }
 
   return (
-    <AiProvider {...aiProps}>
-      <ApplicationFrameContent
-        ai={ai}
-        aiPromotion={aiPromotion}
-        sidebar={sidebar}
-        banner={banner}
-      >
-        {children}
-      </ApplicationFrameContent>
-    </AiProvider>
+    <AiPromotionChatProvider {...aiPromotion}>
+      {contentWithSidePanel}
+    </AiPromotionChatProvider>
   )
 }
 
@@ -174,6 +219,7 @@ function useAutoCloseSidebar(
 function ApplicationFrameContent({
   ai,
   aiPromotion,
+  sidePanel,
   children,
   sidebar,
   banner,
@@ -182,22 +228,28 @@ function ApplicationFrameContent({
     useSidebar()
   const shouldReduceMotion = useReducedMotion()
   const {
-    open: isAiChatOpen,
+    open: isPanelOpenState,
     visualizationMode,
-    canvasContent,
-    canvasEntities,
-    closeCanvas,
     chatWidth,
     resizable,
     panelSide,
     panelContent,
     panelContentSide,
     restoringPanelContentId,
+    canvasContent,
+    canvasEntities,
+    closeCanvas,
   } = useAiChat()
-  const isAiChatFullscreen = visualizationMode === "fullscreen"
+  const hasPanelContent = Boolean(panelContent || restoringPanelContentId)
+  const isPanelOpen =
+    isPanelOpenState && (Boolean(ai?.enabled) || hasPanelContent)
+  const isPanelFullscreen = isPanelOpen && visualizationMode === "fullscreen"
   const isCanvasMode = visualizationMode === "canvas"
   const { open: isAiPromotionChatOpen } = useAiPromotionChat()
   const reservedChatWidth = resizable ? chatWidth : DEFAULT_CHAT_WIDTH
+  const contentTransition = shouldReduceMotion
+    ? { duration: 0 }
+    : CONTENT_TRANSITION
   // Hosts can dock the whole panel left for a chat-first experience (e.g.
   // communications); the default is right, so the standard layout is unchanged.
   const isPanelLeft = panelSide === "left"
@@ -208,30 +260,27 @@ function ApplicationFrameContent({
   // skeleton on the content side, so the layout reserves that edge from the
   // first paint.
   const isSplitPanel = panelContentSide !== panelSide
-  const hasPanelContent = Boolean(panelContent || restoringPanelContentId)
   const activeSide = hasPanelContent ? panelContentSide : panelSide
   const isActiveLeft = activeSide === "left"
 
   // Track fullscreen transitions for smooth exit animation
-  const prevFullscreenRef = useRef(isAiChatFullscreen)
-  const isEnteringFullscreen = isAiChatFullscreen && !prevFullscreenRef.current
-  const isExitingFullscreen = !isAiChatFullscreen && prevFullscreenRef.current
+  const prevFullscreenRef = useRef(isPanelFullscreen)
+  const isEnteringFullscreen = isPanelFullscreen && !prevFullscreenRef.current
+  const isExitingFullscreen = !isPanelFullscreen && prevFullscreenRef.current
   const [
     isFullscreenExitTransitionActive,
     setIsFullscreenExitTransitionActive,
   ] = useState(false)
 
   useEffect(() => {
-    if (!isAiChatFullscreen && prevFullscreenRef.current) {
+    if (!isPanelFullscreen && prevFullscreenRef.current) {
       setIsFullscreenExitTransitionActive(true)
     }
-    prevFullscreenRef.current = isAiChatFullscreen
-  }, [isAiChatFullscreen])
+    prevFullscreenRef.current = isPanelFullscreen
+  }, [isPanelFullscreen])
 
   const isInFullscreenTransition =
-    isAiChatFullscreen ||
-    isFullscreenExitTransitionActive ||
-    isExitingFullscreen
+    isPanelFullscreen || isFullscreenExitTransitionActive || isExitingFullscreen
 
   const chatContainerTransition = useMemo(() => {
     if (isEnteringFullscreen)
@@ -254,15 +303,11 @@ function ApplicationFrameContent({
   // list stays usable — don't float / auto-close the sidebar in that case.
   // Keyed on the side of the *visible* content: in split mode a left-docked
   // conversation coexists with the sidebar while the right AI chat floats it.
-  const floatsOverSidebar = isAiChatOpen && !isActiveLeft
+  const floatsOverSidebar = isPanelOpen && !isActiveLeft
 
   useEffect(() => {
-    setForceFloat(floatsOverSidebar)
-  }, [floatsOverSidebar, setForceFloat])
-
-  useEffect(() => {
-    setForceFloat(isAiPromotionChatOpen)
-  }, [isAiPromotionChatOpen, setForceFloat])
+    setForceFloat(floatsOverSidebar || isAiPromotionChatOpen)
+  }, [floatsOverSidebar, isAiPromotionChatOpen, setForceFloat])
 
   useAutoCloseSidebar(floatsOverSidebar, shouldAutoCloseSidebar)
 
@@ -323,17 +368,17 @@ function ApplicationFrameContent({
               // incoming one, which stay put underneath (z-0 vs z-10).
               animate={{
                 paddingRight:
-                  isAiChatOpen && !isSmallViewport && !isActiveLeft
+                  isPanelOpen && !isSmallViewport && !isActiveLeft
                     ? reservedChatWidth
                     : 0,
                 paddingLeft:
-                  isAiChatOpen && !isSmallViewport && isActiveLeft
+                  isPanelOpen && !isSmallViewport && isActiveLeft
                     ? reservedChatWidth
                     : 0,
               }}
               transition={{
-                paddingRight: CONTENT_TRANSITION,
-                paddingLeft: CONTENT_TRANSITION,
+                paddingRight: contentTransition,
+                paddingLeft: contentTransition,
               }}
             >
               {/* Main content */}
@@ -345,7 +390,7 @@ function ApplicationFrameContent({
                   isInFullscreenTransition
                     ? "overflow-hidden"
                     : "overflow-auto",
-                  !isAiChatOpen && !isAiPromotionChatOpen && "xs:pr-1",
+                  !isPanelOpen && !isAiPromotionChatOpen && "xs:pr-1",
                   // Left seam so the content never sticks to the viewport edge:
                   // none when the sidebar is active (it provides the gap) or when
                   // a left-docked panel is OPEN (it reserves the space); otherwise
@@ -353,11 +398,11 @@ function ApplicationFrameContent({
                   // configured left — so a closed left panel still gets the seam.
                   sidebarState === "locked"
                     ? "pl-0"
-                    : isActiveLeft && isAiChatOpen
+                    : isActiveLeft && isPanelOpen
                       ? "pl-0"
                       : "xs:pl-1",
                   // Consistent breakpoint with the other seams (was a bare `pr-1`).
-                  isAiChatOpen && isActiveLeft && "xs:pr-1"
+                  isPanelOpen && isActiveLeft && "xs:pr-1"
                 )}
                 layoutDependency={sidebarState}
               >
@@ -410,7 +455,7 @@ function ApplicationFrameContent({
                 </div>
               )}
 
-              {ai?.enabled &&
+              {(ai?.enabled || sidePanel?.enabled) &&
                 (() => {
                   // One absolutely-positioned container per docked window. A
                   // single side (the default) keeps today's lone container;
@@ -455,7 +500,7 @@ function ApplicationFrameContent({
                       animate={{
                         width:
                           isSmallViewport ||
-                          (isAiChatFullscreen && isActivePanel)
+                          (isPanelFullscreen && isActivePanel)
                             ? "100%"
                             : reservedChatWidth,
                       }}
@@ -472,12 +517,13 @@ function ApplicationFrameContent({
 
                   return (
                     <>
-                      {panelContainer(
-                        panelSide,
-                        !isSplitPanel || !hasPanelContent,
-                        <F0AiChat />
-                      )}
-                      {isSplitPanel &&
+                      {ai?.enabled &&
+                        panelContainer(
+                          panelSide,
+                          !isSplitPanel || !hasPanelContent,
+                          <F0AiChat />
+                        )}
+                      {(!ai?.enabled || isSplitPanel) &&
                         panelContainer(
                           panelContentSide,
                           hasPanelContent,
@@ -495,3 +541,9 @@ function ApplicationFrameContent({
     </MotionConfig>
   )
 }
+
+export {
+  useApplicationFrameSidePanel,
+  type ApplicationFrameSidePanelReturnValue,
+  type ApplicationFrameSidePanelVisualizationMode,
+} from "@/kits/ai/F0AiChat/providers/AiChatStateProvider"


### PR DESCRIPTION
## Description

- Decouple generic ApplicationFrame side-panel content from AI availability.
- Keep hosted content operational when ai.enabled is false without rendering AI UI or firing AI visibility tracking.
- Expose a neutral useApplicationFrameSidePanel contract for product-owned panels.

## Implementation details

- Add an explicit sidePanel configuration with independent enabled, side, and resizable options.
- Preserve the existing AI panel, split-side behavior, persisted content restoration, and AI promotion composition.
- Disable AI-only file drop and Pong overlays while generic content is visible.
- Add keyboard and pointer resize alternatives, translated accessibility labels, reduced-motion handling, and labelled restore states.
- Add ApplicationFrame documentation, a no-AI Communications story, play assertions, and a Chromatic snapshot.

## Testing

- pnpm --filter @factorialco/f0-react run format:check
- pnpm --filter @factorialco/f0-react run tsc
- 48 focused Vitest tests
- pnpm --filter @factorialco/f0-react run build-storybook
- Browser smoke test: hosted conversation left, resize 360 to 376, no AI copy, no page errors
- F0 code, accessibility, and test-coverage reviews: no open blockers

## Scope

F0 only. No Factorial frontend files are changed in this PR.

---
> Factorial is conducting an analysis on the impact of the used skills. This was autogenerated, please don't delete:
> - factorial-f0