### PR TITLE
feat(react): stamp data-f0-component-name via Component factory

### DIFF
--- a/packages/react/src/components/F0AudioPlayer/__tests__/F0AudioPlayer.test.tsx
+++ b/packages/react/src/components/F0AudioPlayer/__tests__/F0AudioPlayer.test.tsx
@@ -36,6 +36,14 @@ describe("F0AudioPlayer", () => {
     expect(screen.getByRole("button", { name: "Play" })).toBeInTheDocument()
   })
 
+  it("marks the root node with data-f0-component-name", () => {
+    render(<F0AudioPlayer src="test.mp3" />)
+    expect(screen.getByRole("group", { name: "Audio player" })).toHaveAttribute(
+      "data-f0-component-name",
+      "F0AudioPlayer"
+    )
+  })
+
   it("renders the audio element with the given src and preload", () => {
     render(<F0AudioPlayer src="test.mp3" preload="auto" />)
     const audio = getAudio()

--- a/packages/react/src/components/F0AudioPlayer/index.tsx
+++ b/packages/react/src/components/F0AudioPlayer/index.tsx
@@ -1,3 +1,4 @@
+import { Component } from "@/lib/component/component"
 import { withDataTestId } from "@/lib/data-testid"
 import { experimentalComponent } from "@/lib/experimental"
 
@@ -21,7 +22,9 @@ export type { AudioPlayerState, AudioPlayerControls } from "./useAudioPlayer"
  */
 export const F0AudioPlayer = experimentalComponent(
   "F0AudioPlayer",
-  withDataTestId(F0AudioPlayerBase)
+  withDataTestId(
+    Component({ name: "F0AudioPlayer", type: "info" }, F0AudioPlayerBase)
+  )
 )
 
 /**
@@ -29,5 +32,10 @@ export const F0AudioPlayer = experimentalComponent(
  */
 export const F0AudioPlayerCard = experimentalComponent(
   "F0AudioPlayerCard",
-  withDataTestId(F0AudioPlayerCardBase)
+  withDataTestId(
+    Component(
+      { name: "F0AudioPlayerCard", type: "info" },
+      F0AudioPlayerCardBase
+    )
+  )
 )

--- a/packages/react/src/components/F0VideoPlayer/F0VideoPlayer.tsx
+++ b/packages/react/src/components/F0VideoPlayer/F0VideoPlayer.tsx
@@ -1,3 +1,4 @@
+import { Component } from "@/lib/component/component"
 import { withDataTestId } from "@/lib/data-testid"
 import { experimentalComponent } from "@/lib/experimental"
 
@@ -13,5 +14,8 @@ import { F0VideoPlayerInternal } from "./internal"
  * `onMilestone`, `onComplete`, `restrictForwardSeek`).
  */
 export const F0VideoPlayer = withDataTestId(
-  experimentalComponent("F0VideoPlayer", F0VideoPlayerInternal)
+  experimentalComponent(
+    "F0VideoPlayer",
+    Component({ name: "F0VideoPlayer", type: "info" }, F0VideoPlayerInternal)
+  )
 )

--- a/packages/react/src/components/F0VideoPlayer/__tests__/F0VideoPlayer.test.tsx
+++ b/packages/react/src/components/F0VideoPlayer/__tests__/F0VideoPlayer.test.tsx
@@ -76,6 +76,12 @@ describe("F0VideoPlayer", () => {
       expect(region).toHaveAttribute("tabindex", "0")
     })
 
+    it("marks the root node with data-f0-component-name", () => {
+      render(<F0VideoPlayer src={VIDEO_SRC} />)
+      const region = screen.getByRole("region", { name: /video player/i })
+      expect(region).toHaveAttribute("data-f0-component-name", "F0VideoPlayer")
+    })
+
     it("renders the controls only once the video has loaded", () => {
       render(<F0VideoPlayer src={VIDEO_SRC} />)
       // Controls are not in the DOM before load (avoids focusable-but-hidden).

--- a/packages/react/src/components/F0VideoPlayer/internal.tsx
+++ b/packages/react/src/components/F0VideoPlayer/internal.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef } from "react"
+import { useComposedRefs } from "@radix-ui/react-compose-refs"
+import { forwardRef, useCallback, useEffect, useRef } from "react"
 
 import { useI18n } from "@/lib/providers/i18n"
 import { cn, focusRing } from "@/lib/utils"
@@ -25,18 +26,25 @@ import { F0VideoPlayerProps } from "./types"
  *   useRestrictForwardSeek  → blocks seeking past the furthest-watched point.
  *   <Controls>              → presentation only; interactions delegated back here.
  */
-export function F0VideoPlayerInternal({
-  src,
-  autoPlay = false,
-  autoFocus = false,
-  restrictForwardSeek = false,
-  onTrackAction,
-  onMilestone,
-  onComplete,
-  ...dataAttributes
-}: F0VideoPlayerProps) {
+export const F0VideoPlayerInternal = forwardRef<
+  HTMLDivElement,
+  F0VideoPlayerProps
+>(function F0VideoPlayerInternal(
+  {
+    src,
+    autoPlay = false,
+    autoFocus = false,
+    restrictForwardSeek = false,
+    onTrackAction,
+    onMilestone,
+    onComplete,
+    ...dataAttributes
+  },
+  forwardedRef
+) {
   const { t } = useI18n()
   const wrapperRef = useRef<HTMLDivElement>(null)
+  const composedWrapperRef = useComposedRefs(wrapperRef, forwardedRef)
 
   const video = useVideoState(src)
 
@@ -78,7 +86,7 @@ export function F0VideoPlayerInternal({
 
   return (
     <div
-      ref={wrapperRef}
+      ref={composedWrapperRef}
       className={cn(
         "group relative h-full w-full overflow-hidden rounded-[inherit]",
         "[&:fullscreen]:h-screen [&:fullscreen]:w-screen [&:fullscreen]:rounded-none [&:fullscreen]:bg-[#000]",
@@ -134,4 +142,4 @@ export function F0VideoPlayerInternal({
       )}
     </div>
   )
-}
+})

--- a/packages/react/src/lib/component/component.test.tsx
+++ b/packages/react/src/lib/component/component.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from "@testing-library/react"
+import React, { forwardRef } from "react"
+import { describe, expect, it } from "vitest"
+
+import { Component, F0_COMPONENT_NAME_ATTRIBUTE } from "./component"
+
+const Inner = forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  (props, ref) => (
+    <div ref={ref} {...props}>
+      Content
+    </div>
+  )
+)
+Inner.displayName = "Inner"
+
+describe("Component factory", () => {
+  it("stamps data-f0-component-name with meta.name on the root node", () => {
+    const Marked = Component({ name: "F0Test", type: "info" }, Inner)
+
+    render(<Marked />)
+
+    expect(screen.getByText("Content")).toHaveAttribute(
+      F0_COMPONENT_NAME_ATTRIBUTE,
+      "F0Test"
+    )
+  })
+
+  it("stamps regardless of XRay being enabled (no provider present)", () => {
+    const Marked = Component({ name: "F0NoProvider", type: "action" }, Inner)
+
+    render(<Marked />)
+
+    expect(screen.getByText("Content")).toHaveAttribute(
+      "data-f0-component-name",
+      "F0NoProvider"
+    )
+  })
+
+  it("still forwards the caller's ref to the root node", () => {
+    const ref = React.createRef<HTMLDivElement>()
+    const Marked = Component({ name: "F0Ref", type: "info" }, Inner)
+
+    render(<Marked ref={ref} />)
+
+    expect(ref.current).toBeInstanceOf(HTMLDivElement)
+    expect(ref.current).toHaveAttribute("data-f0-component-name", "F0Ref")
+  })
+
+  it("sets displayName to meta.name", () => {
+    const Marked = Component({ name: "F0Named", type: "info" }, Inner)
+
+    expect(Marked.displayName).toBe("F0Named")
+  })
+})

--- a/packages/react/src/lib/component/component.tsx
+++ b/packages/react/src/lib/component/component.tsx
@@ -1,7 +1,16 @@
-import { forwardRef, PropsWithoutRef } from "react"
+import { forwardRef, PropsWithoutRef, useEffect } from "react"
 
 import { useComponentXRay } from "../xray"
 import { ComponentMetadata } from "./types"
+
+/**
+ * Static, per-component-type marker stamped on the root DOM node of every
+ * component built with the {@link Component} factory. Unlike `data-testid`
+ * (which is a per-instance, consumer-supplied test hook), this identifies
+ * *which F0 component* rendered a node — the same value for every instance of
+ * a given component — so static analysis / tooling can map DOM back to F0.
+ */
+export const F0_COMPONENT_NAME_ATTRIBUTE = "data-f0-component-name"
 
 export const Component = <
   R extends HTMLElement | SVGElement,
@@ -12,6 +21,15 @@ export const Component = <
 ) => {
   const Forwarded = forwardRef<R, P>((props, forwardedRef) => {
     const { ref } = useComponentXRay(meta, forwardedRef)
+
+    // Always mark the rendered root node with the component's F0 identity.
+    // This is independent of XRay (a debug-only overlay) and always present.
+    useEffect(() => {
+      const element = ref.current
+      if (element instanceof Element) {
+        element.setAttribute(F0_COMPONENT_NAME_ATTRIBUTE, meta.name)
+      }
+    }, [ref, meta.name])
 
     return <Component ref={ref} {...props} />
   })


### PR DESCRIPTION
## Description

Stamps a static `data-f0-component-name` attribute onto the root DOM node of every component built with the `Component(meta, …)` factory, using `meta.name`. This marks *which* F0 component rendered a node — a per-component-type identity that is the same for every instance — so tooling can map a rendered DOM node back to its F0 component. It is always present (independent of the XRay debug overlay) and adds no extra DOM nodes.

This is deliberately separate from `data-testid`, which is a per-instance, consumer-supplied test hook (each `<F0Button>` can carry a different id) — a different concern, left untouched.

### Why this matters

This is groundwork for **static analysis of the rendered DOM in the monorepo and the composer**. Once every f0 component identifies itself in the DOM, we can run analysis over a rendered tree to **guarantee composition rules** (e.g. which components may/may not nest inside which) and to **assert that certain components include certain things** (required children, expected structure, etc.). Without a reliable, component-type-level marker on the DOM there's no dependable way to attribute a node to an f0 component — `data-testid` can't serve this because it's per-instance and optional. `data-f0-component-name` gives that stable anchor.

## Implementation details

- feat: the `Component` factory (`lib/component/component.tsx`) now stamps `data-f0-component-name={meta.name}` on the wrapped component's root node via a mount effect on the forwarded ref

  <details>
  <summary>Why the Component factory?</summary>

  It is already the F0 component-identity wrapper — it carries `{ name, type }` metadata and already stamped the node with `meta.name` for the XRay debug overlay (gated behind XRay). Making that stamp always-on, under the dedicated `data-f0-component-name` attribute, reuses the right abstraction instead of overloading the per-instance `data-testid` mechanism.
  </details>

- feat(F0AudioPlayer, F0AudioPlayerCard, F0VideoPlayer): route the media players through the factory so their roots carry the attribute

  <details>
  <summary>F0VideoPlayer note</summary>

  `F0VideoPlayerInternal` was a plain function component (no ref forwarding), so the factory's ref-stamp couldn't reach its DOM node. It's now a `forwardRef` that composes the forwarded ref with its existing wrapper ref (used for fullscreen/focus) via `useComposedRefs`.
  </details>

- test: cover stamping by `meta.name`, stamping without any XRay provider, ref forwarding, and per-component assertions on the audio/video roots
- chore: export `F0_COMPONENT_NAME_ATTRIBUTE` for reuse in tooling/tests

## How to verify

Rendered in Storybook and inspected the live DOM: `components-f0audioplayer--default` → root has `data-f0-component-name="F0AudioPlayer"`; `f0videoplayer--default` → root has `data-f0-component-name="F0VideoPlayer"`.

### Coverage / definition of done

Full coverage requires every public component to be built through the `Component(meta, …)` factory. Today only ~12 components use it, so this PR establishes the mechanism and migrates the media players; routing the remaining components through the factory (each needs a `type` classification) is tracked in #4854.