### PR TITLE
chore(storybook): [FCT-59941] align the a11y addon's axe rules with CI

### DIFF
--- a/packages/react/.storybook/preview.tsx
+++ b/packages/react/.storybook/preview.tsx
@@ -16,6 +16,7 @@ import { dataCollectionLocalStorageHandler } from "@/lib/providers/datacollectio
 import { F0Provider } from "@/lib/providers/f0"
 import { buildTranslations, defaultTranslations } from "@/lib/providers/i18n"
 import { ThemeProvider } from "@/lib/providers/theme"
+import { A11Y_RUN_ONLY } from "@/lib/storybook-utils/a11yAxeConfig"
 
 import {
   getAllComponentStatuses,
@@ -137,6 +138,12 @@ const preview: Preview = {
           },
         ],
       },
+
+      // Same rule scope CI enforces (see src/lib/storybook-utils/a11yAxeConfig.ts).
+      // Without this the addon ran axe's defaults, which omit rules axe ships
+      // disabled — notably `target-size` (WCAG 2.2 SC 2.5.8) — so a story could
+      // show 0 violations in the panel and still fail CI.
+      options: { runOnly: A11Y_RUN_ONLY },
 
       // 'todo' - show a11y violations in the test UI only
       // 'error' - fail CI on a11y violations

--- a/packages/react/.storybook/test-runner.ts
+++ b/packages/react/.storybook/test-runner.ts
@@ -10,10 +10,13 @@ import type Reporter from "axe-playwright/dist/types"
 import { appendFileSync, readFileSync } from "fs"
 import { join } from "path"
 
+// NOTE: the `.ts` extension is required — the test-runner's loader does not
+// resolve extensionless sibling imports (Storybook warns "extensionless imports
+// detected" and the module fails to load at runtime).
 import {
   A11Y_CI_CONTEXT,
   A11Y_RUN_ONLY,
-} from "../src/lib/storybook-utils/a11yAxeConfig"
+} from "../src/lib/storybook-utils/a11yAxeConfig.ts"
 
 // Story files grandfathered to skip axe while their violations are burned
 // down (Path to AA). Maps file → number of allowed skip call-sites; counts

--- a/packages/react/.storybook/test-runner.ts
+++ b/packages/react/.storybook/test-runner.ts
@@ -10,6 +10,11 @@ import type Reporter from "axe-playwright/dist/types"
 import { appendFileSync, readFileSync } from "fs"
 import { join } from "path"
 
+import {
+  A11Y_CI_CONTEXT,
+  A11Y_RUN_ONLY,
+} from "../src/lib/storybook-utils/a11yAxeConfig"
+
 // Story files grandfathered to skip axe while their violations are burned
 // down (Path to AA). Maps file → number of allowed skip call-sites; counts
 // may only shrink. Enforced per-count by a11ySkipAllowlist.test.ts; here we
@@ -181,22 +186,11 @@ const config: TestRunnerConfig = {
         }
       })
 
-      // Get violations without throwing an error
-      const violations = await getViolations(page, "#storybook-root", {
-        runOnly: {
-          type: "tag",
-          // WCAG 2.0, 2.1 and 2.2 at levels A and AA — matches the Plexus
-          // audit scope (UNE-EN 301549 + WCAG 2.1/2.2). AAA and axe's
-          // non-normative best-practice rules are intentionally excluded.
-          values: [
-            "wcag2a",
-            "wcag2aa",
-            "wcag21a",
-            "wcag21aa",
-            "wcag22a",
-            "wcag22aa",
-          ],
-        },
+      // Get violations without throwing an error. The rule scope is shared with
+      // the a11y addon (see src/lib/storybook-utils/a11yAxeConfig.ts) so the
+      // panel and CI cannot drift apart.
+      const violations = await getViolations(page, A11Y_CI_CONTEXT, {
+        runOnly: A11Y_RUN_ONLY,
       })
 
       // Report violations if any are found

--- a/packages/react/src/component-status/A11yRow.tsx
+++ b/packages/react/src/component-status/A11yRow.tsx
@@ -1,6 +1,7 @@
 import type { AxeResults, Result, TagValue } from "axe-core"
 import React, { useCallback, useEffect, useRef, useState } from "react"
 
+import { A11Y_WCAG_TAGS } from "../lib/storybook-utils/a11yAxeConfig"
 import type { A11yTier } from "./component-status"
 
 /**
@@ -20,14 +21,9 @@ import type { A11yTier } from "./component-status"
  * is a fresh, default-state indicator.
  */
 
-const WCAG_TAGS: TagValue[] = [
-  "wcag2a",
-  "wcag2aa",
-  "wcag21a",
-  "wcag21aa",
-  "wcag22a",
-  "wcag22aa",
-]
+// Shared with the addon (preview.tsx) and CI (test-runner.ts) so this row's
+// verdict is judged by the same rules the gate enforces.
+const WCAG_TAGS: TagValue[] = [...A11Y_WCAG_TAGS]
 
 interface Criterion {
   ruleId: string

--- a/packages/react/src/lib/storybook-utils/a11yAxeConfig.ts
+++ b/packages/react/src/lib/storybook-utils/a11yAxeConfig.ts
@@ -1,0 +1,55 @@
+/**
+ * Single source of truth for the axe rule scope used by BOTH accessibility
+ * surfaces:
+ *
+ * - the Storybook a11y **addon** (interactive panel) — via
+ *   `parameters.a11y.options.runOnly` in `.storybook/preview.tsx`
+ * - the **CI** test-runner — via `getViolations(...)` in
+ *   `.storybook/test-runner.ts`
+ *
+ * Keeping them in one place matters: they used to diverge silently. The addon
+ * ran axe's defaults while CI passed an explicit tag filter, so any rule that
+ * axe ships **disabled by default** ran in CI and was invisible in the panel.
+ * `target-size` (WCAG 2.2 SC 2.5.8) is the notable one — `enabled: false` in
+ * axe-core, activated by selecting the `wcag22aa` tag. That mismatch meant a
+ * story could look clean in the addon and fail CI.
+ *
+ * Do not inline these tags at a call-site — import them, so the two surfaces
+ * cannot drift apart again.
+ */
+
+/**
+ * WCAG 2.0, 2.1 and 2.2 at levels A and AA — matches the Plexus audit scope
+ * (UNE-EN 301549 + WCAG 2.1/2.2). Level AAA and axe's non-normative
+ * `best-practice` rules are intentionally excluded.
+ *
+ * Selecting rules by tag also switches on rules axe disables by default when
+ * they carry one of these tags (e.g. `target-size` via `wcag22aa`).
+ */
+export const A11Y_WCAG_TAGS = [
+  "wcag2a",
+  "wcag2aa",
+  "wcag21a",
+  "wcag21aa",
+  "wcag22a",
+  "wcag22aa",
+] as const
+
+/** `runOnly` object for `axe.run()` / the addon's `a11y.options`. */
+export const A11Y_RUN_ONLY = {
+  type: "tag" as const,
+  values: [...A11Y_WCAG_TAGS],
+}
+
+/**
+ * The element CI scopes axe to.
+ *
+ * NOTE — a known asymmetry, deliberately left in place: CI scopes to the story
+ * root, while the addon scans the whole document. Portaled content (dropdowns,
+ * tooltips, dialogs, the Select listbox) mounts outside `#storybook-root`, so
+ * CI does **not** see it and the addon does. Narrowing the addon to this
+ * selector would hide the only place portal violations are currently visible.
+ * Widening CI is tracked separately — it needs care, because the full document
+ * also contains Storybook's own chrome.
+ */
+export const A11Y_CI_CONTEXT = "#storybook-root"

--- a/vendor/skills/f0-storybook-testing/SKILL.md
+++ b/vendor/skills/f0-storybook-testing/SKILL.md
@@ -30,7 +30,8 @@ For story file structure and snapshot patterns, see the `f0-storybook-stories` s
 
 ### a11y Tests (automatic)
 
-- axe runs on **every story** automatically after render (WCAG 2.x AA)
+- axe runs on **every story** automatically after render (WCAG 2.0/2.1/2.2 A + AA). The tag list lives in `src/lib/storybook-utils/a11yAxeConfig.ts` and is shared by CI, the addon panel and the docs a11y row — don't inline it
+- **The addon panel is not a CI predictor.** Rules are shared, but state, scope and viewport differ, so a story can show 0 violations in the panel and still fail CI. Before flipping a file to `test: "error"`, run `pnpm test-storybook -- --testPathPatterns <Component>`. See `references/storybook-test-patterns.md`
 - Default behaviour on violation: test **fails** (`"error"` mode)
 - Skipping axe is **not allowed for new stories**: `a11y: { skipCi: true }` (and the deprecated `withSkipA11y()` helper, which sets it) fail CI unless the story file is grandfathered in `.storybook/a11y-skip-allowlist.json` — a burndown list of file → allowed call-site count that only shrinks (adding a skip even to a grandfathered file fails the unit tests). `test: "off"` is rejected too.
 - **When you remove a `skipCi` or `withSkipA11y` usage** (a11y burndown), you MUST update `.storybook/a11y-skip-allowlist.json` in the same change: lower that file's count by the number of call-sites removed, and delete the entry entirely when it reaches zero. Verify with `pnpm --filter @factorialco/f0-react exec vitest run src/lib/storybook-utils/a11ySkipAllowlist.test.ts` — it fails on any mismatch.

--- a/vendor/skills/f0-storybook-testing/references/storybook-test-patterns.md
+++ b/vendor/skills/f0-storybook-testing/references/storybook-test-patterns.md
@@ -77,9 +77,38 @@ play: async ({ canvasElement }) => {
 
 ## a11y Tests (automatic via axe-playwright)
 
-axe runs on **every story** automatically after render. Tags checked: `wcag2a`, `wcag2aa`, `wcag21a`, `wcag21aa`.
+axe runs on **every story** automatically after render. Tags checked: `wcag2a`, `wcag2aa`, `wcag21a`, `wcag21aa`, `wcag22a`, `wcag22aa` — WCAG 2.0/2.1/2.2 at levels A and AA. AAA and axe's non-normative `best-practice` rules are intentionally excluded.
 
-Default on violation: **test fails**.
+The tag list lives in **one** place, `src/lib/storybook-utils/a11yAxeConfig.ts`, and is imported by the CI test-runner, the Storybook a11y addon (`preview.tsx`) and the docs-panel a11y row (`A11yRow.tsx`). Don't inline it at a call-site — the three surfaces used to drift apart.
+
+Default on violation: **test fails** (`test: "error"`) — but note `preview.tsx` currently sets a global `test: "todo"`, so in practice a story only blocks CI if it opts into `"error"`.
+
+### The addon panel is not a CI predictor
+
+A story can look clean in the Storybook Accessibility panel and still fail CI. Four things differ; only the first is now aligned:
+
+| | Addon panel | CI test-runner | Aligned? |
+| --- | --- | --- | --- |
+| **Rule set** | shared tag list | shared tag list | ✅ yes |
+| **State** | whatever is on screen right now | each story from its own `args`, **then** its play function | ❌ no |
+| **Scope** | whole document | `#storybook-root` | ❌ no |
+| **Viewport** | your canvas size | 1280x720 | ❌ no |
+
+Consequences worth knowing:
+
+- **State.** CI evaluates every story from its declared `args`. A story that presets a value renders UI you would not see by opening the component's default story — e.g. `F0Select`'s `Clearable` sets `value: "dark"`, so the clear button is present on load and its `target-size` violation fires without any interaction.
+- **Scope.** Portaled content (dropdowns, tooltips, dialogs, listboxes) mounts **outside** `#storybook-root`, so **CI does not scan it** and the addon does. The two miss different things.
+- **Viewport.** Geometry-dependent rules (`target-size`, `scrollable-region-focusable`) legitimately disagree between a narrow canvas and 1280x720.
+
+**Before flipping a file to `test: "error"`, run the real thing:**
+
+```bash
+pnpm --filter @factorialco/f0-react test-storybook -- --testPathPatterns <Component>
+```
+
+Same runner, same rules, same scope, same viewport, every story, play functions included. Checking the panel — or only the default story — is not sufficient evidence.
+
+For files still listed in `.storybook/a11y-skip-allowlist.json`, even that won't help: the test-runner returns early, so those stories are **not measured at all**. "CI never reported it" is not evidence a skipped file is clean.
 
 ### Configuring a11y behaviour per story
 


### PR DESCRIPTION
## Description

https://factorialmakers.atlassian.net/browse/FCT-59941

The Storybook a11y **addon** and the **CI** test-runner ran different axe rule sets, and nothing surfaced the difference. CI passes an explicit `runOnly` tag filter; the addon had no `options`, so it ran axe's **defaults**.

axe ships some rules `enabled: false`, and selecting them by tag switches them on. So CI ran rules the addon never did — **a story could show 0 violations in the panel and still fail CI.**

`target-size` (WCAG 2.2 SC 2.5.8) is the case that bit us: `enabled: false` in axe-core, activated only via the `wcag22aa` tag, which #4775 added to `test-runner.ts` without touching `preview.tsx`. That's why #4738 (Select) failed CI on `target-size` after removing its `skipCi`, on a component whose panel showed nothing — see the screenshots in that thread.

There was also a **third** independent copy of the tag list in `src/component-status/A11yRow.tsx` — the live audit behind the Accessibility row on every docs page, which also feeds the a11y gate in `meetsStableBar()`.

## Implementation details

- chore: add `src/lib/storybook-utils/a11yAxeConfig.ts` as the single source of truth (`A11Y_WCAG_TAGS`, `A11Y_RUN_ONLY`, `A11Y_CI_CONTEXT`), with the rationale and the known asymmetries documented inline.
- chore: `preview.tsx` sets `a11y.options.runOnly` so the addon runs CI's rules.
- chore: `test-runner.ts` imports the shared constant instead of its inline array.
- chore: `A11yRow.tsx` imports `A11Y_WCAG_TAGS` instead of its own copy.

| Surface | Before | After |
| --- | --- | --- |
| CI (`test-runner.ts`) | inline tag array | `A11Y_RUN_ONLY` |
| Addon (`preview.tsx`) | axe defaults (no filter) | `a11y.options.runOnly` |
| Docs panel (`A11yRow.tsx`) | own inline copy | `A11Y_WCAG_TAGS` |

**No enforcement change.** The global mode stays `test: "todo"`, so newly visible violations are non-blocking. The addon will surface more findings — that is the point, not a regression.

<details>
<summary>Note on the required <code>.ts</code> extension</summary>

`test-runner.ts` imports the constant with an explicit `.ts` extension. The test-runner's loader does not resolve extensionless sibling imports — Storybook warns *"extensionless imports detected"* and the module fails at runtime. This is the reason `wcagFromTags` was previously inlined there rather than shared with `A11yRow`. Typecheck does **not** catch it; only running `test-storybook` does. A comment records this so it is not re-broken.
</details>

## Net rule change for the addon

- **Gains 3** (were invisible, CI-enforced): `target-size` (WCAG 2.2 AA), `aria-roledescription` (2 A), `audio-caption` (2 A)
- **Loses 30**, all `best-practice` only, none WCAG-required: `heading-order`, `landmark-*`, `region`, `tabindex`, `empty-heading`, `aria-dialog-name`, `skip-link`, …

The best-practice rules were never a deliberate choice: the only mention of `best-practice` in the repo is the comment in `test-runner.ts` explaining they are *excluded*. They appeared in the panel purely because the addon was unconfigured, they gate nothing, and both intentional surfaces (CI and the docs a11y row) already excluded them. Tag filter selects **69 of 104** axe rules.

## Deliberately NOT aligned

- **Scope.** CI scopes axe to `#storybook-root`; the addon scans the whole document. Portaled content (dropdowns, tooltips, dialogs, the Select listbox) mounts **outside** `#storybook-root`, so **CI does not see it** and the addon does. Narrowing the addon would hide the only place portal violations are currently visible. Widening CI is a separate question — the document also holds Storybook's own chrome. Documented in `a11yAxeConfig.ts`.
- **Viewport.** The addon uses the canvas size, CI uses 1280×720. Not configurable away, and it is why viewport-sensitive rules like `scrollable-region-focusable` can still legitimately disagree between the two.

## Verification

- `tsc --noEmit` clean; oxlint 0 warnings; oxfmt clean.
- `vitest run src/component-status/` — **44 pass** (includes `A11yRow.test.tsx`, `ComponentStability.test.tsx`).
- `pnpm test-storybook --testPathPatterns F0BigNumber` — **7/7 pass**, confirming the shared module loads in the test-runner (this is what caught the extensionless-import bug).
- `pnpm test-storybook --testPathPatterns F0Card/__stories__/Card` — **29/29 pass** and still reports `target-size` (2 nodes) as a non-blocking warning, confirming the shared `runOnly` is genuinely applied rather than silently dropped.

## Note for review

⚠️ After this lands, **the addon panel will show more violations across the library** — `target-size` in particular. Nothing new is being enforced; those violations were always there and always counted in CI. Expect questions from anyone who reads the panel as a health check.

ℹ️ #4775's measured 2.2 baseline is a lower bound: it was taken while ~36 files still skipped axe, so `target-size` inside those files was invisible to it. Corrected figures (21 stories / 9 files, vs the 5 reported) posted as a comment on FCT-59727.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
