### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.56.3",
+  "packages/react": "4.56.4",
   "packages/react-native": "0.59.0",
   "packages/core": "1.56.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.56.4](https://github.com/factorialco/f0/compare/f0-react-v4.56.3...f0-react-v4.56.4) (2026-07-27)
+
+
+### Bug Fixes
+
+* **ResourceHeader:** use secondary border token for bottom rule ([#4839](https://github.com/factorialco/f0/issues/4839)) ([3a08ea4](https://github.com/factorialco/f0/commit/3a08ea49958fc4a3b1647005f2e3d9cfcdc2522c))
+
 ## [4.56.3](https://github.com/factorialco/f0/compare/f0-react-v4.56.2...f0-react-v4.56.3) (2026-07-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.56.3",
+  "version": "4.56.4",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.56.4</summary>

## [4.56.4](https://github.com/factorialco/f0/compare/f0-react-v4.56.3...f0-react-v4.56.4) (2026-07-27)


### Bug Fixes

* **ResourceHeader:** use secondary border token for bottom rule ([#4839](https://github.com/factorialco/f0/issues/4839)) ([3a08ea4](https://github.com/factorialco/f0/commit/3a08ea49958fc4a3b1647005f2e3d9cfcdc2522c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).