### PR TITLE
feat(SurveyFormBuilder): add a 0-10 rating scale (FCT-59663)

### DIFF
--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Form/__tests__/useQuestionActions.test.ts
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Form/__tests__/useQuestionActions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest"
 
+import { getDefaultParamsForQuestionType, getRatingOptions } from "../../lib"
 import {
   getCurrentRatingType,
   RATING_OPTIONS,
@@ -60,6 +61,16 @@ describe("getCurrentRatingType", () => {
     }))
     expect(getCurrentRatingType("rating", { type: "rating", options })).toBe(
       "1-10"
+    )
+  })
+
+  it('detects "0-10" rating type', () => {
+    const options = Array.from({ length: 11 }, (_, i) => ({
+      value: i,
+      label: String(i),
+    }))
+    expect(getCurrentRatingType("rating", { type: "rating", options })).toBe(
+      "0-10"
     )
   })
 
@@ -173,18 +184,78 @@ describe("shouldResetParamsOnTypeChange", () => {
 })
 
 describe("RATING_OPTIONS", () => {
-  it("contains three rating presets", () => {
-    expect(RATING_OPTIONS).toHaveLength(3)
+  it("contains four rating presets", () => {
+    expect(RATING_OPTIONS).toHaveLength(4)
   })
 
-  it('includes "1-5", "1-10", and "emojis"', () => {
+  it('includes "1-5", "1-10", "0-10", and "emojis"', () => {
     const values = RATING_OPTIONS.map((o) => o.value)
-    expect(values).toEqual(["1-5", "1-10", "emojis"])
+    expect(values).toEqual(["1-5", "1-10", "0-10", "emojis"])
   })
 
   it("has labels for each option", () => {
     for (const option of RATING_OPTIONS) {
       expect(option.label).toBeTruthy()
     }
+  })
+
+  it("can build options for every preset it offers", () => {
+    for (const option of RATING_OPTIONS) {
+      expect(getRatingOptions(option.value).length).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe("getRatingOptions", () => {
+  it('builds 1..5 for "1-5"', () => {
+    expect(getRatingOptions("1-5").map((o) => o.value)).toEqual([1, 2, 3, 4, 5])
+  })
+
+  it('builds 1..10 for "1-10"', () => {
+    expect(getRatingOptions("1-10").map((o) => o.value)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+    ])
+  })
+
+  it('builds 0..10 for "0-10", the eNPS scale', () => {
+    const options = getRatingOptions("0-10")
+
+    expect(options).toHaveLength(11)
+    expect(options.map((o) => o.value)).toEqual([
+      0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+    ])
+    expect(options.map((o) => o.label)).toEqual([
+      "0",
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+      "10",
+    ])
+  })
+
+  it("round-trips every numeric preset through getCurrentRatingType", () => {
+    for (const preset of ["1-5", "1-10", "0-10"] as const) {
+      expect(
+        getCurrentRatingType("rating", {
+          type: "rating",
+          options: getRatingOptions(preset),
+        })
+      ).toBe(preset)
+    }
+  })
+})
+
+describe("getDefaultParamsForQuestionType", () => {
+  // A literal 0 would render the "0" cell of a 0-10 scale as already chosen.
+  it("leaves a new rating question unanswered", () => {
+    const params = getDefaultParamsForQuestionType("rating")
+
+    expect(params).toHaveProperty("value", undefined)
   })
 })

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Form/index.stories.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Form/index.stories.tsx
@@ -370,6 +370,76 @@ export const WithAllowCreate: Story = {
 }
 
 /**
+ * Every rating scale the question-type menu offers, side by side. Open a
+ * question's actions menu → Rating to switch between them; the submenu shows a
+ * checkmark next to the scale currently in use, which is re-derived from the
+ * stored options rather than persisted separately.
+ *
+ * 0-10 is the standard eNPS scale. It is the only preset containing a `0`,
+ * which is why an unanswered rating question carries no value at all instead of
+ * defaulting to 0 — otherwise its first cell would look pre-selected.
+ */
+export const WithRatingScales: Story = {
+  args: {
+    elements: [
+      {
+        type: "question",
+        question: {
+          id: "q-rating-1-5",
+          title: "How would you rate your onboarding? (1 - 5)",
+          type: "rating" as const,
+          options: Array.from({ length: 5 }, (_, index) => ({
+            value: index + 1,
+            label: String(index + 1),
+          })),
+        },
+      },
+      {
+        type: "question",
+        question: {
+          id: "q-rating-1-10",
+          title: "How clear are your goals for this quarter? (1 - 10)",
+          type: "rating" as const,
+          options: Array.from({ length: 10 }, (_, index) => ({
+            value: index + 1,
+            label: String(index + 1),
+          })),
+        },
+      },
+      {
+        type: "question",
+        question: {
+          id: "q-rating-0-10",
+          title:
+            "How likely are you to recommend us as a place to work? (0 - 10)",
+          description: "0 is not at all likely, 10 is extremely likely.",
+          type: "rating" as const,
+          options: Array.from({ length: 11 }, (_, value) => ({
+            value,
+            label: String(value),
+          })),
+        },
+      },
+      {
+        type: "question",
+        question: {
+          id: "q-rating-emojis",
+          title: "How was your week? (Emojis)",
+          type: "rating" as const,
+          options: [
+            { value: 1, label: "😠" },
+            { value: 2, label: "😐" },
+            { value: 3, label: "😊" },
+            { value: 4, label: "😍" },
+            { value: 5, label: "🤩" },
+          ],
+        },
+      },
+    ],
+  },
+}
+
+/**
  * A blocked, predefined section: `locked` on the section disables its fields,
  * removes its edit menu and drag handle, and makes the questions inside it
  * non-interactive. The section's `lockedNote` surfaces as the "Locked" tag

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/ActionsMenu/useQuestionActions.ts
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/ActionsMenu/useQuestionActions.ts
@@ -13,6 +13,7 @@ import { SurveyFormBuilderCallbacks, QuestionType } from "../../../types"
 export const RATING_OPTIONS: { label: string; value: RatingOptionType }[] = [
   { label: "1 - 5", value: "1-5" },
   { label: "1 - 10", value: "1-10" },
+  { label: "0 - 10", value: "0-10" },
   { label: "Emojis", value: "emojis" },
 ]
 
@@ -175,7 +176,9 @@ export function useQuestionActionsFactory() {
         onQuestionChange?.({
           id: questionId,
           type: "rating",
-          value: 0,
+          // Clear the selection rather than resetting it to 0, which is a real
+          // option on the 0-10 scale.
+          value: undefined,
           options: getRatingOptions(ratingType),
         } as Parameters<
           NonNullable<SurveyFormBuilderCallbacks["onQuestionChange"]>

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/BaseScoreQuestion/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/BaseScoreQuestion/index.tsx
@@ -49,7 +49,9 @@ export const BaseScoreQuestion = ({
     onQuestionChange?.({
       id: baseQuestionComponentProps.id,
       type: "rating",
-      value: value ?? 0,
+      // Passed through untouched: coercing to 0 would mark the "0" cell of a
+      // 0-10 scale as selected just because a label was edited.
+      value,
       options: updatedOptions,
     } as Parameters<NonNullable<typeof onQuestionChange>>[0])
   }

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/lib.ts
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/lib.ts
@@ -1,6 +1,6 @@
 import { QuestionType } from "./types"
 
-export type RatingOptionType = "1-5" | "1-10" | "emojis"
+export type RatingOptionType = "1-5" | "1-10" | "0-10" | "emojis"
 
 export const getRatingOptions = (type: RatingOptionType) => {
   switch (type) {
@@ -13,6 +13,12 @@ export const getRatingOptions = (type: RatingOptionType) => {
       return new Array(10).fill(0).map((_, index) => ({
         value: index + 1,
         label: (index + 1).toString(),
+      }))
+    // Starts at 0, which makes it the standard eNPS scale.
+    case "0-10":
+      return new Array(11).fill(0).map((_, index) => ({
+        value: index,
+        label: index.toString(),
       }))
     case "emojis":
       return [
@@ -45,6 +51,11 @@ export const detectRatingOptionType = (
     return "1-10"
   }
 
+  // If length is 11 and all labels are numeric → "0-10"
+  if (length === 11 && allNumeric) {
+    return "0-10"
+  }
+
   // If length is 5 and not all numeric (has emojis) → "emojis"
   if (length === 5 && !allNumeric) {
     return "emojis"
@@ -57,7 +68,9 @@ export const getDefaultParamsForQuestionType = (questionType: QuestionType) => {
   switch (questionType) {
     case "rating":
       return {
-        value: 0,
+        // Undefined rather than 0: on a 0-10 scale a literal 0 would render
+        // the "0" cell as already chosen on an unanswered question.
+        value: undefined,
         options: getRatingOptions("1-5"),
       }
     case "select":

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/types.ts
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/types.ts
@@ -144,7 +144,9 @@ type OnChangeQuestionParams = BaseQuestionOnChangeParams &
       }
     | {
         type: "rating"
-        value: number
+        // Optional so an unanswered question can be reported as having no
+        // selection. 0 cannot stand in for that on the 0-10 scale.
+        value?: number
         options?: { value: number; label: string }[]
       }
     | {


### PR DESCRIPTION
## Description

Adds **0 - 10** to the `SurveyFormBuilder` rating scale picker, alongside the existing 1 - 5, 1 - 10 and Emojis.

0-10 is the standard eNPS scale. A customer ([FCT-59663](https://factorialmakers.atlassian.net/browse/FCT-59663)) lost theirs during a backend survey migration and, when they tried to rebuild it, found the picker only offered 1-5 and 1-10 — so they settled for 1-10, which makes their eNPS scores wrong and non-comparable with history. The backend half of the fix repairs the migrated data; this half lets authors build 0-10 questions going forward.

The render paths already handled 0-10 fine — `RatingQuestionField` and `BaseScoreQuestion` map over whatever options they are given. Only the picker refused to produce it.

## Type of change

- [x] Component enhancement / variant (existing component, no breaking change)
- [x] Bug fix

<sub>The enhancement is the new scale. The bug fix is the pre-selected `0` cell described below — reachable only once a scale containing `0` exists.</sub>

## Screenshots

See the new `SurveyFormBuilder` → **With Rating Scales** story, or run it locally.

<img width="1200" height="1100" alt="image" src="https://github.com/user-attachments/assets/4b96a0ab-1dc9-4216-b6a2-23411b83fe85" />

Verified in Storybook on that story:

- the 0-10 question renders **11 cells starting at `0`**
- **no cell is pre-selected on load** — including the `0` cell, which is the bug fixed here
- the Rating row of the question actions menu reads **`0 - 10`**, i.e. `detectRatingOptionType` recognises the new scale
- the 1-5, 1-10 and emoji scales are unchanged

## Implementation details

**The scale itself**

- `RatingOptionType` gains `"0-10"`.
- `getRatingOptions` gains a `"0-10"` case building 11 options whose values start at **0** (`value: index`, not `index + 1`).
- `detectRatingOptionType` gains an 11-numeric-options case. Without it the picker's submenu trigger shows no current-scale label and the checkmark never renders, because the scale identity is not persisted — it is re-derived from the stored options on every render.
- `RATING_OPTIONS` gains `{ label: "0 - 10", value: "0-10" }`, placed before `Emojis` so the existing order is undisturbed.

**The `value: 0` bug this exposed**

0-10 is the first preset containing a real `0` option. Rating questions defaulted to `value: 0`, and `BaseScoreQuestion` marks a cell selected with `value === option.value` — so an **unanswered** 0-10 question rendered its `0` cell as already chosen. There is no way to distinguish "unanswered" from "answered 0" while `0` is the sentinel, so unanswered now means no value at all:

- `getDefaultParamsForQuestionType("rating")` → `value: undefined`
- `handleSelectRatingType` → `value: undefined` (switching scale clears the selection rather than resetting it to a real option)
- `handleChangeLabel` passes the existing `value` through instead of coercing it to `0`
- the `onQuestionChange` rating payload widens `value: number` → `value?: number` to express that

The authoring `value` is local preview state — Factorial's element mutation sends `options`, never a `value` — so nothing persisted changes. The **answering** path was never affected: `buildNumberSchema` tests `v === undefined || v === null` rather than falsiness, and `RatingQuestionField` uses strict `===`, so a respondent answering `0` always worked.

**Tests**

- Full unit suite: **4913 passed**, 0 failures. `tsc`, oxlint and oxfmt clean.
- `useQuestionActions.test.ts` covers: `RATING_OPTIONS` contains `0-10`; detection of an 11-option numeric set; `getRatingOptions("0-10")` producing values and labels `0..10`; a round-trip of every numeric preset through `getCurrentRatingType`; every preset in `RATING_OPTIONS` being buildable; and a new rating question being unanswered by default.
- New `WithRatingScales` story renders all four scales side by side, which also gives Chromatic coverage.

## Notes for review

- `RATING_OPTIONS` is a module-level const shared by **every** `SurveyFormBuilder` consumer — Engagement Surveys, Trainings and Procurement all render the same picker — so 0-10 is now offered everywhere. Deliberate, and consistent with how 1-5 / 1-10 / emojis already work; the alternative was a `ratingScales` prop, which adds public API and a context change for one caller's benefit.
- Adding a member to the exported `RatingOptionType` union is technically breaking for a consumer doing an exhaustive `switch` on it. The only such switch in this repo is `getRatingOptions`, which is extended.
- **`value: number` → `value?: number` is an interface change — checked against the Factorial monorepo, nothing breaks.** It widens what the library *hands to* an `onQuestionChange` callback, so a consumer using `params.value` in a number-only position would get a compile error (loudly, via `tsc` — not a silent runtime break). Verified in `factorialco/factorial`:
  - `onQuestionChange` has **zero** consumers across `frontend/src` and `mobile/src`. Factorial's editor passes only `onChange` (`newFormEditor/form.tsx:294`), which hands over the whole element array.
  - `QuestionElement` — the type Factorial *does* use (`newFormEditor/helpers.ts:1`) — is untouched: `RatingQuestionProps.value` was already `value?: number` on `main`.
  - Factorial's GraphQL → f0 rating mapping (`helpers.ts:204-213`) never sets `value`, so its rating questions already arrived with `value: undefined`. The old `value: 0` only ever appeared for a question added or rescaled inside the builder.
  - The return path `QuestionElementToQuestionnaireElement` (`helpers.ts:407-431`) emits no `value` key at all — every `.value` in that file is an *option* value — so nothing reaches the mutation. Factorial's dirty-tracking `isEqual` diff (`form.tsx:266`) runs on that same stripped shape, so change detection is unaffected too.
  - `getDefaultParamsForQuestionType` is not imported anywhere in the monorepo, and the other `SurveyFormBuilder` consumers (Trainings, Procurement, inbox tasks) don't reference rating questions at all.
- Scale labels are hardcoded English — there are no `surveyFormBuilder.*` i18n keys for them. `"0 - 10"` is numeric so it needs no translation; i18n-ing the whole list (`"Emojis"` included) is a separate task.
- **Left alone deliberately:** `detectRatingOptionType` classifies any 5 non-numeric labels as `"emojis"`, so Factorial's descriptive 1-5 defaults ("Very low"…"Very high") render through the emoji-picker branch of `ScoreEditOption`. Pre-existing, unrelated to this change, and fixing it means making detection value-based instead of length-based — worth doing, but not here.
- **Shipping dependency:** Factorial pins `"@factorialco/f0-react": "4.39.1"` while `main` is at `4.56.5`. This option is invisible to the customer until that pin moves, which is its own piece of work.

## Context

- [💼 Jira FCT-59663](https://factorialmakers.atlassian.net/browse/FCT-59663)
- [💻 Backend PR](https://github.com/factorialco/factorial/pull/107732) — repairs the already-migrated 0-10 questions


[FCT-59663]: https://factorialmakers.atlassian.net/browse/FCT-59663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
