### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.56.4",
+  "packages/react": "4.56.5",
   "packages/react-native": "0.59.0",
   "packages/core": "1.56.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.56.5](https://github.com/factorialco/f0/compare/f0-react-v4.56.4...f0-react-v4.56.5) (2026-07-28)
+
+
+### Bug Fixes
+
+* **SurveyFormBuilder:** [FCT-59912] fix Add-option contrast + enforce a11y ([#4764](https://github.com/factorialco/f0/issues/4764)) ([d9af07c](https://github.com/factorialco/f0/commit/d9af07ca72983bf2c9a30cf90d36104fc8ba3099))
+
 ## [4.56.4](https://github.com/factorialco/f0/compare/f0-react-v4.56.3...f0-react-v4.56.4) (2026-07-27)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.56.4",
+  "version": "4.56.5",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.56.5</summary>

## [4.56.5](https://github.com/factorialco/f0/compare/f0-react-v4.56.4...f0-react-v4.56.5) (2026-07-28)


### Bug Fixes

* **SurveyFormBuilder:** [FCT-59912] fix Add-option contrast + enforce a11y ([#4764](https://github.com/factorialco/f0/issues/4764)) ([d9af07c](https://github.com/factorialco/f0/commit/d9af07ca72983bf2c9a30cf90d36104fc8ba3099))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).

[FCT-59912]: https://factorialmakers.atlassian.net/browse/FCT-59912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ