### PR TITLE
fix(EditableTable): span disabled background across cell hint

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/DisabledCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/DisabledCell.tsx
@@ -23,7 +23,7 @@ export function DisabledCell<R extends RecordType>({
         iconColor="secondary"
         // px only (no vertical padding) so the disabled cell matches the 48px
         // height of editable/display-only cells and rows stay aligned.
-        className="min-h-12 bg-f1-background-disabled [&_*]:text-f1-foreground-secondary"
+        className="min-h-12 [&_*]:text-f1-foreground-secondary"
       />
     </BaseCell>
   )


### PR DESCRIPTION
## Problem

For **disabled cells that have a column hint**, the disabled grey fill didn't span the full cell: the main content area showed the disabled background but the hint icon area had a lighter background.

Before:
<img width="1916" height="1041" alt="before" src="https://github.com/user-attachments/assets/7e7df4d5-3b0a-4cd3-9c11-a186993f4ca1" />

After:
<img width="1915" height="1038" alt="after" src="https://github.com/user-attachments/assets/ebd8bd8f-9e15-4466-a545-e1d8c1d1337a" />


## Root cause

`bg-f1-background-disabled` resolves to `hsl(219 88% 17% / 0.02)` — a 2% alpha **tint**, not an opaque colour, so it compounds when layered.

Follow-up to #4643, which moved the disabled fill onto the `BaseCell` **root** so it spans the full cell height. `DisabledCell` was still *also* applying `bg-f1-background-disabled` on the inner `ReadOnlyCellContent`, so:

- **Content area** → root tint + inner tint ≈ 4% (darker)
- **Hint icon area** → root tint only = 2% (lighter)

That difference is the mismatched hint background.

## Fix

Remove the redundant inner `bg-f1-background-disabled` from `DisabledCell`. The single root-level fill now covers content **and** hint uniformly.
