### PR TITLE
fix(a11y): [FCT-59951] remove axe rule suppressions and gate future ones

### DIFF
--- a/packages/react/src/components/avatars/F0AvatarEmoji/__stories__/F0AvatarEmoji.stories.tsx
+++ b/packages/react/src/components/avatars/F0AvatarEmoji/__stories__/F0AvatarEmoji.stories.tsx
@@ -29,16 +29,6 @@ const meta = {
           .join(""),
       },
     },
-    a11y: {
-      config: {
-        rules: [
-          {
-            id: "color-contrast",
-            enabled: false,
-          },
-        ],
-      },
-    },
   },
 } satisfies Meta<typeof F0AvatarEmoji>
 

--- a/packages/react/src/components/avatars/F0AvatarIcon/__stories__/F0AvatarIcon.stories.tsx
+++ b/packages/react/src/components/avatars/F0AvatarIcon/__stories__/F0AvatarIcon.stories.tsx
@@ -36,16 +36,6 @@ const meta = {
           .join(""),
       },
     },
-    a11y: {
-      config: {
-        rules: [
-          {
-            id: "color-contrast",
-            enabled: false,
-          },
-        ],
-      },
-    },
   },
 } satisfies Meta<typeof F0AvatarIcon>
 

--- a/packages/react/src/experimental/Widgets/Charts/PieChartWidget/index.stories.tsx
+++ b/packages/react/src/experimental/Widgets/Charts/PieChartWidget/index.stories.tsx
@@ -10,11 +10,6 @@ const meta = {
   component: PieChartWidget,
   parameters: {
     layout: "centered",
-    a11y: {
-      config: {
-        rules: [{ id: "svg-img-alt", enabled: false }],
-      },
-    },
   },
   tags: ["autodocs", "experimental"],
   args: {

--- a/packages/react/src/experimental/Widgets/Layout/Dashboard/index.stories.tsx
+++ b/packages/react/src/experimental/Widgets/Layout/Dashboard/index.stories.tsx
@@ -50,13 +50,7 @@ const meta = {
     widgetWidth: "sm",
     children: Array.from({ length: 20 }, (_, i) => widgets[i % widgets.length]),
   },
-  parameters: {
-    a11y: {
-      config: {
-        rules: [{ id: "svg-img-alt", enabled: false }],
-      },
-    },
-  },
+  parameters: {},
 } satisfies Meta<typeof Dashboard>
 
 export default meta

--- a/packages/react/src/experimental/Widgets/Layout/WidgetStrip/index.stories.tsx
+++ b/packages/react/src/experimental/Widgets/Layout/WidgetStrip/index.stories.tsx
@@ -37,13 +37,7 @@ const meta = {
   args: {
     children: Array.from({ length: 4 }, (_, i) => widgets[i % widgets.length]),
   },
-  parameters: {
-    a11y: {
-      config: {
-        rules: [{ id: "svg-img-alt", enabled: false }],
-      },
-    },
-  },
+  parameters: {},
 } satisfies Meta<typeof WidgetStrip>
 
 export default meta

--- a/packages/react/src/kits/Charts/PieChart/index.stories.tsx
+++ b/packages/react/src/kits/Charts/PieChart/index.stories.tsx
@@ -6,13 +6,7 @@ const meta: Meta<typeof PieChart> = {
   component: PieChart,
   title: "Charts/PieChart",
   tags: ["no-sidebar"],
-  parameters: {
-    a11y: {
-      config: {
-        rules: [{ id: "svg-img-alt", enabled: false }],
-      },
-    },
-  },
+  parameters: {},
   decorators: [
     (Story) => (
       <div className="h-96 w-full">

--- a/packages/react/src/layouts/Layout/__stories__/Layout.stories.tsx
+++ b/packages/react/src/layouts/Layout/__stories__/Layout.stories.tsx
@@ -58,11 +58,6 @@ const meta = {
   },
   parameters: withSkipA11y({
     layout: "fullscreen",
-    a11y: {
-      config: {
-        rules: [{ id: "svg-img-alt", enabled: false }],
-      },
-    },
     docs: {
       description: {
         component: [

--- a/packages/react/src/layouts/TwoColumnLayout/__stories__/TwoColumnLayout.stories.tsx
+++ b/packages/react/src/layouts/TwoColumnLayout/__stories__/TwoColumnLayout.stories.tsx
@@ -48,11 +48,6 @@ const meta = {
     ),
   },
   parameters: {
-    a11y: {
-      config: {
-        rules: [{ id: "svg-img-alt", enabled: false }],
-      },
-    },
     docs: {
       description: {
         component: [

--- a/packages/react/src/lib/storybook-utils/a11yRuleSuppression.test.ts
+++ b/packages/react/src/lib/storybook-utils/a11yRuleSuppression.test.ts
@@ -1,0 +1,88 @@
+import { readdirSync, readFileSync } from "fs"
+import { join, relative } from "path"
+import { describe, expect, it } from "vitest"
+
+/**
+ * Gate: no story may switch an axe rule off.
+ *
+ * `a11y: { config: { rules: [{ id: "...", enabled: false }] } }` was a silent
+ * escape hatch. Unlike `skipCi` — which is gated by
+ * `a11ySkipAllowlist.test.ts` and recorded in an allowlist — a disabled rule
+ * left **no trace anywhere**: it never appears in the CI job summary, never
+ * lands in `a11y-violations.jsonl` (so no PR comment), and shows nothing in the
+ * Storybook a11y panel. It was strictly more invisible than skipping.
+ *
+ * There is deliberately no allowlist here: the population was reduced to zero
+ * in the same change that added this test, so the rule is simply "never".
+ *
+ * Deferring a known violation? Use `a11y: { test: "todo" }` — axe still runs
+ * and still reports; it just doesn't block. For genuinely non-applicable
+ * elements prefer an element-scoped opt-out, e.g.
+ * `data-a11y-color-contrast-ignore` (see the `color-contrast` selector in
+ * `.storybook/preview.tsx`), which narrows the exemption to the one node
+ * instead of blinding a whole story.
+ */
+
+const packageRoot = join(__dirname, "../../..")
+
+/**
+ * Find axe rule descriptors that disable a rule. Matches both the compact
+ * (`rules: [{ id: "x", enabled: false }]`) and expanded object forms by
+ * checking whether an `enabled: false` sits inside a `rules:` array entry that
+ * also carries an `id:`. Scoped this way so unrelated `enabled: false` config
+ * (e.g. a component's own `aiPromotion` prop) is not flagged.
+ */
+const findDisabledRules = (content: string): string[] => {
+  const hits: string[] = []
+  const re = /rules:\s*\[([\s\S]*?)\]/g
+  let m: RegExpExecArray | null
+  while ((m = re.exec(content)) !== null) {
+    const body = m[1]
+    if (!/enabled:\s*false/.test(body)) continue
+    // Collect the rule ids that appear in this array, for a useful message.
+    const ids = [...body.matchAll(/id:\s*["']([^"']+)["']/g)].map((x) => x[1])
+    hits.push(...(ids.length > 0 ? ids : ["<unknown rule>"]))
+  }
+  return hits
+}
+
+const findStoryFilesSuppressingRules = (
+  dir: string
+): Record<string, string[]> => {
+  const results: Record<string, string[]> = {}
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      Object.assign(results, findStoryFilesSuppressingRules(fullPath))
+    } else if (entry.name.endsWith(".stories.tsx")) {
+      const disabled = findDisabledRules(readFileSync(fullPath, "utf-8"))
+      if (disabled.length > 0) {
+        results[relative(packageRoot, fullPath)] = disabled
+      }
+    }
+  }
+  return results
+}
+
+describe("a11y rule suppression", () => {
+  it("no story disables an axe rule via a11y.config.rules", () => {
+    const offenders = findStoryFilesSuppressingRules(join(packageRoot, "src"))
+    expect(
+      Object.entries(offenders).map(
+        ([file, rules]) => `${file} → ${rules.join(", ")}`
+      ),
+      `These stories switch an axe rule off, which hides the violation from ` +
+        `CI's job summary, from a11y-violations.jsonl (the PR comment) and ` +
+        `from the Storybook a11y panel — it leaves no trace at all.\n\n` +
+        `Instead:\n` +
+        `  • Deferring a known violation → a11y: { test: "todo" } (axe still ` +
+        `runs and reports, it just doesn't block)\n` +
+        `  • Intentional/accepted → a11y: { test: "warning" }\n` +
+        `  • A specific element genuinely not applicable → an element-scoped ` +
+        `opt-out such as data-a11y-color-contrast-ignore, so only that node is ` +
+        `exempt\n\n` +
+        `Enabling or re-configuring a rule (enabled: true, or adding a ` +
+        `selector) is fine — this gate only rejects disabling.`
+    ).toEqual([])
+  })
+})

--- a/packages/react/src/lib/storybook-utils/a11yRuleSuppression.test.ts
+++ b/packages/react/src/lib/storybook-utils/a11yRuleSuppression.test.ts
@@ -22,34 +22,91 @@ import { describe, expect, it } from "vitest"
  * `.storybook/preview.tsx`), which narrows the exemption to the one node
  * instead of blinding a whole story.
  *
- * Scope covers both per-story parameters **and** `.storybook/` global
- * parameters — a global disable would silence a rule library-wide, which is
- * worse than any single story doing it.
+ * Scope covers per-story parameters **and** `.storybook/` global parameters — a
+ * global disable would silence a rule library-wide, which is worse than any
+ * single story doing it.
  */
 
 const packageRoot = join(__dirname, "../../..")
 
 /**
- * Find axe rule descriptors that disable a rule. Matches both the compact
- * (`rules: [{ id: "x", enabled: false }]`) and expanded object forms by
- * checking whether an `enabled: false` sits inside a `rules:` array that also
- * carries an `id:`. Scoped this way so unrelated `enabled: false` config (e.g.
- * a component's own `aiPromotion` prop, or a React context default) is not
- * flagged.
+ * Extract the body of every `a11y: { ... }` object in `content`, by matching
+ * braces.
  *
- * Returns the disabled rule ids, for a useful failure message.
+ * Detection is deliberately scoped to these blocks rather than searching for
+ * any `rules:` array: `rules` is a generic name that other, unrelated APIs use
+ * (`src/lib/text.ts` has its own `Rules` type for text formatting), so an
+ * unscoped match would flag non-a11y config and fail a PR with a misleading
+ * accessibility error.
+ *
+ * Brace counting ignores string and comment contents, so a `{` inside a
+ * selector or a comment cannot unbalance it.
+ */
+export const extractA11yBlocks = (content: string): string[] => {
+  const blocks: string[] = []
+  const opener = /a11y\s*:\s*\{/g
+
+  // Only the match position matters — `opener.lastIndex` is where the block
+  // body starts — so the match object itself is not needed.
+  while (opener.exec(content) !== null) {
+    let i = opener.lastIndex
+    let depth = 1
+    let quote: string | null = null
+    let comment: "line" | "block" | null = null
+
+    while (i < content.length && depth > 0) {
+      const ch = content[i]
+      const next = content[i + 1]
+
+      if (comment === "line") {
+        if (ch === "\n") comment = null
+      } else if (comment === "block") {
+        if (ch === "*" && next === "/") (i++, (comment = null))
+      } else if (quote) {
+        if (ch === "\\") i++
+        else if (ch === quote) quote = null
+      } else if (ch === "/" && next === "/") {
+        comment = "line"
+        i++
+      } else if (ch === "/" && next === "*") {
+        comment = "block"
+        i++
+      } else if (ch === '"' || ch === "'" || ch === "`") {
+        quote = ch
+      } else if (ch === "{") {
+        depth++
+      } else if (ch === "}") {
+        depth--
+      }
+      i++
+    }
+    blocks.push(content.slice(opener.lastIndex, i - 1))
+  }
+  return blocks
+}
+
+/**
+ * Rule ids disabled inside an `a11y` block. Matches both the compact
+ * (`rules: [{ id: "x", enabled: false }]`) and expanded object forms.
+ *
+ * Only `rules` arrays count — `a11y: { disable: true }` is deliberately out of
+ * scope: CI never consults it (`test-runner.ts` runs axe regardless), so it
+ * suppresses only the addon panel, and every current usage already sits beside
+ * a gated `skipCi`.
  */
 export const findDisabledRules = (content: string): string[] => {
   const hits: string[] = []
-  const re = /rules\s*:\s*\[([\s\S]*?)\]/g
-  let m: RegExpExecArray | null
-  while ((m = re.exec(content)) !== null) {
-    const body = m[1]
-    if (!/enabled\s*:\s*false/.test(body)) continue
-    const ids = [...body.matchAll(/id\s*:\s*["']([^"']+)["']/g)].map(
-      (x) => x[1]
-    )
-    hits.push(...(ids.length > 0 ? ids : ["<unknown rule>"]))
+  for (const block of extractA11yBlocks(content)) {
+    const re = /rules\s*:\s*\[([\s\S]*?)\]/g
+    let m: RegExpExecArray | null
+    while ((m = re.exec(block)) !== null) {
+      const body = m[1]
+      if (!/enabled\s*:\s*false/.test(body)) continue
+      const ids = [...body.matchAll(/id\s*:\s*["']([^"']+)["']/g)].map(
+        (x) => x[1]
+      )
+      hits.push(...(ids.length > 0 ? ids : ["<unknown rule>"]))
+    }
   }
   return hits
 }
@@ -85,8 +142,8 @@ const findSuppressions = (files: string[]): Record<string, string[]> => {
   return results
 }
 
-describe("findDisabledRules (detector)", () => {
-  it("catches the compact single-line form", () => {
+describe("findDisabledRules — catches a11y suppressions", () => {
+  it("the compact single-line form", () => {
     expect(
       findDisabledRules(
         `parameters: { a11y: { config: { rules: [{ id: "svg-img-alt", enabled: false }] } } }`
@@ -94,7 +151,78 @@ describe("findDisabledRules (detector)", () => {
     ).toEqual(["svg-img-alt"])
   })
 
-  it("catches the expanded multi-line form", () => {
+  it("the expanded multi-line form", () => {
+    expect(
+      findDisabledRules(`
+        parameters: {
+          a11y: {
+            config: {
+              rules: [
+                {
+                  id: "color-contrast",
+                  enabled: false,
+                },
+              ],
+            },
+          },
+        }
+      `)
+    ).toEqual(["color-contrast"])
+  })
+
+  it("several disabled rules in one array", () => {
+    expect(
+      findDisabledRules(
+        `a11y: { config: { rules: [{ id: "a", enabled: false }, { id: "b", enabled: false }] } }`
+      )
+    ).toEqual(["a", "b"])
+  })
+
+  it("single-quoted ids and loose spacing", () => {
+    expect(
+      findDisabledRules(
+        `a11y : { config : { rules : [ { id : 'target-size' , enabled : false } ] } }`
+      )
+    ).toEqual(["target-size"])
+  })
+
+  it("more than one a11y block in a file", () => {
+    expect(
+      findDisabledRules(`
+        export const A = { parameters: { a11y: { config: { rules: [{ id: "one", enabled: false }] } } } }
+        export const B = { parameters: { a11y: { config: { rules: [{ id: "two", enabled: false }] } } } }
+      `)
+    ).toEqual(["one", "two"])
+  })
+
+  it("a suppression sitting beside other a11y keys", () => {
+    expect(
+      findDisabledRules(`
+        a11y: {
+          test: "todo",
+          config: { rules: [{ id: "region", enabled: false }] },
+        },
+      `)
+    ).toEqual(["region"])
+  })
+
+  it("reports a placeholder when the disabled rule has no id", () => {
+    expect(
+      findDisabledRules(`a11y: { config: { rules: [{ enabled: false }] } }`)
+    ).toEqual(["<unknown rule>"])
+  })
+})
+
+describe("findDisabledRules — does not flag legitimate config", () => {
+  it("allows enabling a rule", () => {
+    expect(
+      findDisabledRules(
+        `a11y: { config: { rules: [{ id: "color-contrast", enabled: true }] } }`
+      )
+    ).toEqual([])
+  })
+
+  it("allows reconfiguring an enabled rule with a selector (preview.tsx pattern)", () => {
     expect(
       findDisabledRules(`
         a11y: {
@@ -102,79 +230,78 @@ describe("findDisabledRules (detector)", () => {
             rules: [
               {
                 id: "color-contrast",
-                enabled: false,
+                enabled: true,
+                selector: "*:not([data-a11y-color-contrast-ignore])",
               },
             ],
           },
         },
       `)
-    ).toEqual(["color-contrast"])
-  })
-
-  it("catches several disabled rules in one array", () => {
-    expect(
-      findDisabledRules(
-        `rules: [{ id: "a", enabled: false }, { id: "b", enabled: false }]`
-      )
-    ).toEqual(["a", "b"])
-  })
-
-  it("catches single-quoted ids and tolerant spacing", () => {
-    expect(
-      findDisabledRules(`rules : [ { id : 'target-size' , enabled : false } ]`)
-    ).toEqual(["target-size"])
-  })
-
-  it("catches more than one rules array in a file", () => {
-    expect(
-      findDisabledRules(`
-        const a = { rules: [{ id: "one", enabled: false }] }
-        const b = { rules: [{ id: "two", enabled: false }] }
-      `)
-    ).toEqual(["one", "two"])
-  })
-
-  it("allows enabling a rule", () => {
-    expect(
-      findDisabledRules(`rules: [{ id: "color-contrast", enabled: true }]`)
     ).toEqual([])
   })
 
-  it("allows reconfiguring an enabled rule with a selector (preview.tsx pattern)", () => {
+  it("allows an empty rules array", () => {
+    expect(findDisabledRules(`a11y: { config: { rules: [] } }`)).toEqual([])
+  })
+
+  it("ignores a11y.disable (out of scope — CI ignores it)", () => {
+    expect(findDisabledRules(`a11y: { skipCi: true, disable: true }`)).toEqual(
+      []
+    )
+  })
+})
+
+describe("findDisabledRules — does not flag non-a11y config", () => {
+  it("ignores a `rules` array outside any a11y block", () => {
+    // `rules` is a generic name. src/lib/text.ts has its own Rules type, and a
+    // component could gain a `rules` prop — neither is an axe suppression.
     expect(
-      findDisabledRules(`
-        rules: [
-          {
-            id: "color-contrast",
-            enabled: true,
-            selector: "*:not([data-a11y-color-contrast-ignore])",
-          },
-        ],
-      `)
+      findDisabledRules(
+        `args: { validation: { rules: [{ id: "required", enabled: false }] } }`
+      )
+    ).toEqual([])
+  })
+
+  it("ignores a text-formatting rules object", () => {
+    expect(
+      findDisabledRules(
+        `args: { rules: { disallowEmpty: false, enabled: false } }`
+      )
     ).toEqual([])
   })
 
   it("ignores unrelated enabled: false config", () => {
-    // e.g. ApplicationFrame's aiPromotion prop, or a React context default —
-    // no `rules:` array, so not an axe suppression.
+    expect(
+      findDisabledRules(`aiPromotion: { enabled: false, greeting: "Hey" }`)
+    ).toEqual([])
+  })
+
+  it("does not leak past the end of an a11y block", () => {
+    // The disable sits AFTER the a11y block closes, so it must not be picked up.
     expect(
       findDisabledRules(`
-        aiPromotion: {
-          enabled: false,
-          greeting: "Hey",
-        },
+        parameters: {
+          a11y: { test: "todo" },
+          chart: { rules: [{ id: "gridlines", enabled: false }] },
+        }
       `)
     ).toEqual([])
   })
 
-  it("ignores a rules array with no disabled entry", () => {
-    expect(findDisabledRules(`rules: [{ id: "region" }]`)).toEqual([])
-  })
-
-  it("reports a placeholder when the disabled rule has no id", () => {
-    expect(findDisabledRules(`rules: [{ enabled: false }]`)).toEqual([
-      "<unknown rule>",
-    ])
+  it("is not confused by braces inside strings or comments", () => {
+    expect(
+      findDisabledRules(`
+        a11y: {
+          // a brace in a comment: {
+          config: {
+            rules: [
+              { id: "color-contrast", enabled: true, selector: "div{}" },
+            ],
+          },
+        },
+        other: { rules: [{ id: "nope", enabled: false }] },
+      `)
+    ).toEqual([])
   })
 })
 

--- a/packages/react/src/lib/storybook-utils/a11yRuleSuppression.test.ts
+++ b/packages/react/src/lib/storybook-utils/a11yRuleSuppression.test.ts
@@ -1,5 +1,6 @@
 import { readdirSync, readFileSync } from "fs"
 import { join, relative } from "path"
+import ts from "typescript"
 import { describe, expect, it } from "vitest"
 
 /**
@@ -29,85 +30,82 @@ import { describe, expect, it } from "vitest"
 
 const packageRoot = join(__dirname, "../../..")
 
-/**
- * Extract the body of every `a11y: { ... }` object in `content`, by matching
- * braces.
- *
- * Detection is deliberately scoped to these blocks rather than searching for
- * any `rules:` array: `rules` is a generic name that other, unrelated APIs use
- * (`src/lib/text.ts` has its own `Rules` type for text formatting), so an
- * unscoped match would flag non-a11y config and fail a PR with a misleading
- * accessibility error.
- *
- * Brace counting ignores string and comment contents, so a `{` inside a
- * selector or a comment cannot unbalance it.
- */
-export const extractA11yBlocks = (content: string): string[] => {
-  const blocks: string[] = []
-  const opener = /a11y\s*:\s*\{/g
+const nameOf = (n: ts.PropertyName): string | undefined =>
+  ts.isIdentifier(n) || ts.isStringLiteral(n) ? n.text : undefined
 
-  // Only the match position matters — `opener.lastIndex` is where the block
-  // body starts — so the match object itself is not needed.
-  while (opener.exec(content) !== null) {
-    let i = opener.lastIndex
-    let depth = 1
-    let quote: string | null = null
-    let comment: "line" | "block" | null = null
-
-    while (i < content.length && depth > 0) {
-      const ch = content[i]
-      const next = content[i + 1]
-
-      if (comment === "line") {
-        if (ch === "\n") comment = null
-      } else if (comment === "block") {
-        if (ch === "*" && next === "/") (i++, (comment = null))
-      } else if (quote) {
-        if (ch === "\\") i++
-        else if (ch === quote) quote = null
-      } else if (ch === "/" && next === "/") {
-        comment = "line"
-        i++
-      } else if (ch === "/" && next === "*") {
-        comment = "block"
-        i++
-      } else if (ch === '"' || ch === "'" || ch === "`") {
-        quote = ch
-      } else if (ch === "{") {
-        depth++
-      } else if (ch === "}") {
-        depth--
-      }
-      i++
+const propValue = (
+  obj: ts.ObjectLiteralExpression,
+  name: string
+): ts.Expression | undefined => {
+  for (const p of obj.properties) {
+    if (ts.isPropertyAssignment(p) && nameOf(p.name) === name) {
+      return p.initializer
     }
-    blocks.push(content.slice(opener.lastIndex, i - 1))
   }
-  return blocks
+  return undefined
 }
 
 /**
- * Rule ids disabled inside an `a11y` block. Matches both the compact
- * (`rules: [{ id: "x", enabled: false }]`) and expanded object forms.
+ * Rule ids disabled inside an `a11y: { ... }` object.
+ *
+ * Parsed rather than pattern-matched. `rules` is a generic name that unrelated
+ * APIs use (`src/lib/text.ts` has its own `Rules` type for text formatting), so
+ * matching `rules:` textually would flag non-a11y config and fail a PR with a
+ * misleading accessibility error. Walking the AST scopes detection to real
+ * `a11y` properties and gets quoting, comments and nesting right for free.
  *
  * Only `rules` arrays count — `a11y: { disable: true }` is deliberately out of
  * scope: CI never consults it (`test-runner.ts` runs axe regardless), so it
  * suppresses only the addon panel, and every current usage already sits beside
  * a gated `skipCi`.
+ *
+ * Limitation: a rule id or `enabled` value assembled at runtime (a variable, a
+ * spread) is not resolved — the value has to be a literal to be seen.
  */
 export const findDisabledRules = (content: string): string[] => {
+  const source = ts.createSourceFile(
+    "story.tsx",
+    content,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ false,
+    ts.ScriptKind.TSX
+  )
   const hits: string[] = []
-  for (const block of extractA11yBlocks(content)) {
-    const re = /rules\s*:\s*\[([\s\S]*?)\]/g
-    let m: RegExpExecArray | null
-    while ((m = re.exec(block)) !== null) {
-      const body = m[1]
-      if (!/enabled\s*:\s*false/.test(body)) continue
-      const ids = [...body.matchAll(/id\s*:\s*["']([^"']+)["']/g)].map(
-        (x) => x[1]
-      )
-      hits.push(...(ids.length > 0 ? ids : ["<unknown rule>"]))
+
+  /** Collect disabled ids from any `rules` array inside this a11y object. */
+  const collectFromA11y = (a11y: ts.ObjectLiteralExpression): void => {
+    const walk = (node: ts.Node): void => {
+      if (
+        ts.isPropertyAssignment(node) &&
+        nameOf(node.name) === "rules" &&
+        ts.isArrayLiteralExpression(node.initializer)
+      ) {
+        for (const el of node.initializer.elements) {
+          if (!ts.isObjectLiteralExpression(el)) continue
+          if (propValue(el, "enabled")?.kind !== ts.SyntaxKind.FalseKeyword) {
+            continue
+          }
+          const id = propValue(el, "id")
+          hits.push(id && ts.isStringLiteral(id) ? id.text : "<unknown rule>")
+        }
+      }
+      ts.forEachChild(node, walk)
     }
+    walk(a11y)
   }
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isPropertyAssignment(node) &&
+      nameOf(node.name) === "a11y" &&
+      ts.isObjectLiteralExpression(node.initializer)
+    ) {
+      collectFromA11y(node.initializer)
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(source)
+
   return hits
 }
 
@@ -142,48 +140,73 @@ const findSuppressions = (files: string[]): Record<string, string[]> => {
   return results
 }
 
+/**
+ * Fixtures must be valid TypeScript — the detector parses, so a bare
+ * `a11y: { ... }` fragment would be read as a labeled statement rather than an
+ * object property and would (correctly) match nothing.
+ */
+const inMeta = (body: string) => `const meta = { ${body} }`
+
 describe("findDisabledRules — catches a11y suppressions", () => {
   it("the compact single-line form", () => {
     expect(
       findDisabledRules(
-        `parameters: { a11y: { config: { rules: [{ id: "svg-img-alt", enabled: false }] } } }`
+        inMeta(
+          `parameters: { a11y: { config: { rules: [{ id: "svg-img-alt", enabled: false }] } } }`
+        )
       )
     ).toEqual(["svg-img-alt"])
   })
 
   it("the expanded multi-line form", () => {
     expect(
-      findDisabledRules(`
-        parameters: {
-          a11y: {
-            config: {
-              rules: [
-                {
-                  id: "color-contrast",
-                  enabled: false,
-                },
-              ],
+      findDisabledRules(
+        inMeta(`
+          parameters: {
+            a11y: {
+              config: {
+                rules: [
+                  {
+                    id: "color-contrast",
+                    enabled: false,
+                  },
+                ],
+              },
             },
           },
-        }
-      `)
+        `)
+      )
     ).toEqual(["color-contrast"])
   })
 
   it("several disabled rules in one array", () => {
     expect(
       findDisabledRules(
-        `a11y: { config: { rules: [{ id: "a", enabled: false }, { id: "b", enabled: false }] } }`
+        inMeta(
+          `a11y: { config: { rules: [{ id: "a", enabled: false }, { id: "b", enabled: false }] } }`
+        )
       )
     ).toEqual(["a", "b"])
   })
 
-  it("single-quoted ids and loose spacing", () => {
+  it("single-quoted ids", () => {
     expect(
       findDisabledRules(
-        `a11y : { config : { rules : [ { id : 'target-size' , enabled : false } ] } }`
+        inMeta(
+          `a11y: { config: { rules: [{ id: 'target-size', enabled: false }] } }`
+        )
       )
     ).toEqual(["target-size"])
+  })
+
+  it("quoted property names", () => {
+    expect(
+      findDisabledRules(
+        inMeta(
+          `"a11y": { "config": { "rules": [{ "id": "region", "enabled": false }] } }`
+        )
+      )
+    ).toEqual(["region"])
   })
 
   it("more than one a11y block in a file", () => {
@@ -197,18 +220,22 @@ describe("findDisabledRules — catches a11y suppressions", () => {
 
   it("a suppression sitting beside other a11y keys", () => {
     expect(
-      findDisabledRules(`
-        a11y: {
-          test: "todo",
-          config: { rules: [{ id: "region", enabled: false }] },
-        },
-      `)
+      findDisabledRules(
+        inMeta(`
+          a11y: {
+            test: "todo",
+            config: { rules: [{ id: "region", enabled: false }] },
+          },
+        `)
+      )
     ).toEqual(["region"])
   })
 
   it("reports a placeholder when the disabled rule has no id", () => {
     expect(
-      findDisabledRules(`a11y: { config: { rules: [{ enabled: false }] } }`)
+      findDisabledRules(
+        inMeta(`a11y: { config: { rules: [{ enabled: false }] } }`)
+      )
     ).toEqual(["<unknown rule>"])
   })
 })
@@ -217,37 +244,43 @@ describe("findDisabledRules — does not flag legitimate config", () => {
   it("allows enabling a rule", () => {
     expect(
       findDisabledRules(
-        `a11y: { config: { rules: [{ id: "color-contrast", enabled: true }] } }`
+        inMeta(
+          `a11y: { config: { rules: [{ id: "color-contrast", enabled: true }] } }`
+        )
       )
     ).toEqual([])
   })
 
   it("allows reconfiguring an enabled rule with a selector (preview.tsx pattern)", () => {
     expect(
-      findDisabledRules(`
-        a11y: {
-          config: {
-            rules: [
-              {
-                id: "color-contrast",
-                enabled: true,
-                selector: "*:not([data-a11y-color-contrast-ignore])",
-              },
-            ],
+      findDisabledRules(
+        inMeta(`
+          a11y: {
+            config: {
+              rules: [
+                {
+                  id: "color-contrast",
+                  enabled: true,
+                  selector: "*:not([data-a11y-color-contrast-ignore])",
+                },
+              ],
+            },
           },
-        },
-      `)
+        `)
+      )
     ).toEqual([])
   })
 
   it("allows an empty rules array", () => {
-    expect(findDisabledRules(`a11y: { config: { rules: [] } }`)).toEqual([])
+    expect(
+      findDisabledRules(inMeta(`a11y: { config: { rules: [] } }`))
+    ).toEqual([])
   })
 
   it("ignores a11y.disable (out of scope — CI ignores it)", () => {
-    expect(findDisabledRules(`a11y: { skipCi: true, disable: true }`)).toEqual(
-      []
-    )
+    expect(
+      findDisabledRules(inMeta(`a11y: { skipCi: true, disable: true }`))
+    ).toEqual([])
   })
 })
 
@@ -257,7 +290,9 @@ describe("findDisabledRules — does not flag non-a11y config", () => {
     // component could gain a `rules` prop — neither is an axe suppression.
     expect(
       findDisabledRules(
-        `args: { validation: { rules: [{ id: "required", enabled: false }] } }`
+        inMeta(
+          `args: { validation: { rules: [{ id: "required", enabled: false }] } }`
+        )
       )
     ).toEqual([])
   })
@@ -265,42 +300,45 @@ describe("findDisabledRules — does not flag non-a11y config", () => {
   it("ignores a text-formatting rules object", () => {
     expect(
       findDisabledRules(
-        `args: { rules: { disallowEmpty: false, enabled: false } }`
+        inMeta(`args: { rules: { disallowEmpty: false, enabled: false } }`)
       )
     ).toEqual([])
   })
 
   it("ignores unrelated enabled: false config", () => {
     expect(
-      findDisabledRules(`aiPromotion: { enabled: false, greeting: "Hey" }`)
+      findDisabledRules(
+        inMeta(`aiPromotion: { enabled: false, greeting: "Hey" }`)
+      )
     ).toEqual([])
   })
 
   it("does not leak past the end of an a11y block", () => {
-    // The disable sits AFTER the a11y block closes, so it must not be picked up.
     expect(
-      findDisabledRules(`
-        parameters: {
-          a11y: { test: "todo" },
-          chart: { rules: [{ id: "gridlines", enabled: false }] },
-        }
-      `)
+      findDisabledRules(
+        inMeta(`
+          parameters: {
+            a11y: { test: "todo" },
+            chart: { rules: [{ id: "gridlines", enabled: false }] },
+          },
+        `)
+      )
     ).toEqual([])
   })
 
   it("is not confused by braces inside strings or comments", () => {
     expect(
-      findDisabledRules(`
-        a11y: {
-          // a brace in a comment: {
-          config: {
-            rules: [
-              { id: "color-contrast", enabled: true, selector: "div{}" },
-            ],
+      findDisabledRules(
+        inMeta(`
+          a11y: {
+            // a brace in a comment: {
+            config: {
+              rules: [{ id: "color-contrast", enabled: true, selector: "div{}" }],
+            },
           },
-        },
-        other: { rules: [{ id: "nope", enabled: false }] },
-      `)
+          other: { rules: [{ id: "nope", enabled: false }] },
+        `)
+      )
     ).toEqual([])
   })
 })

--- a/packages/react/src/lib/storybook-utils/a11yRuleSuppression.test.ts
+++ b/packages/react/src/lib/storybook-utils/a11yRuleSuppression.test.ts
@@ -3,7 +3,7 @@ import { join, relative } from "path"
 import { describe, expect, it } from "vitest"
 
 /**
- * Gate: no story may switch an axe rule off.
+ * Gate: nothing may switch an axe rule off.
  *
  * `a11y: { config: { rules: [{ id: "...", enabled: false }] } }` was a silent
  * escape hatch. Unlike `skipCi` — which is gated by
@@ -12,8 +12,8 @@ import { describe, expect, it } from "vitest"
  * lands in `a11y-violations.jsonl` (so no PR comment), and shows nothing in the
  * Storybook a11y panel. It was strictly more invisible than skipping.
  *
- * There is deliberately no allowlist here: the population was reduced to zero
- * in the same change that added this test, so the rule is simply "never".
+ * There is deliberately no allowlist: the population was reduced to zero in the
+ * same change that added this test, so the rule is simply "never".
  *
  * Deferring a known violation? Use `a11y: { test: "todo" }` — axe still runs
  * and still reports; it just doesn't block. For genuinely non-applicable
@@ -21,6 +21,10 @@ import { describe, expect, it } from "vitest"
  * `data-a11y-color-contrast-ignore` (see the `color-contrast` selector in
  * `.storybook/preview.tsx`), which narrows the exemption to the one node
  * instead of blinding a whole story.
+ *
+ * Scope covers both per-story parameters **and** `.storybook/` global
+ * parameters — a global disable would silence a rule library-wide, which is
+ * worse than any single story doing it.
  */
 
 const packageRoot = join(__dirname, "../../..")
@@ -28,50 +32,175 @@ const packageRoot = join(__dirname, "../../..")
 /**
  * Find axe rule descriptors that disable a rule. Matches both the compact
  * (`rules: [{ id: "x", enabled: false }]`) and expanded object forms by
- * checking whether an `enabled: false` sits inside a `rules:` array entry that
- * also carries an `id:`. Scoped this way so unrelated `enabled: false` config
- * (e.g. a component's own `aiPromotion` prop) is not flagged.
+ * checking whether an `enabled: false` sits inside a `rules:` array that also
+ * carries an `id:`. Scoped this way so unrelated `enabled: false` config (e.g.
+ * a component's own `aiPromotion` prop, or a React context default) is not
+ * flagged.
+ *
+ * Returns the disabled rule ids, for a useful failure message.
  */
-const findDisabledRules = (content: string): string[] => {
+export const findDisabledRules = (content: string): string[] => {
   const hits: string[] = []
-  const re = /rules:\s*\[([\s\S]*?)\]/g
+  const re = /rules\s*:\s*\[([\s\S]*?)\]/g
   let m: RegExpExecArray | null
   while ((m = re.exec(content)) !== null) {
     const body = m[1]
-    if (!/enabled:\s*false/.test(body)) continue
-    // Collect the rule ids that appear in this array, for a useful message.
-    const ids = [...body.matchAll(/id:\s*["']([^"']+)["']/g)].map((x) => x[1])
+    if (!/enabled\s*:\s*false/.test(body)) continue
+    const ids = [...body.matchAll(/id\s*:\s*["']([^"']+)["']/g)].map(
+      (x) => x[1]
+    )
     hits.push(...(ids.length > 0 ? ids : ["<unknown rule>"]))
   }
   return hits
 }
 
-const findStoryFilesSuppressingRules = (
-  dir: string
-): Record<string, string[]> => {
-  const results: Record<string, string[]> = {}
+/** Recursively collect files under `dir` matching `match`. */
+const collectFiles = (
+  dir: string,
+  match: (name: string) => boolean
+): string[] => {
+  const out: string[] = []
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
-    const fullPath = join(dir, entry.name)
+    const full = join(dir, entry.name)
     if (entry.isDirectory()) {
-      Object.assign(results, findStoryFilesSuppressingRules(fullPath))
-    } else if (entry.name.endsWith(".stories.tsx")) {
-      const disabled = findDisabledRules(readFileSync(fullPath, "utf-8"))
-      if (disabled.length > 0) {
-        results[relative(packageRoot, fullPath)] = disabled
+      if (entry.name === "node_modules" || entry.name === "storybook-static") {
+        continue
       }
+      out.push(...collectFiles(full, match))
+    } else if (match(entry.name)) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+const findSuppressions = (files: string[]): Record<string, string[]> => {
+  const results: Record<string, string[]> = {}
+  for (const file of files) {
+    const disabled = findDisabledRules(readFileSync(file, "utf-8"))
+    if (disabled.length > 0) {
+      results[relative(packageRoot, file)] = disabled
     }
   }
   return results
 }
 
-describe("a11y rule suppression", () => {
-  it("no story disables an axe rule via a11y.config.rules", () => {
-    const offenders = findStoryFilesSuppressingRules(join(packageRoot, "src"))
+describe("findDisabledRules (detector)", () => {
+  it("catches the compact single-line form", () => {
     expect(
-      Object.entries(offenders).map(
+      findDisabledRules(
+        `parameters: { a11y: { config: { rules: [{ id: "svg-img-alt", enabled: false }] } } }`
+      )
+    ).toEqual(["svg-img-alt"])
+  })
+
+  it("catches the expanded multi-line form", () => {
+    expect(
+      findDisabledRules(`
+        a11y: {
+          config: {
+            rules: [
+              {
+                id: "color-contrast",
+                enabled: false,
+              },
+            ],
+          },
+        },
+      `)
+    ).toEqual(["color-contrast"])
+  })
+
+  it("catches several disabled rules in one array", () => {
+    expect(
+      findDisabledRules(
+        `rules: [{ id: "a", enabled: false }, { id: "b", enabled: false }]`
+      )
+    ).toEqual(["a", "b"])
+  })
+
+  it("catches single-quoted ids and tolerant spacing", () => {
+    expect(
+      findDisabledRules(`rules : [ { id : 'target-size' , enabled : false } ]`)
+    ).toEqual(["target-size"])
+  })
+
+  it("catches more than one rules array in a file", () => {
+    expect(
+      findDisabledRules(`
+        const a = { rules: [{ id: "one", enabled: false }] }
+        const b = { rules: [{ id: "two", enabled: false }] }
+      `)
+    ).toEqual(["one", "two"])
+  })
+
+  it("allows enabling a rule", () => {
+    expect(
+      findDisabledRules(`rules: [{ id: "color-contrast", enabled: true }]`)
+    ).toEqual([])
+  })
+
+  it("allows reconfiguring an enabled rule with a selector (preview.tsx pattern)", () => {
+    expect(
+      findDisabledRules(`
+        rules: [
+          {
+            id: "color-contrast",
+            enabled: true,
+            selector: "*:not([data-a11y-color-contrast-ignore])",
+          },
+        ],
+      `)
+    ).toEqual([])
+  })
+
+  it("ignores unrelated enabled: false config", () => {
+    // e.g. ApplicationFrame's aiPromotion prop, or a React context default —
+    // no `rules:` array, so not an axe suppression.
+    expect(
+      findDisabledRules(`
+        aiPromotion: {
+          enabled: false,
+          greeting: "Hey",
+        },
+      `)
+    ).toEqual([])
+  })
+
+  it("ignores a rules array with no disabled entry", () => {
+    expect(findDisabledRules(`rules: [{ id: "region" }]`)).toEqual([])
+  })
+
+  it("reports a placeholder when the disabled rule has no id", () => {
+    expect(findDisabledRules(`rules: [{ enabled: false }]`)).toEqual([
+      "<unknown rule>",
+    ])
+  })
+})
+
+describe("a11y rule suppression", () => {
+  const files = [
+    ...collectFiles(join(packageRoot, "src"), (n) =>
+      n.endsWith(".stories.tsx")
+    ),
+    // Global parameters live here — a disable at this level would silence a
+    // rule for the whole library.
+    ...collectFiles(
+      join(packageRoot, ".storybook"),
+      (n) => n.endsWith(".ts") || n.endsWith(".tsx")
+    ),
+  ]
+
+  it("scans a non-trivial number of files (guards against a broken walker)", () => {
+    expect(files.length).toBeGreaterThan(100)
+  })
+
+  it("nothing disables an axe rule via a11y config rules", () => {
+    expect(
+      Object.entries(findSuppressions(files)).map(
         ([file, rules]) => `${file} → ${rules.join(", ")}`
       ),
-      `These stories switch an axe rule off, which hides the violation from ` +
+      `These files switch an axe rule off, which hides the violation from ` +
         `CI's job summary, from a11y-violations.jsonl (the PR comment) and ` +
         `from the Storybook a11y panel — it leaves no trace at all.\n\n` +
         `Instead:\n` +

--- a/packages/react/src/patterns/ResourceHeader/index.stories.tsx
+++ b/packages/react/src/patterns/ResourceHeader/index.stories.tsx
@@ -340,18 +340,7 @@ export const CompanyHeader: Story = {
       },
     ],
   },
-  parameters: {
-    a11y: {
-      config: {
-        rules: [
-          {
-            id: "color-contrast",
-            enabled: false,
-          },
-        ],
-      },
-    },
-  },
+  parameters: {},
 }
 
 export const PersonHeader: Story = {

--- a/vendor/skills/f0-storybook-testing/SKILL.md
+++ b/vendor/skills/f0-storybook-testing/SKILL.md
@@ -52,17 +52,10 @@ parameters: {
   }
 }
 
-// Custom axe rules for this story
-parameters: {
-  a11y: {
-    config: {
-      rules: [{ id: "color-contrast", enabled: false }]
-    }
-  }
-}
 ```
 
 - The contract: `test: "error"` = enforced (default), `test: "todo"` = known debt to fix, `test: "warning"` = intentional. axe always runs.
+- **Never disable an axe rule** (`a11y: { config: { rules: [{ id, enabled: false }] } }`) — blocked by `a11yRuleSuppression.test.ts`. It leaves no trace at all: no CI failure, no job-summary line, no PR comment, nothing in the addon panel. Use `test: "todo"` to defer, or an element-scoped opt-out like `data-a11y-color-contrast-ignore` when a single node genuinely doesn't apply. Enabling/reconfiguring a rule is fine.
 
 ## Commands
 

--- a/vendor/skills/f0-storybook-testing/references/storybook-test-patterns.md
+++ b/vendor/skills/f0-storybook-testing/references/storybook-test-patterns.md
@@ -138,18 +138,23 @@ parameters: {
     test: "warning"
   }
 }
-
-// Disable a specific rule for this story
-parameters: {
-  a11y: {
-    config: {
-      rules: [{ id: "color-contrast", enabled: false }]
-    }
-  }
-}
 ```
 
 The contract: `test: "error"` = enforced (the default), `test: "todo"` = known debt to fix, `test: "warning"` = intentional/accepted.
+
+### Never disable an axe rule
+
+`a11y: { config: { rules: [{ id: "...", enabled: false }] } }` is **not allowed** and is blocked by `src/lib/storybook-utils/a11yRuleSuppression.test.ts`.
+
+It is worse than skipping. A disabled rule leaves **no trace anywhere**: no CI failure, no job-summary line, no entry in `a11y-violations.jsonl` (so no PR comment), and nothing in the Storybook a11y panel. `skipCi` at least appears in an allowlist you can count.
+
+Use instead:
+
+- **Deferring a known violation** → `a11y: { test: "todo" }`. axe still runs and still reports; it just doesn't block.
+- **Intentional / accepted** → `a11y: { test: "warning" }`.
+- **One element genuinely not applicable** → an element-scoped opt-out, so only that node is exempt rather than the whole story. `data-a11y-color-contrast-ignore` is the existing example — `.storybook/preview.tsx` narrows the `color-contrast` rule with `selector: "*:not([data-a11y-color-contrast-ignore])"`, and `BaseAvatar.tsx` uses it on the avatar surface.
+
+*Enabling* or reconfiguring a rule is fine — the gate only rejects disabling.
 
 ### withSkipA11y() (deprecated) vs withSnapshot()
 


### PR DESCRIPTION
## Description

https://factorialmakers.atlassian.net/browse/FCT-59951

#4772 gated `a11y: { skipCi: true }`, but a second, **ungated** escape hatch remained:

```tsx
parameters: { a11y: { config: { rules: [{ id: "color-contrast", enabled: false }] } } }
```

This is **strictly more invisible than `skipCi`**. A disabled rule:

- doesn't fail CI
- produces **no** job-summary line (`test-runner.ts` only emits those for `todo`/`warning`)
- produces **no** entry in `a11y-violations.jsonl`, so **no PR comment**
- shows **nothing** in the Storybook a11y panel

`skipCi` at least leaves a countable allowlist entry and fails CI when newly added. A disabled rule left no trace at all, and nothing stopped anyone adding one.

It was also **documented as a supported pattern** in this skill (`SKILL.md`, `references/storybook-test-patterns.md`), using `color-contrast` — a WCAG 1.4.3 **AA** rule — as the worked example. Very likely where the existing usages came from.

## The debt was zero

9 story files were suppressing rules, **none with a comment explaining why**. All 9 turned out to be dead weight — every affected story passes with them removed, **no component fixes needed**:

- **`color-contrast` (3)** — `F0AvatarEmoji`, `F0AvatarIcon`, `ResourceHeader`. Redundant: `BaseAvatar.tsx` already carries `data-a11y-color-contrast-ignore`, the element-scoped opt-out honoured by `preview.tsx`'s `color-contrast` selector. The story-level disables predate it.
- **`svg-img-alt` (6)** — `PieChartWidget`, `Widgets/Layout/Dashboard`, `WidgetStrip`, `kits/Charts/PieChart`, `layouts/Layout`, `TwoColumnLayout`. No longer reproduces.
- **`layouts/Layout`** was pure dead code — the file also has `skipCi` and is allowlisted, so axe never ran there anyway.

So the suppressions were only hiding the fact that there was nothing to hide.

## Implementation details

- fix: remove all 9 suppressions
- docs: drop the documented pattern from `SKILL.md` and `references/storybook-test-patterns.md`, replacing it with a **"Never disable an axe rule"** section pointing at `test: "todo"` and the element-scoped alternative
- test: add `src/lib/storybook-utils/a11yRuleSuppression.test.ts` — a static gate asserting no story disables an axe rule

- test: 12 unit tests for the detector itself, plus a widened scan (see below)

**No allowlist.** The population is zero after this PR, so the rule is simply "never" — no grandfathering, no counts to shrink. Much lighter than #4772's ratchet, because rule-disabling is detectable in source: one unit test, no `test-runner.ts` change, no runtime plumbing, no reporting.

*Enabling* or reconfiguring a rule (`enabled: true`, adding a `selector`) stays allowed — the gate only rejects disabling, so `preview.tsx`'s `color-contrast` selector config is unaffected.

## Verification

Ran the real test-runner against a fresh build, per affected story file — all green:

| File | Result |
| --- | --- |
| `F0AvatarEmoji` | 2/2 |
| `F0AvatarIcon` | 2/2 |
| `ResourceHeader` | 15/15 |
| `PieChartWidget` | 1/1 |
| `kits/Charts/PieChart` | 1/1 |
| `Widgets/Layout/Dashboard` | 3/3 |
| `WidgetStrip` | 5/5 |
| `TwoColumnLayout` | 5/5 |
| `layouts/Layout` | 7/7 |

### Testing the gate itself

A gate whose only assertion is "scan the repo, expect empty" is a false-negative risk: if the detection regex breaks, it keeps passing and silently stops gating. So the detector is unit-tested directly — **12 tests**:

Positive cases: compact single-line form, expanded multi-line form, several disabled rules in one array, single-quoted ids with tolerant spacing (`rules : [ { id : 'x' , enabled : false } ]`), and more than one `rules` array per file.

Negative cases that matter: `enabled: true` is allowed, reconfiguring an enabled rule **with a selector** is allowed (that's `preview.tsx`'s own pattern, so a regression here would break the global contrast config), and unrelated `enabled: false` config is not flagged — e.g. `ApplicationFrame`'s `aiPromotion` prop or a React context default.

Plus a guard asserting the walker sees >100 files, so a broken walker fails loudly instead of passing vacuously.

### Widened scope

The first version only scanned `*.stories.tsx`, which left a bigger hole than the one it closed: a disable in **`.storybook/preview.tsx` global parameters** silences a rule *library-wide* and would have been invisible. The scan now covers `.storybook/*.ts(x)` as well.

Verified by injection, both levels:

- a suppression added to `kits/Charts/PieChart` → fails, reporting `src/kits/Charts/PieChart/index.stories.tsx → svg-img-alt`
- a **global** disable added to `preview.tsx` → fails, reporting `.storybook/preview.tsx → color-contrast`

Both pass again once reverted.

Also: `src/lib/storybook-utils/` suite **15/15** (both a11y gates), `tsc --noEmit` clean, oxlint 0 warnings, oxfmt clean.

## Not in scope

`a11y: { disable: true }` also exists (2 usages in `Navigation/Dropdown`). It is **not** a CI loophole — `test-runner.ts` never consults it, so axe still runs in CI — and both usages already sit alongside a gated `skipCi`. It only suppresses the addon panel. Left alone deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
