### PR TITLE
fix(component-status): auto-run the a11y audit in the maturity tooltip

### DIFF
--- a/packages/react/src/component-status/A11yRow.test.tsx
+++ b/packages/react/src/component-status/A11yRow.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
+
+import { A11yRow, A11yTooltipRow } from "./A11yRow"
+
+// axe-core is dynamically imported inside the audit; hoist a mock so both rows
+// exercise the real audit path without loading the (heavy, DOM-scanning) lib.
+const { axeRun } = vi.hoisted(() => ({ axeRun: vi.fn() }))
+vi.mock("axe-core", () => ({ default: { run: axeRun } }))
+
+/**
+ * The audit only runs against story canvases inside `#storybook-docs`. Mount a
+ * fake docs root with one `.docs-story` canvas so `runAudit` has a target and
+ * `isInStorybookDocs()` returns true.
+ */
+function mountDocsRoot() {
+  const root = document.createElement("div")
+  root.id = "storybook-docs"
+  const canvas = document.createElement("div")
+  canvas.className = "docs-story"
+  root.appendChild(canvas)
+  document.body.appendChild(root)
+  return root
+}
+
+beforeEach(() => {
+  axeRun.mockReset()
+  axeRun.mockResolvedValue({ violations: [] })
+})
+
+afterEach(() => {
+  document.getElementById("storybook-docs")?.remove()
+})
+
+describe("A11yTooltipRow (maturity tooltip)", () => {
+  test("runs the axe audit automatically on mount (tooltip open)", async () => {
+    mountDocsRoot()
+
+    render(<A11yTooltipRow detail="axe posture detail" tier="enforced" />)
+
+    // No disclosure to click — mounting the row (i.e. opening the tooltip) is
+    // enough to kick off the live check.
+    expect(
+      screen.queryByText(/check the rendered stories/i)
+    ).not.toBeInTheDocument()
+
+    await waitFor(() => expect(axeRun).toHaveBeenCalled())
+    expect(
+      await screen.findByText(/no violations in the stories/i)
+    ).toBeInTheDocument()
+  })
+
+  test("lists the failing WCAG criteria the audit reports", async () => {
+    mountDocsRoot()
+    axeRun.mockResolvedValue({
+      violations: [
+        {
+          id: "color-contrast",
+          description: "Elements must meet minimum contrast",
+          tags: ["cat.color", "wcag2aa", "wcag143"],
+          nodes: [{}, {}],
+        },
+      ],
+    })
+
+    render(<A11yTooltipRow detail="axe posture detail" tier="skipped" />)
+
+    expect(await screen.findByText("color-contrast")).toBeInTheDocument()
+    expect(screen.getByText(/WCAG 1\.4\.3 AA \(2\.0\)/)).toBeInTheDocument()
+    expect(screen.getByText(/2 elements/)).toBeInTheDocument()
+  })
+
+  test("falls back to 'unavailable' when not on the docs page", async () => {
+    // No #storybook-docs root mounted.
+    render(<A11yTooltipRow detail="axe posture detail" tier="todo" />)
+
+    expect(
+      await screen.findByText(/live results are available on the storybook/i)
+    ).toBeInTheDocument()
+    expect(axeRun).not.toHaveBeenCalled()
+  })
+})
+
+describe("A11yRow (docs panel)", () => {
+  test("defers the audit until the reader expands the disclosure", async () => {
+    mountDocsRoot()
+
+    const { container } = render(
+      <A11yRow detail="axe posture detail" tier="enforced" />
+    )
+
+    // Idle on first render — the docs page stays cheap until asked.
+    expect(screen.getByText(/check the rendered stories/i)).toBeInTheDocument()
+    expect(axeRun).not.toHaveBeenCalled()
+
+    // Expanding the <details> triggers the run.
+    const details = container.querySelector("details")!
+    details.open = true
+    fireEvent(details, new Event("toggle", { bubbles: false }))
+
+    await waitFor(() => expect(axeRun).toHaveBeenCalled())
+    expect(
+      await screen.findByText(/no violations in the stories/i)
+    ).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/component-status/A11yRow.tsx
+++ b/packages/react/src/component-status/A11yRow.tsx
@@ -1,15 +1,23 @@
 import type { AxeResults, Result, TagValue } from "axe-core"
-import React, { useCallback, useRef, useState } from "react"
+import React, { useCallback, useEffect, useRef, useState } from "react"
+
+import type { A11yTier } from "./component-status"
 
 /**
  * The Accessibility row inside the Maturity-level checklist.
  *
- * Collapsed, it shows the build-time posture (enforced / not-enforced / axe
- * skipped) — cheap, works anywhere the panel ships. On first expand, and only
- * inside Storybook, it lazily loads axe-core and runs it against the story
- * canvases already rendered on the docs page, then lists the failing WCAG
- * criteria. CI (`test: "error"`, with play functions) remains the source of
- * truth — this is a fresh, default-state indicator.
+ * It shows the build-time posture (enforced / not-enforced / axe skipped) —
+ * cheap, works anywhere the panel ships — and a live axe run against the story
+ * canvases already rendered on the docs page, listing the failing WCAG
+ * criteria. Two surfaces consume it:
+ *
+ * - `A11yRow` (the docs panel): the audit is behind a "Check the rendered
+ *   stories" disclosure, so the page stays cheap until the reader asks.
+ * - `A11yTooltipRow` (the maturity tag tooltip): a tooltip is transient and
+ *   can't hold a disclosure, so the audit fires automatically on open.
+ *
+ * CI (`test: "error"`, with play functions) remains the source of truth — this
+ * is a fresh, default-state indicator.
  */
 
 const WCAG_TAGS: TagValue[] = [
@@ -52,7 +60,7 @@ function wcagFromTags(
   return { sc, level, version }
 }
 
-type AuditState =
+export type A11yAuditState =
   | { status: "idle" }
   | { status: "running" }
   | { status: "unavailable" }
@@ -101,44 +109,183 @@ async function runAudit(): Promise<Criterion[]> {
   return Array.from(byRule.values()).sort((a, b) => b.nodes - a.nodes)
 }
 
-export function A11yRow({
-  detail,
-  tier,
-}: {
-  detail: string
-  tier: "skipped" | "todo" | "enforced"
-}) {
-  const [audit, setAudit] = useState<AuditState>({ status: "idle" })
+/**
+ * Runs the live axe audit and exposes its state plus an idempotent `start()`.
+ * Call `start()` from a user action (the panel's disclosure) or on mount (the
+ * tooltip); repeat calls are no-ops, so the expensive axe run happens at most
+ * once per mount. Outside Storybook docs the state resolves to `unavailable`.
+ */
+export function useA11yAudit(): {
+  state: A11yAuditState
+  start: () => void
+} {
+  const [state, setState] = useState<A11yAuditState>({ status: "idle" })
   const started = useRef(false)
+
+  const start = useCallback(() => {
+    if (started.current) return
+    started.current = true
+    if (!isInStorybookDocs()) {
+      setState({ status: "unavailable" })
+      return
+    }
+    setState({ status: "running" })
+    runAudit().then(
+      (criteria) => setState({ status: "done", criteria }),
+      () => setState({ status: "unavailable" })
+    )
+  }, [])
+
+  return { state, start }
+}
+
+/** Color treatment per surface: the light docs panel vs. the dark tooltip. */
+const TONE = {
+  panel: {
+    strong: "text-f1-foreground",
+    muted: "text-f1-foreground-secondary",
+  },
+  tooltip: {
+    // The tooltip surface is dark with an inherited white base, so muted text
+    // is expressed as opacity over that white rather than the secondary token
+    // (which resolves to a too-dim 50% white here). Strong text inherits.
+    strong: "",
+    muted: "opacity-75",
+  },
+} as const
+
+/**
+ * The result of a live axe run: a spinner while it works, the failing WCAG
+ * criteria when done, or a fallback line when it can't run outside the docs
+ * page. Presentational — the audit itself lives in `useA11yAudit`.
+ */
+export function A11yAuditResults({
+  state,
+  tone = "panel",
+}: {
+  state: A11yAuditState
+  tone?: keyof typeof TONE
+}) {
+  const c = TONE[tone]
+  return (
+    <div className="mt-2" aria-live="polite">
+      {state.status === "running" && (
+        <div className="flex items-center gap-2">
+          <svg
+            className={`h-4 w-4 shrink-0 animate-spin motion-reduce:animate-none ${c.muted}`}
+            viewBox="0 0 24 24"
+            fill="none"
+            aria-hidden="true"
+          >
+            <circle
+              cx="12"
+              cy="12"
+              r="9"
+              stroke="currentColor"
+              strokeOpacity="0.25"
+              strokeWidth="3"
+            />
+            <path
+              d="M21 12a9 9 0 0 0-9-9"
+              stroke="currentColor"
+              strokeWidth="3"
+              strokeLinecap="round"
+            />
+          </svg>
+          <span>Checking the rendered stories…</span>
+        </div>
+      )}
+      {state.status === "unavailable" && (
+        <p className="m-0">
+          Live results are available on the Storybook docs page. See the story’s{" "}
+          <strong>Accessibility</strong> tab for per-element detail.
+        </p>
+      )}
+      {state.status === "done" && state.criteria.length === 0 && (
+        <p className="m-0 text-f1-foreground-positive">
+          No violations in the stories’ default state.
+        </p>
+      )}
+      {state.status === "done" && state.criteria.length > 0 && (
+        <div role="list" className="space-y-1">
+          {state.criteria.map((crit) => (
+            <div
+              key={crit.ruleId}
+              role="listitem"
+              className="flex items-start gap-2 text-base"
+            >
+              <span aria-hidden className="shrink-0 text-f1-foreground-warning">
+                ⚠
+              </span>
+              <span>
+                <code className={c.strong}>{crit.ruleId}</code>
+                {crit.sc && (
+                  <span className={c.muted}>
+                    {" "}
+                    · WCAG {crit.sc} {crit.level} ({crit.version})
+                  </span>
+                )}
+                <span className={c.muted}>
+                  {" "}
+                  · {crit.description} · {crit.nodes}{" "}
+                  {crit.nodes === 1 ? "element" : "elements"}
+                </span>
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+      {(state.status === "done" || state.status === "unavailable") && (
+        <p className={`mt-2 text-sm ${c.muted}`}>
+          Checked in each story’s default state — violations behind interactions
+          (open menus, dialogs) aren’t shown here. CI enforces the full set,
+          including play-function states.
+        </p>
+      )}
+    </div>
+  )
+}
+
+/** Static posture line ("enforced" / "not enforced yet" / "axe skipped") shared
+ * by both a11y rows, plus the glyph that leads the checklist item. */
+function posture(tier: A11yTier): {
+  glyph: string
+  enforced: boolean
+  text: string
+} {
+  const enforced = tier === "enforced"
+  return {
+    enforced,
+    glyph: enforced ? "✓" : "✕",
+    text:
+      tier === "enforced"
+        ? "enforced"
+        : tier === "skipped"
+          ? "axe skipped"
+          : "not enforced yet",
+  }
+}
+
+/**
+ * The Accessibility checklist row for the docs panel. The live axe run is
+ * behind a "Check the rendered stories" disclosure so the docs page stays
+ * cheap until the reader expands it.
+ */
+export function A11yRow({ detail, tier }: { detail: string; tier: A11yTier }) {
+  const { state, start } = useA11yAudit()
 
   const onToggle = useCallback(
     (e: React.SyntheticEvent<HTMLDetailsElement>) => {
-      if (!e.currentTarget.open || started.current) return
-      started.current = true
-      if (!isInStorybookDocs()) {
-        setAudit({ status: "unavailable" })
-        return
-      }
-      setAudit({ status: "running" })
-      runAudit().then(
-        (criteria) => setAudit({ status: "done", criteria }),
-        () => setAudit({ status: "unavailable" })
-      )
+      if (!e.currentTarget.open) return
+      start()
     },
-    []
+    [start]
   )
 
-  const enforced = tier === "enforced"
-  const glyph = enforced ? "✓" : "✕"
+  const { glyph, enforced, text } = posture(tier)
   const glyphColor = enforced
     ? "text-f1-foreground-positive"
     : "text-f1-foreground-secondary"
-  const posture =
-    tier === "enforced"
-      ? "enforced"
-      : tier === "skipped"
-        ? "axe skipped"
-        : "not enforced yet"
 
   return (
     <div role="listitem" className="flex items-start gap-2">
@@ -149,7 +296,7 @@ export function A11yRow({
         {/* Label + posture, always visible — matches the other checklist rows. */}
         <div className="text-base text-f1-foreground">
           Accessibility{" "}
-          <span className="text-f1-foreground-secondary">— {posture}</span>
+          <span className="text-f1-foreground-secondary">— {text}</span>
         </div>
         <div className="mt-0.5 text-base text-f1-foreground-secondary">
           {detail}
@@ -159,87 +306,50 @@ export function A11yRow({
             <summary className="cursor-pointer list-none text-f1-foreground marker:hidden [&::-webkit-details-marker]:hidden">
               Check the rendered stories
             </summary>
-            <div className="mt-2" aria-live="polite">
-              {audit.status === "running" && (
-                <div className="flex items-center gap-2">
-                  <svg
-                    className="h-4 w-4 shrink-0 animate-spin text-f1-foreground-secondary motion-reduce:animate-none"
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    aria-hidden="true"
-                  >
-                    <circle
-                      cx="12"
-                      cy="12"
-                      r="9"
-                      stroke="currentColor"
-                      strokeOpacity="0.25"
-                      strokeWidth="3"
-                    />
-                    <path
-                      d="M21 12a9 9 0 0 0-9-9"
-                      stroke="currentColor"
-                      strokeWidth="3"
-                      strokeLinecap="round"
-                    />
-                  </svg>
-                  <span>Checking the rendered stories…</span>
-                </div>
-              )}
-              {audit.status === "unavailable" && (
-                <p className="m-0">
-                  Live results are available on the Storybook docs page. See the
-                  story’s <strong>Accessibility</strong> tab for per-element
-                  detail.
-                </p>
-              )}
-              {audit.status === "done" && audit.criteria.length === 0 && (
-                <p className="m-0 text-f1-foreground-positive">
-                  No violations in the stories’ default state.
-                </p>
-              )}
-              {audit.status === "done" && audit.criteria.length > 0 && (
-                <div role="list" className="space-y-1">
-                  {audit.criteria.map((c) => (
-                    <div
-                      key={c.ruleId}
-                      role="listitem"
-                      className="flex items-start gap-2 text-base"
-                    >
-                      <span
-                        aria-hidden
-                        className="shrink-0 text-f1-foreground-warning"
-                      >
-                        ⚠
-                      </span>
-                      <span>
-                        <code className="text-f1-foreground">{c.ruleId}</code>
-                        {c.sc && (
-                          <span className="text-f1-foreground-secondary">
-                            {" "}
-                            · WCAG {c.sc} {c.level} ({c.version})
-                          </span>
-                        )}
-                        <span className="text-f1-foreground-secondary">
-                          {" "}
-                          · {c.description} · {c.nodes}{" "}
-                          {c.nodes === 1 ? "element" : "elements"}
-                        </span>
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              )}
-              {(audit.status === "done" || audit.status === "unavailable") && (
-                <p className="mt-2 text-sm text-f1-foreground-secondary">
-                  Checked in each story’s default state — violations behind
-                  interactions (open menus, dialogs) aren’t shown here. CI
-                  enforces the full set, including play-function states.
-                </p>
-              )}
-            </div>
+            <A11yAuditResults state={state} tone="panel" />
           </details>
         </div>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * The Accessibility checklist row for the maturity-tag tooltip. A tooltip is
+ * transient and can't hold a disclosure, so the live axe run fires
+ * automatically on open (mount) and its results render inline.
+ */
+export function A11yTooltipRow({
+  detail,
+  tier,
+}: {
+  detail: string
+  tier: A11yTier
+}) {
+  const { state, start } = useA11yAudit()
+
+  // The tooltip content only mounts while open, so mounting == opening: run the
+  // audit as soon as the reader reveals the tooltip. `start` is idempotent.
+  useEffect(() => {
+    start()
+  }, [start])
+
+  const { glyph, enforced, text } = posture(tier)
+
+  return (
+    <div role="listitem" className="flex items-start gap-2">
+      <span
+        aria-hidden
+        className={`mt-0.5 shrink-0 ${enforced ? "text-f1-foreground-positive" : "opacity-60"}`}
+      >
+        {glyph}
+      </span>
+      <div className="min-w-0">
+        <div className="text-base">
+          Accessibility <span className="opacity-75">— {text}</span>
+        </div>
+        <div className="mt-0.5 text-base opacity-75">{detail}</div>
+        <A11yAuditResults state={state} tone="tooltip" />
       </div>
     </div>
   )

--- a/packages/react/src/component-status/ComponentStability.test.tsx
+++ b/packages/react/src/component-status/ComponentStability.test.tsx
@@ -1,8 +1,24 @@
-import { render, screen } from "@testing-library/react"
-import { describe, expect, test } from "vitest"
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest"
 
-import { ComponentStability } from "./ComponentStability"
+import { ComponentMaturityTag, ComponentStability } from "./ComponentStability"
 import { type ComponentEntry } from "./component-status"
+
+// axe-core is dynamically imported by the a11y audit; hoist a mock so opening
+// the maturity tooltip exercises the real audit wiring without the heavy lib.
+const { axeRun } = vi.hoisted(() => ({ axeRun: vi.fn() }))
+vi.mock("axe-core", () => ({ default: { run: axeRun } }))
+
+/** A fake Storybook docs root with one story canvas so the audit has a target
+ * and `isInStorybookDocs()` returns true. */
+function mountDocsRoot() {
+  const root = document.createElement("div")
+  root.id = "storybook-docs"
+  const canvas = document.createElement("div")
+  canvas.className = "docs-story"
+  root.appendChild(canvas)
+  document.body.appendChild(root)
+}
 
 const DATASET: ComponentEntry[] = [
   {
@@ -116,4 +132,57 @@ describe("ComponentStability", () => {
       expect(row.textContent).toContain(glyph)
     }
   )
+})
+
+describe("ComponentMaturityTag", () => {
+  beforeEach(() => {
+    axeRun.mockReset()
+    axeRun.mockResolvedValue({ violations: [] })
+  })
+
+  afterEach(() => {
+    document.getElementById("storybook-docs")?.remove()
+  })
+
+  test("renders the maturity badge and nothing for unknown components", () => {
+    const { container, rerender } = render(
+      <ComponentMaturityTag componentName="Card" components={DATASET} />
+    )
+    expect(screen.getByText("Experimental")).toBeInTheDocument()
+
+    rerender(
+      <ComponentMaturityTag componentName="DoesNotExist" components={DATASET} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  // Regression guard for #4836: collapsing the maturity panel into the title
+  // tag dropped the a11y row's live audit. The tooltip has no "check the
+  // rendered stories" control, so opening it must run the audit automatically.
+  test("runs the a11y audit automatically when the tooltip opens", async () => {
+    mountDocsRoot()
+
+    const { container } = render(
+      <ComponentMaturityTag componentName="Card" components={DATASET} />
+    )
+
+    // Nothing runs until the tooltip is revealed — the row mounts on open.
+    expect(axeRun).not.toHaveBeenCalled()
+
+    const trigger = container.querySelector("[data-state]") as HTMLElement
+    fireEvent.focus(trigger)
+
+    // Opening the tooltip must kick off the audit with no user action — this is
+    // the behaviour #4836 regressed.
+    await waitFor(() => expect(axeRun).toHaveBeenCalled())
+    // …and its results render inline (findAllBy: Radix briefly double-mounts the
+    // content during its open animation).
+    expect(
+      (await screen.findAllByText(/no violations in the stories/i)).length
+    ).toBeGreaterThan(0)
+    // The auto-run replaces the panel's manual disclosure entirely.
+    expect(
+      screen.queryByText(/check the rendered stories/i)
+    ).not.toBeInTheDocument()
+  })
 })

--- a/packages/react/src/component-status/ComponentStability.tsx
+++ b/packages/react/src/component-status/ComponentStability.tsx
@@ -7,7 +7,7 @@ import {
   TooltipTrigger,
 } from "@/ui/tooltip"
 
-import { A11yRow } from "./A11yRow"
+import { A11yRow, A11yTooltipRow } from "./A11yRow"
 import {
   getComponentStatus,
   type ApiStatus,
@@ -162,9 +162,9 @@ export function ComponentStability({
 /**
  * The maturity summary + Definition-of-Done checklist, rendered statically for
  * the `ComponentMaturityTag` tooltip. It carries the same information as the
- * `ComponentStability` panel, but the accessibility row is shown as a plain
- * status line (no live axe audit) since a tooltip is transient and shouldn't
- * hold interactive controls.
+ * `ComponentStability` panel. The accessibility row runs the same live axe
+ * audit as the panel, fired automatically on open since a tooltip is transient
+ * and can't hold a "check the rendered stories" disclosure.
  */
 function StatusDetails({ status }: { status: ComponentStatus }) {
   // The tooltip surface is dark with a white (`f1-foreground-inverse`) base, so
@@ -176,45 +176,53 @@ function StatusDetails({ status }: { status: ComponentStatus }) {
 
       {status.showChecklist && (
         <div role="list" className="mt-3 space-y-3">
-          {status.requirements.map((req) => (
-            <div
-              key={req.key}
-              role="listitem"
-              className="flex items-start gap-2"
-            >
-              <span
-                aria-hidden
-                className={`mt-0.5 shrink-0 ${req.met ? "text-f1-foreground-positive" : "opacity-60"}`}
+          {status.requirements.map((req) =>
+            req.key === "a11y" ? (
+              <A11yTooltipRow
+                key={req.key}
+                detail={req.detail}
+                tier={status.a11yTier}
+              />
+            ) : (
+              <div
+                key={req.key}
+                role="listitem"
+                className="flex items-start gap-2"
               >
-                {req.met ? "✓" : "✕"}
-              </span>
-              <div>
-                <div className="text-base">{req.label}</div>
-                <div className="mt-0.5 text-base opacity-75">
-                  {req.detail}
-                  {req.criteria && req.criteria.length > 0 && (
-                    <div role="list" className="mt-1 space-y-0.5">
-                      {req.criteria.map((criterion) => (
-                        <div
-                          key={criterion.label}
-                          role="listitem"
-                          className="flex items-start gap-2 text-base"
-                        >
-                          <span
-                            aria-hidden
-                            className={`shrink-0 ${criterion.met ? "text-f1-foreground-positive" : "opacity-60"}`}
+                <span
+                  aria-hidden
+                  className={`mt-0.5 shrink-0 ${req.met ? "text-f1-foreground-positive" : "opacity-60"}`}
+                >
+                  {req.met ? "✓" : "✕"}
+                </span>
+                <div>
+                  <div className="text-base">{req.label}</div>
+                  <div className="mt-0.5 text-base opacity-75">
+                    {req.detail}
+                    {req.criteria && req.criteria.length > 0 && (
+                      <div role="list" className="mt-1 space-y-0.5">
+                        {req.criteria.map((criterion) => (
+                          <div
+                            key={criterion.label}
+                            role="listitem"
+                            className="flex items-start gap-2 text-base"
                           >
-                            {criterion.met ? "✓" : "✕"}
-                          </span>
-                          <span>{criterion.label}</span>
-                        </div>
-                      ))}
-                    </div>
-                  )}
+                            <span
+                              aria-hidden
+                              className={`shrink-0 ${criterion.met ? "text-f1-foreground-positive" : "opacity-60"}`}
+                            >
+                              {criterion.met ? "✓" : "✕"}
+                            </span>
+                            <span>{criterion.label}</span>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
+            )
+          )}
         </div>
       )}
     </div>

--- a/packages/react/vite/axe-core.stub.ts
+++ b/packages/react/vite/axe-core.stub.ts
@@ -1,0 +1,17 @@
+/**
+ * Test-only stand-in for `axe-core`.
+ *
+ * The a11y audit in `src/component-status/A11yRow.tsx` reaches axe-core via a
+ * dynamic `import("axe-core")`. axe-core is only ever a transitive dependency
+ * here (pulled in by Storybook's a11y tooling), so it isn't resolvable from
+ * this package on its own — under Vitest that makes the dynamic import fail to
+ * resolve at transform time. Aliasing `axe-core` to this stub for the unit
+ * project keeps the import resolvable without adding a runtime dependency.
+ *
+ * Tests that exercise the audit `vi.mock("axe-core", …)` to control the
+ * results, so this default is only the "no violations" fallback for any test
+ * that renders the audit without mocking.
+ */
+export default {
+  run: async () => ({ violations: [] }),
+}

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -23,6 +23,10 @@ export default defineConfig({
     setupFiles: ["./vite/vitest.setup.ts"],
     alias: {
       ...alias,
+      // axe-core is only a transitive (Storybook) dependency, so the a11y
+      // audit's dynamic `import("axe-core")` isn't resolvable from this package
+      // under Vitest. Point it at a stub; audit tests mock it anyway.
+      "axe-core": path.resolve(dirname, "./vite/axe-core.stub.ts"),
     },
     typecheck: {
       tsconfig: "./tsconfig.tests.json",


### PR DESCRIPTION
## Description

Restores the live accessibility audit inside the component **maturity tooltip**. [#4836](https://github.com/factorialco/f0/pull/4836) collapsed the maturity panel into an inline title tag + tooltip, but in doing so the Accessibility row lost its live axe audit (the panel's "Check the rendered stories" disclosure). The tooltip only showed a static status line.

Since a tooltip is transient and shouldn't hold an expandable control, the audit now runs **automatically when the tooltip opens** (its content only mounts while open).

## Type of change

- [x] Bug fix

## Screenshots (if applicable)

Hovering a component's maturity tag now runs the audit on open and renders the result inline (e.g. _"No violations in the stories' default state."_) under **Accessibility — not enforced yet**, with no button to click.

## Implementation details

- **`A11yRow.tsx`** — extracted the audit engine into a reusable `useA11yAudit()` hook (idempotent `start()`) and a presentational `A11yAuditResults` renderer. The panel's `A11yRow` keeps its "Check the rendered stories" disclosure; a new **`A11yTooltipRow`** calls `start()` on mount (= tooltip open) and renders results inline, styled for the dark tooltip surface.
- **`ComponentStability.tsx`** — `StatusDetails` (the tooltip body) now renders `A11yTooltipRow` for the `a11y` requirement instead of a static line.
- **Tests** — new `A11yRow.test.tsx` (auto-run on mount, WCAG-criteria rendering, off-docs fallback, panel defers-until-expand) and a regression guard in `ComponentStability.test.tsx` asserting that opening the `ComponentMaturityTag` tooltip always calls axe. Existing panel posture tests are preserved.
- **Test infra** — `axe-core` is only a transitive (Storybook) dependency, so the audit's dynamic `import("axe-core")` isn't resolvable under Vitest. Added a Vitest alias to a small stub (`vite/axe-core.stub.ts`); audit tests mock it. No runtime dependency added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)