### PR TITLE
fix(value-display): align country avatar size with other entity cells

### DIFF
--- a/packages/react/src/ui/value-display/types/country/country.tsx
+++ b/packages/react/src/ui/value-display/types/country/country.tsx
@@ -23,7 +23,7 @@ export const CountryCell = (
 
   return (
     <div data-cell-type="country" className="flex items-center gap-2">
-      <F0AvatarFlag size="sm" flag={args.code} aria-label={countryName} />{" "}
+      <F0AvatarFlag size="xs" flag={args.code} aria-label={countryName} />
       <OneEllipsis className="min-w-0 flex-1 text-f1-foreground" tag="span">
         {countryName}
       </OneEllipsis>


### PR DESCRIPTION
## Description

The `country` value-display cell rendered its flag avatar at `size="sm"` (24px box), while every other entity cell in `value-display` renders at `size="xs"` (20px box). Country rows therefore sat visually taller than person / team / company rows in the same table or list.

This drops the country flag avatar to `xs` so all entity cells line up.

## Type of change

- [x] Bug fix

## Screenshots (if applicable)

Measured in Storybook (`Components/Value Display/*`), avatar bounding box:

| Cell | Before | After |
| --- | --- | --- |
| Country | 24 x 24 | **20 x 20** |
| Team | 20 x 20 | 20 x 20 |
| Company | 20 x 20 | 20 x 20 |
| Person | 20 x 20 | 20 x 20 |

The `Value Display/Country > Snapshot` story is a Chromatic snapshot, so the visual diff shows up in the Chromatic build on this PR.

## Implementation details

`packages/react/src/ui/value-display/types/country/country.tsx`

- `<F0AvatarFlag size="sm" />` becomes `<F0AvatarFlag size="xs" />`, matching `PersonCell`, `TeamCell` and `CompanyCell`.
- Removed the stray `{" "}` JSX whitespace after the avatar. The wrapper already applies `gap-2`, so that literal space was adding extra horizontal spacing that the other cells do not have.

No API change: `size` is not part of the `country` cell value type, so nothing consumer-facing moves.
