### PR TITLE
fix(F0Graph): force instant node positioning (transition: none)

### DIFF
--- a/packages/react/src/patterns/F0Graph/F0Graph.css
+++ b/packages/react/src/patterns/F0Graph/F0Graph.css
@@ -32,6 +32,18 @@
   @apply cursor-pointer;
 }
 
+/* Node positioning must be instant. On expand/collapse the anchor-hold pans the
+ * viewport in a single frame (see `handleAnchorReflow`), assuming the node snaps
+ * to its new position in that same frame. A `transition` on the node transform —
+ * e.g. a bare global `.react-flow__node { transition: transform … }` rule leaked
+ * from elsewhere in a consuming app — breaks that: the camera jumps while the
+ * node eases, so the anchored node visibly slides. Own the invariant here rather
+ * than trust consumer CSS. Content transitions live on inner [data-zoom-level]
+ * elements and are unaffected. */
+.f0-graph .react-flow__node {
+  transition: none;
+}
+
 /* Respect OS reduced-motion preference — disable CSS transitions */
 @media (prefers-reduced-motion: reduce) {
   .f0-graph [data-zoom-level],


### PR DESCRIPTION
## Description

F0Graph's **anchor-hold** keeps the toggled node visually fixed on expand/collapse by panning the viewport in a **single frame** (`handleAnchorReflow` → `reactFlow.setViewport`), assuming node positions **snap** to their new spot in that same frame. Any CSS `transition` on the node `transform` breaks this invariant: the camera jumps while the node **eases** to its new position, so the anchored node (and its subtree) visibly **slides** over the transition duration.

This is reachable from consuming apps: React Flow's `.react-flow__node` is a **global** class, so a bare unscoped rule like `.react-flow__node { transition: transform 0.25s ease-in-out }` anywhere in the app leaks onto F0Graph and animates its node positions. We hit exactly this in the Factorial org chart (a rule from an unrelated module leaked in), producing a lateral "the parent arrives late" slide on expand.

Left local forcing the error vs right forcing the error but with the F0 fix

https://github.com/user-attachments/assets/bdb1be28-6c03-4be8-bcdb-8a4abd23c555




## Type of change

- [x] Bug fix

## Implementation details

`F0Graph.css`: add `.f0-graph .react-flow__node { transition: none }`. F0Graph now **owns** the instant-positioning invariant its anchor-hold depends on, instead of trusting consumer/global CSS. Only the `.react-flow__node` wrapper is affected — F0GraphNode's intentional content transitions (opacity, avatar scale, chrome) live on inner `[data-zoom-level]` elements and are untouched.

## Testing

- F0Graph unit tests unaffected (CSS-only, no API/behavior change to the components).
- Repro is timing/paint-level (a CSS transition on node transform); verified against a real consumer where the leaked rule caused the slide and this reset removes it.

## Notes

Defense-in-depth: the leaking rule should also be scoped at its source in the consuming app. This change makes F0Graph robust regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)