### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.56.1",
+  "packages/react": "4.56.2",
   "packages/react-native": "0.59.0",
   "packages/core": "1.56.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.56.2](https://github.com/factorialco/f0/compare/f0-react-v4.56.1...f0-react-v4.56.2) (2026-07-27)
+
+
+### Bug Fixes
+
+* **ai:** welcome suggestions popover closes when switching to the last group ([#4653](https://github.com/factorialco/f0/issues/4653)) ([d640b12](https://github.com/factorialco/f0/commit/d640b12e36c335619635d0aba45bbc18a97b2205))
+
 ## [4.56.1](https://github.com/factorialco/f0/compare/f0-react-v4.56.0...f0-react-v4.56.1) (2026-07-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.56.1",
+  "version": "4.56.2",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.56.2</summary>

## [4.56.2](https://github.com/factorialco/f0/compare/f0-react-v4.56.1...f0-react-v4.56.2) (2026-07-27)


### Bug Fixes

* **ai:** welcome suggestions popover closes when switching to the last group ([#4653](https://github.com/factorialco/f0/issues/4653)) ([d640b12](https://github.com/factorialco/f0/commit/d640b12e36c335619635d0aba45bbc18a97b2205))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).