### PR TITLE
fix(F0DataChart): round negative bars away from the zero line

### DIFF
--- a/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
@@ -105,6 +105,38 @@ export const MultipleSeries: Story = {
 }
 
 /**
+ * Values can be negative. Each bar is rounded on the end pointing away from
+ * the zero line, so negative bars are rounded at the bottom (on the left for
+ * horizontal orientation) and flat where they meet the axis.
+ */
+export const NegativeValues: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "bar",
+    categories: ["Barcelona", "Paris", "Berlin", "London", "Remote"],
+    series: [{ name: "Gender pay gap", data: [24.3, 8.1, -0.4, -27.5, -35.2] }],
+    showLegend: false,
+    valueFormatter: (v) => `${v}%`,
+  },
+}
+
+/** Negative values stacked below the zero line, positive ones above it. */
+export const StackedNegativeValues: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "bar",
+    stacked: true,
+    categories: ["Q1", "Q2", "Q3", "Q4"],
+    series: [
+      { name: "Hires", data: [24, 18, 12, 20] },
+      { name: "Internal moves", data: [6, 4, 9, 5] },
+      { name: "Voluntary exits", data: [-8, -12, -6, -10] },
+      { name: "Involuntary exits", data: [-3, -2, -14, -4] },
+    ],
+  },
+}
+
+/**
  * Each bar has a `target` value — the gap between the actual value and the
  * target is rendered as a faded "ghost" bar above the solid one.
  */

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -39,6 +39,9 @@ vi.mock("../utils/useContainerSize", () => ({
   useContainerSize: () => containerSize,
 }))
 
+type BarDataItem = number | { value: number; itemStyle?: BarItemStyle }
+type BarItemStyle = { color?: string; borderRadius?: number | number[] }
+
 function getLatestOption() {
   const call = setOptionMock.mock.calls.at(-1)
   if (!call) throw new Error("setOption was never called")
@@ -46,7 +49,15 @@ function getLatestOption() {
     legend?: { show?: boolean }
     xAxis: { axisLabel: { show: boolean } }
     yAxis: { axisLabel: { show: boolean } }
+    series: { data: BarDataItem[]; itemStyle: BarItemStyle }[]
   }
+}
+
+/** Corner radii of every bar in a series, `undefined` for plain-number data */
+function getBorderRadii(seriesIndex: number) {
+  return getLatestOption().series[seriesIndex].data.map((item) =>
+    typeof item === "number" ? undefined : item.itemStyle?.borderRadius
+  )
 }
 
 beforeEach(() => {
@@ -103,5 +114,104 @@ describe("BarChart — responsive breakpoints", () => {
     // Horizontal bars: X = value axis (shown at md), Y = category axis (hidden at md)
     expect(option.xAxis.axisLabel.show).toBe(true)
     expect(option.yAxis.axisLabel.show).toBe(false)
+  })
+})
+
+describe("BarChart — corner rounding", () => {
+  const categories = ["Jan", "Feb", "Mar"]
+
+  it("keeps the radius on the series when every value is positive", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        categories={categories}
+        series={[{ name: "A", data: [1, 2, 3] }]}
+      />
+    )
+
+    const option = getLatestOption()
+    expect(option.series[0].data).toEqual([1, 2, 3])
+    expect(option.series[0].itemStyle.borderRadius).toEqual([4, 4, 0, 0])
+  })
+
+  it("rounds negative vertical bars at the bottom, away from the zero line", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        categories={categories}
+        series={[{ name: "A", data: [5, -5, 0] }]}
+      />
+    )
+
+    expect(getBorderRadii(0)).toEqual([
+      [4, 4, 0, 0],
+      [0, 0, 4, 4],
+      [4, 4, 0, 0],
+    ])
+  })
+
+  it("rounds negative horizontal bars on the left, away from the zero line", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        orientation="horizontal"
+        categories={categories}
+        series={[{ name: "A", data: [5, -5, 0] }]}
+      />
+    )
+
+    expect(getBorderRadii(0)).toEqual([
+      [0, 4, 4, 0],
+      [4, 0, 0, 4],
+      [0, 4, 4, 0],
+    ])
+  })
+
+  it("keeps per-bar color overrides alongside the negative radius", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        categories={["Jan", "Feb"]}
+        series={[
+          {
+            name: "A",
+            data: [
+              { value: 5, color: "malibu" },
+              { value: -5, color: "red" },
+            ],
+          },
+        ]}
+      />
+    )
+
+    const [positive, negative] = getLatestOption().series[0].data
+    if (typeof positive === "number" || typeof negative === "number") {
+      throw new Error("expected data items with itemStyle")
+    }
+    expect(positive.itemStyle?.color).toBeDefined()
+    expect(negative.itemStyle?.color).toBeDefined()
+    expect(negative.itemStyle?.borderRadius).toEqual([0, 0, 4, 4])
+  })
+
+  it("rounds only the outer segment of each sign when stacked", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        stacked
+        categories={["Jan"]}
+        series={[
+          { name: "A", data: [10] },
+          { name: "B", data: [5] },
+          { name: "C", data: [-3] },
+          { name: "D", data: [-7] },
+        ]}
+      />
+    )
+
+    // A and C are sandwiched by B (positive) and D (negative) respectively
+    expect(getBorderRadii(0)).toEqual([0])
+    expect(getBorderRadii(1)).toEqual([[4, 4, 0, 0]])
+    expect(getBorderRadii(2)).toEqual([0])
+    expect(getBorderRadii(3)).toEqual([[0, 0, 4, 4]])
   })
 })

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -45,6 +45,80 @@ function hasTargets(series: F0DataChartBarSeries): boolean {
   )
 }
 
+const BAR_CORNER_RADIUS = 4
+
+/**
+ * Corner radii (`[top-left, top-right, bottom-right, bottom-left]`) rounding
+ * only the end of the bar that points away from the zero line. Negative bars
+ * grow in the opposite direction, so they need the opposite corners.
+ */
+function barCornerRadius(isVertical: boolean, isNegative: boolean): number[] {
+  if (isVertical) {
+    return isNegative
+      ? [0, 0, BAR_CORNER_RADIUS, BAR_CORNER_RADIUS]
+      : [BAR_CORNER_RADIUS, BAR_CORNER_RADIUS, 0, 0]
+  }
+  return isNegative
+    ? [BAR_CORNER_RADIUS, 0, 0, BAR_CORNER_RADIUS]
+    : [0, BAR_CORNER_RADIUS, BAR_CORNER_RADIUS, 0]
+}
+
+/** Resolves the corner radii of a single bar segment */
+type BorderRadiusResolver = (
+  seriesIndex: number,
+  dataIndex: number,
+  value: number
+) => number[] | number
+
+/**
+ * Builds a per-bar corner radius resolver, needed only when some value is
+ * negative: the series-level radius can't express two directions at once.
+ *
+ * ECharts stacks positive and negative values away from the zero line in
+ * opposite directions, so a stacked category has up to two outer segments —
+ * the last series contributing a positive value and the last one contributing
+ * a negative value — and only those two get rounded.
+ */
+function buildBorderRadiusResolver(
+  series: F0DataChartBarSeries[],
+  isVertical: boolean,
+  stacked: boolean
+): BorderRadiusResolver | undefined {
+  const hasNegativeValues = series.some((s) =>
+    s.data.some((point) => getValue(point) < 0)
+  )
+  if (!hasNegativeValues) {
+    return undefined
+  }
+
+  if (!stacked) {
+    return (_seriesIndex, _dataIndex, value) =>
+      barCornerRadius(isVertical, value < 0)
+  }
+
+  const outerPositive = new Map<number, number>()
+  const outerNegative = new Map<number, number>()
+  series.forEach((s, seriesIndex) => {
+    s.data.forEach((point, dataIndex) => {
+      const value = getValue(point)
+      if (value > 0) {
+        outerPositive.set(dataIndex, seriesIndex)
+      } else if (value < 0) {
+        outerNegative.set(dataIndex, seriesIndex)
+      }
+    })
+  })
+
+  return (seriesIndex, dataIndex, value) => {
+    if (value === 0) return 0
+    const isNegative = value < 0
+    const outer = isNegative ? outerNegative : outerPositive
+    return outer.get(dataIndex) === seriesIndex
+      ? barCornerRadius(isVertical, isNegative)
+      : 0
+  }
+}
+
 /**
  * Build ECharts series entries for a single F0DataChartBarSeries.
  *
@@ -59,7 +133,8 @@ function buildSeriesEntries(
   showLabels: boolean,
   stacked: boolean,
   isLastSeries: boolean,
-  labelColor: string
+  labelColor: string,
+  resolveBorderRadius: BorderRadiusResolver | undefined
 ): echarts.BarSeriesOption[] {
   const color = resolveColor(series, index)
   const hasTargetData = hasTargets(series)
@@ -73,29 +148,32 @@ function buildSeriesEntries(
       ? `stack-${index}`
       : undefined
 
-  // Build per-item data: use plain numbers when no per-bar color overrides
-  // exist, otherwise produce ECharts data items with per-item itemStyle
-  const hasPerBarColors = series.data.some(
-    (d) => getPointColor(d) !== undefined
-  )
+  // Build per-item data: use plain numbers unless the point needs its own
+  // itemStyle (per-bar color override or a direction-specific corner radius)
+  const mainData = series.data.map((point, dataIndex) => {
+    const value = getValue(point)
+    const pointColor = getPointColor(point)
+    const pointBorderRadius = resolveBorderRadius?.(index, dataIndex, value)
+    if (pointColor === undefined && pointBorderRadius === undefined) {
+      return value
+    }
+    return {
+      value,
+      itemStyle: {
+        ...(pointColor !== undefined && { color: pointColor }),
+        ...(pointBorderRadius !== undefined && {
+          borderRadius: pointBorderRadius,
+        }),
+      },
+    }
+  })
 
-  const mainData = hasPerBarColors
-    ? series.data.map((point) => {
-        const pointColor = getPointColor(point)
-        if (pointColor === undefined) {
-          return getValue(point)
-        }
-        return {
-          value: getValue(point),
-          itemStyle: { color: pointColor },
-        }
-      })
-    : series.data.map(getValue)
-
-  // Round only the far end (away from the axis):
+  // Round only the far end (away from the zero line):
   // - Vertical: top corners rounded, bottom flat against x-axis
   // - Horizontal: right corners rounded, left flat against y-axis
-  const borderRadius = isVertical ? [4, 4, 0, 0] : [0, 4, 4, 0]
+  // Negative bars grow the other way, so `resolveBorderRadius` overrides this
+  // per data point.
+  const borderRadius = barCornerRadius(isVertical, false)
   // Stacked series that aren't the last one get no rounding (sandwiched)
   const effectiveBorderRadius = stacked && !isLastSeries ? 0 : borderRadius
 
@@ -247,6 +325,12 @@ export function useBarChartOptions(
     const effectiveShowLegend = responsive.showLegend && showLegend
     const { showCategoryAxis, showValueAxis } = responsive
 
+    const resolveBorderRadius = buildBorderRadiusResolver(
+      series,
+      isVertical,
+      stacked
+    )
+
     // Build all ECharts series (including target ghost bars)
     const echartsSeries = series.flatMap((s, i) =>
       buildSeriesEntries(
@@ -256,7 +340,8 @@ export function useBarChartOptions(
         showLabels,
         stacked,
         i === series.length - 1,
-        theme.colors.foregroundSecondary
+        theme.colors.foregroundSecondary,
+        resolveBorderRadius
       )
     )
 


### PR DESCRIPTION
## Description

Negative bars in `F0DataChart`'s bar chart were rounded on the wrong end: the rounded corners sat on the zero line and the tip of the bar was square. Spotted on an `F0AnalyticsDashboard` chart with negative values.

## Screenshots (if applicable)

Both frames below are the same story with the same data — only `useBarChartOptions.ts` differs (the "before" frame is that file reverted to `main`). Images are the ECharts canvas exported at 2x device resolution; the inset is a 3x pixel crop of the London bar.

**Single series** — before: rounded at the zero line, square at the tip. After: flat at the zero line, rounded at the tip. Positive bars are pixel-identical in both.

<img width="1256" height="1268" alt="Single series bar chart, before and after" src="https://github.com/user-attachments/assets/1b5fafda-4ebe-4346-b673-23cc6835d318" />

**Stacked** — before: the bottom of each stack is square and the radius is stranded mid-stack at the zero line (clearest on Q2/Q4). After: the bottom-most negative segment is rounded and the inner joints are square, mirroring the top.

<img width="964" height="1268" alt="Stacked bar chart with negative values, before and after" src="https://github.com/user-attachments/assets/276ec97a-d645-4f94-a147-d677af3c26ba" />

Reproducible from the two new stories: `F0DataChart/Bar → NegativeValues` and `StackedNegativeValues`. Horizontal orientation verified the same way (negatives round on the left); `WithTargets` and `PerBarColors` render unchanged.

## Implementation details

`useBarChartOptions` hardcoded the radius per orientation (`[4,4,0,0]` vertical, `[0,4,4,0]` horizontal) with the intent of "round the far end, keep the axis end flat". Corner order is screen-space, so for a bar growing downward (or leftward) from zero those corners are precisely the end touching the axis.

- `barCornerRadius(isVertical, isNegative)` now returns the corners pointing away from the zero line: negatives get `[0,0,4,4]` vertical and `[4,0,0,4]` horizontal.
- A single series can hold both signs, so the radius moves from the series to per-data-point `itemStyle`. The resolver is only built when the chart actually contains a negative value — all-positive charts keep the exact series-level option they had before, so no existing chart changes.
- Stacked charts: ECharts stacks positives and negatives in opposite directions, so a category has up to two outer segments — the last series contributing a positive value and the last one contributing a negative value. Only those get rounded; sandwiched segments stay square (previously "last series always rounds", which put a radius mid-stack once negatives were involved).
- Per-bar `color` overrides still merge with the resolved radius.

### Tests

4 new cases in `BarChart.test.tsx` covering vertical, horizontal, per-bar colors, and stacked mixed signs, plus a regression guard asserting all-positive charts keep plain-number data and the series-level radius. Full `F0DataChart` suite: 100 passed.

### Known gap

The legacy recharts `kits/Charts/BarChart` has the same class of bug in `type="stacked-by-sign"` mode (`radius={[4, 4, 0, 0]}` for every bar). Fixing it needs a custom bar shape rather than a radius tuple, so it is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
