### PR TITLE
feat(OneTable): pin column header and summary row when the page scrolls

### DIFF
--- a/packages/react/src/experimental/OneTable/Table/index.tsx
+++ b/packages/react/src/experimental/OneTable/Table/index.tsx
@@ -14,13 +14,46 @@ import { TableHeader } from "../TableHeader"
 import { TableRow } from "../TableRow"
 import { TableContext } from "../utils/TableContext"
 
+export type TableScroll = "self" | "page"
+
 export interface TableProps {
   children: React.ReactNode
   loading?: boolean
-  fixedHeader?: boolean
+
+  /**
+   * Which element provides the scrollport that sticky rows pin to.
+   *
+   * - `"self"`: the table scrolls inside its own container. The container must
+   *   be height-constrained for that to happen, otherwise it grows to fit the
+   *   rows and the sticky header pins to a box that is itself scrolled away.
+   * - `"page"`: the table creates no scrollport of its own, so sticky rows pin
+   *   to the closest scrolling ancestor — normally the page. Use this when the
+   *   table sits in a page that scrolls as a whole. Horizontal scrolling moves
+   *   to that ancestor too.
+   *
+   * @default "self"
+   */
+  scroll?: TableScroll
 }
 
-function TableBase({ children, loading = false }: TableProps) {
+/**
+ * Closest ancestor that scrolls. Used in `"page"` mode, where the horizontal
+ * offset that drives the frozen-column shadows lives on an ancestor rather
+ * than on our own container.
+ */
+function getScrollParent(element: HTMLElement): HTMLElement | null {
+  let node = element.parentElement
+  while (node) {
+    const { overflowX, overflowY } = getComputedStyle(node)
+    if (/auto|scroll|overlay/.test(`${overflowX} ${overflowY}`)) {
+      return node
+    }
+    node = node.parentElement
+  }
+  return null
+}
+
+function TableBase({ children, loading = false, scroll = "self" }: TableProps) {
   const [isScrolled, setIsScrolled] = useState(false)
   const [isScrolledRight, setIsScrolledRight] = useState(false)
 
@@ -30,26 +63,35 @@ function TableBase({ children, loading = false }: TableProps) {
     const container = containerRef.current
     if (!container) return
 
+    const scroller = scroll === "page" ? getScrollParent(container) : container
+    if (!scroller) return
+
     const handleScroll = () => {
-      setIsScrolled(container.scrollLeft > 0)
+      setIsScrolled(scroller.scrollLeft > 0)
       setIsScrolledRight(
-        container.scrollWidth - container.scrollLeft - container.clientWidth > 0
+        scroller.scrollWidth - scroller.scrollLeft - scroller.clientWidth > 0
       )
     }
 
     handleScroll()
-    container.addEventListener("scroll", handleScroll)
+    scroller.addEventListener("scroll", handleScroll)
 
     return () => {
-      container.removeEventListener("scroll", handleScroll)
+      scroller.removeEventListener("scroll", handleScroll)
     }
-  }, [])
+  }, [scroll])
 
   return (
     <TableContext.Provider
       value={{ isScrolled, setIsScrolled, isScrolledRight, setIsScrolledRight }}
     >
-      <div ref={containerRef} className="relative h-full w-full overflow-auto">
+      <div
+        ref={containerRef}
+        className={cn(
+          "relative w-full",
+          scroll === "self" && "h-full overflow-auto"
+        )}
+      >
         <TableRoot
           className={cn(loading && "select-none opacity-50 transition-opacity")}
           aria-live={loading ? "polite" : undefined}

--- a/packages/react/src/experimental/OneTable/TableHead/index.tsx
+++ b/packages/react/src/experimental/OneTable/TableHead/index.tsx
@@ -286,8 +286,12 @@ export function TableHead({
       className={cn(
         "group h-11",
         "bg-f1-background",
-        isSticky &&
-          (isScrolled || isScrolledRight) &&
+        // Gated per axis, matching the shadow gradient below. A left-frozen
+        // cell only floats over content once scrolled horizontally; keying it
+        // off isScrolledRight lifted the leading header cell and gave it its
+        // own hairline on any table that merely had overflow to the right,
+        // leaving that column out of step with the rest of the header.
+        ((isStickyLeft && isScrolled) || (isStickyRight && isScrolledRight)) &&
           "relative bg-f1-background z-10 before:absolute before:inset-x-0 before:bottom-0 before:h-px before:w-full before:bg-f1-border-secondary before:content-['']",
         isSticky && "sticky",
         hidden && "after:hidden",

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -230,6 +230,7 @@ export const defaultTranslations = {
       },
     },
     summaries: {
+      total: "Total sum",
       types: {
         sum: "sum",
         count: "count",

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -116,6 +116,7 @@ export const TableCollection = <
   visualizationSettings,
   fromVisualization = "table",
   summaryPlaceholder = "-",
+  scroll = "self",
 }: CollectionProps<
   R,
   Filters,
@@ -308,6 +309,23 @@ export const TableCollection = <
     columnPlaceholder ?? summaryPlaceholder
 
   /**
+   * Summary value for a column, or undefined when the column defines no
+   * summary or the value came back empty.
+   */
+  const getColumnSummaryValue = (column: (typeof columns)[number]) => {
+    if (
+      !column.summary ||
+      !source.summaries ||
+      source.summaries[column.summary]?.type !== "sum"
+    ) {
+      return undefined
+    }
+
+    const value = summaryData?.data[column.summary]
+    return isEmptySummaryValue(value) ? undefined : `${value}`
+  }
+
+  /**
    * Handle column sort click
    */
   const handleSortClick = (columnSorting: SortingKey<Sortings>) => {
@@ -430,7 +448,7 @@ export const TableCollection = <
               "overflow-hidden rounded-lg border border-solid border-f1-border-secondary [&_thead::before]:!bg-transparent [&_thead_th>div:first-child]:!bg-transparent [&_tbody>tr:last-child::after]:!bg-transparent"
           )}
         >
-          <OneTable loading={isLoading}>
+          <OneTable loading={isLoading} scroll={scroll}>
             <TableHeader sticky={true}>
               {headerGroups ? (
                 <TableRow>
@@ -603,9 +621,14 @@ export const TableCollection = <
                   <TableRow>
                     <th
                       colSpan={1 + selectionHeaderColSpan}
-                      className="h-11 border-0 border-t border-solid border-f1-border-secondary bg-f1-background-secondary px-5"
+                      className="relative h-11 border-0 border-t border-solid border-f1-border-secondary bg-f1-background px-5"
                     >
-                      <div className="flex items-center gap-3">
+                      {/* This row sits in the sticky header, so rows scroll
+                          behind it and it needs an opaque base. The secondary
+                          tint is only 6% opaque, so it is layered over that
+                          base rather than applied to the cell directly. */}
+                      <div className="pointer-events-none absolute inset-0 bg-f1-background-secondary" />
+                      <div className="relative flex items-center gap-3">
                         <HighlightedCount
                           text={
                             allSelectedStatus.checked &&
@@ -864,81 +887,56 @@ export const TableCollection = <
                           width={checkColumnWidth}
                           sticky={{ left: 0 }}
                         >
-                          {summaryData.label && (
-                            <div className="font-medium text-f1-foreground-secondary">
-                              {summaryData.label}
-                            </div>
-                          )}
+                          {""}
                         </TableCell>
                       )}
-                      {columns.map((column, cellIndex) => (
-                        <TableCell
-                          key={`summary-${String(column.label)}`}
-                          firstCell={cellIndex === 0}
-                          width={column.width}
-                          sticky={getStickyPosition(cellIndex)}
-                          className={cn(
-                            isEditableTable &&
-                              (cellIndex !== columns.length - 1 ||
-                                showItemActions) &&
-                              "border-0 border-r-[1px] border-solid border-f1-border-secondary"
-                          )}
-                        >
-                          {cellIndex === 0 &&
-                          !source.selectable &&
-                          summaryData.label ? (
-                            <div className="font-medium text-f1-foreground-secondary">
-                              {summaryData.label}
-                            </div>
-                          ) : (
-                            <div
-                              className={cn(
-                                column.align === "right" ? "justify-end" : "",
-                                "flex"
-                              )}
-                            >
-                              {(() => {
-                                const placeholder = getSummaryPlaceholder(
-                                  column.summaryPlaceholder
-                                )
+                      {columns.map((column, cellIndex) => {
+                        const summaryValue = getColumnSummaryValue(column)
 
-                                if (
-                                  column.summary &&
-                                  source.summaries &&
-                                  source.summaries[column.summary]?.type ===
-                                    "sum"
-                                ) {
-                                  const summaryValue =
-                                    summaryData.data[column.summary]
+                        // The leading column labels the row so the values can
+                        // stand on their own, instead of repeating the summary
+                        // type next to every one of them. A leading column that
+                        // carries its own summary keeps showing the value.
+                        const showLabel =
+                          cellIndex === 0 && summaryValue === undefined
 
-                                  if (isEmptySummaryValue(summaryValue)) {
-                                    return (
-                                      <span className="text-f1-foreground-secondary">
-                                        {placeholder}
-                                      </span>
-                                    )
-                                  }
-
-                                  return (
-                                    <div className="flex gap-1">
-                                      <span className="text-f1-foreground-secondary">
-                                        {i18n.collections.summaries.types.sum}
-                                      </span>
-                                      {`${summaryValue}`}
-                                    </div>
-                                  )
-                                }
-
-                                return (
+                        return (
+                          <TableCell
+                            key={`summary-${String(column.label)}`}
+                            firstCell={cellIndex === 0}
+                            width={column.width}
+                            sticky={getStickyPosition(cellIndex)}
+                            className={cn(
+                              isEditableTable &&
+                                (cellIndex !== columns.length - 1 ||
+                                  showItemActions) &&
+                                "border-0 border-r-[1px] border-solid border-f1-border-secondary"
+                            )}
+                          >
+                            {showLabel ? (
+                              <div className="font-medium text-f1-foreground-secondary">
+                                {summaryData.label ??
+                                  i18n.collections.summaries.total}
+                              </div>
+                            ) : (
+                              <div
+                                className={cn(
+                                  column.align === "right" ? "justify-end" : "",
+                                  "flex"
+                                )}
+                              >
+                                {summaryValue ?? (
                                   <span className="text-f1-foreground-secondary">
-                                    {placeholder}
+                                    {getSummaryPlaceholder(
+                                      column.summaryPlaceholder
+                                    )}
                                   </span>
-                                )
-                              })()}
-                            </div>
-                          )}
-                        </TableCell>
-                      ))}
+                                )}
+                              </div>
+                            )}
+                          </TableCell>
+                        )
+                      })}
                       {showItemActions &&
                         (isEditableTable ? (
                           <TableCell

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/__tests__/Table.test.tsx
@@ -1130,6 +1130,36 @@ describe("TableCollection", () => {
       )
     })
 
+    it("labels the summary row in the leading column instead of each value", async () => {
+      render(
+        <TableCollection<
+          SummaryPerson,
+          TestFilters,
+          SortingsDefinition,
+          SummaryTestDefinitions,
+          ItemActionsDefinition<SummaryPerson>,
+          TestNavigationFilters,
+          GroupingDefinition<SummaryPerson>
+        >
+          columns={summaryColumns}
+          source={createSummarySource({ salarySummary: 1200 })}
+          onSelectItems={vi.fn()}
+          onLoadData={vi.fn()}
+          onLoadError={vi.fn()}
+        />
+      )
+
+      const summaryCells = await getSummaryRowCells()
+
+      expect(within(summaryCells[0]).getByText("Total sum")).toHaveClass(
+        "text-f1-foreground-secondary"
+      )
+      expect(within(summaryCells[2]).getByText("1200")).toBeInTheDocument()
+      expect(
+        within(summaryCells[2]).queryByText(/sum/i)
+      ).not.toBeInTheDocument()
+    })
+
     it("applies row-level summaryPlaceholder to empty summary and non-summary cells", async () => {
       render(
         <TableCollection<
@@ -1205,7 +1235,7 @@ describe("TableCollection", () => {
       expect(within(salaryCell).getByText("COLUMN")).toBeInTheDocument()
     })
 
-    it("keeps sum prefix for non-empty values and treats 0 as non-empty", async () => {
+    it("renders the value without a type prefix and treats 0 as non-empty", async () => {
       render(
         <TableCollection<
           SummaryPerson,
@@ -1228,8 +1258,8 @@ describe("TableCollection", () => {
       const summaryCells = await getSummaryRowCells()
       const salaryCell = summaryCells[2]
 
-      expect(within(salaryCell).getByText(/sum/i)).toBeInTheDocument()
       expect(within(salaryCell).getByText("0")).toBeInTheDocument()
+      expect(within(salaryCell).queryByText(/sum/i)).not.toBeInTheDocument()
       expect(within(salaryCell).queryByText("ROW")).not.toBeInTheDocument()
     })
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/types.ts
@@ -1,6 +1,6 @@
 import { ComponentProps, ComponentType, ReactNode } from "react"
 
-import { TableHead } from "@/experimental/OneTable"
+import { TableHead, type TableScroll } from "@/experimental/OneTable"
 import {
   FiltersDefinition,
   GroupingDefinition,
@@ -165,6 +165,27 @@ export type TableVisualizationOptions<
    * Useful for embedding the table inside panels or detail views.
    */
   bordered?: boolean
+
+  /**
+   * Which element the sticky column header and summary row pin to.
+   *
+   * - `"self"`: the rows scroll inside the table's own container, so the
+   *   filter bar above it stays in place. Pair with the collection's
+   *   `fullHeight` prop, which is what constrains that container's height.
+   * - `"page"`: the collection scrolls with the page, so the filter bar
+   *   scrolls away while the column header pins to the top of the viewport
+   *   and the summary row to the bottom. Leave `fullHeight` off, otherwise the
+   *   rows are clipped to the collection's height instead of extending the
+   *   page. Horizontal overflow also moves to the page scroller, which drags
+   *   the filter bar sideways with the rows — so prefer `"self"` for tables
+   *   wide enough to scroll horizontally, and for frozen columns.
+   *
+   * Note the sticky rows pin to the scrollport's content edge: a scroll
+   * container with top padding leaves a band where rows show above the header.
+   *
+   * @default "self"
+   */
+  scroll?: TableScroll
 }
 
 export type TableCollectionProps<


### PR DESCRIPTION
## Why

On a page that scrolls as a whole, `OneTable`'s header and summary rows don't stay put: you lose the column headers as you scroll, and have to scroll to the very bottom to read the totals. The `thead`/`tfoot` are already `position: sticky`, but that only works when the container is height-constrained (`fullHeight`). Otherwise the container grows to fit every row and the stickiness pins to a box that is itself scrolled off-screen — dead code on any page-scrolled collection.

## What

- **New `scroll: "self" | "page"` on the table visualization** — default `"self"`, so no existing collection changes behaviour. `"page"` makes the table create no scrollport of its own, so sticky rows resolve against the page scroller: header pins to the top of the viewport, summary row to the bottom, filter bar scrolls away above.
- **Summary row now reads as a totals row** — the leading column labels it in gray (`collections.summaries.total`, overridable per collection via `summaries.label`) instead of repeating the summary type beside every value.
- **Two latent fixes** reachable only once rows can scroll behind the header: the select-all-pages banner was tinted at 6% opacity over nothing (rows showed through) → now over an opaque base; a left-frozen header cell took its "floating" lift at `scrollLeft: 0` → now gated per axis.

## Current behaviour

https://github.com/user-attachments/assets/539786c7-21c5-4737-972c-0bc8d0c58c25

## Proposal demo

https://github.com/user-attachments/assets/191a8d4c-d6a8-42b7-b0fb-be86a6db97f3

## Trade-off to review

In `"page"` mode, horizontal overflow also moves to the page scroller — so on a table wide enough to scroll sideways, the filter bar drags along with the rows. Plain CSS sticky can't split the axes: `overflow-x: auto` re-creates the vertical scrollport that breaks the sticky header. So `"page"` suits tables that fit horizontally; `"self"` stays right for wide / frozen-column tables. Documented on the prop — happy to reshape the API if you'd rather make it harder to misuse.

## Verification

101 unit tests pass, typecheck clean. Prototyped on a real page (Spending → Employee expenses): header and summary row both pin flush and stack above the app footer rather than being occluded by it.

