### PR TITLE
feat(F0Chat): show reader and reaction users

### DIFF
--- a/packages/react/src/components/F0VideoPlayer/__stories__/F0VideoPlayer.mdx
+++ b/packages/react/src/components/F0VideoPlayer/__stories__/F0VideoPlayer.mdx
@@ -20,6 +20,9 @@ controls auto-hide and reveal again on hover or keyboard focus — set
 <Canvas of={Stories.Default} />
 <Controls of={Stories.Playground} />
 
+When several players share a surface, pass a contextual `ariaLabel` such as
+`"Video player: quarterly walkthrough"` so each player region is distinct.
+
 ## Keyboard shortcuts
 
 While the player (or a non-input descendant) holds focus:

--- a/packages/react/src/components/F0VideoPlayer/__stories__/F0VideoPlayer.mdx
+++ b/packages/react/src/components/F0VideoPlayer/__stories__/F0VideoPlayer.mdx
@@ -20,6 +20,9 @@ controls auto-hide and reveal again on hover or keyboard focus — set
 <Canvas of={Stories.Default} />
 <Controls of={Stories.Playground} />
 
+When several players share a surface, pass a contextual `ariaLabel` such as
+`"Video player: quarterly walkthrough"` so each player region is distinct.
+
 ## Keyboard shortcuts
 
 While the player (or a non-input descendant) holds focus:
@@ -46,6 +49,11 @@ player. The parent receives playback information through the callbacks:
   10s" and "97%". Short videos complete at 97%; long videos in their final 10s.
 - **`restrictForwardSeek`** — prevents seeking past the furthest-watched point and
   renders a marker at that position.
+- **`download`** — adds an explicit download action to the player controls.
+  Native media downloads stay disabled; use this when the embedding surface
+  lets viewers save the source.
+
+<Canvas of={Stories.Downloadable} />
 
 ## Captions
 
@@ -181,6 +189,7 @@ Actions panel below.
 
 - Advanced browser behaviours are always disabled: the native context menu (and
   its "Save video as…" download), Picture-in-Picture, remote playback and drag.
-  This is intentional for embedded product video; there is no opt-in for v1.
+  Embedding surfaces can opt into a controlled download button through
+  `download`; the remaining browser behaviours stay unavailable.
 - The playback-speed menu portals into the player wrapper (not `document.body`)
   so it stays visible and interactive in fullscreen.

--- a/packages/react/src/components/F0VideoPlayer/__stories__/F0VideoPlayer.stories.tsx
+++ b/packages/react/src/components/F0VideoPlayer/__stories__/F0VideoPlayer.stories.tsx
@@ -1,5 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { ReactNode, useEffect, useRef } from "react"
+import { fn } from "storybook/test"
+
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import { F0VideoPlayer } from "../F0VideoPlayer"
 import { bigBuckBunnyCaptions } from "./bigBuckBunnyCaptions"
@@ -76,6 +79,50 @@ export const Playground: Story = {
   },
   // No captions — flagged by the video-captions a11y rule.
   parameters: { a11y: { test: "todo" } },
+}
+
+export const Downloadable: Story = {
+  tags: ["no-sidebar"],
+  args: {
+    content: { captions: bigBuckBunnyCaptions },
+    download: {
+      label: "Download sample video",
+      onClick: fn(),
+    },
+  },
+}
+
+export const Snapshot: Story = {
+  tags: ["no-sidebar"],
+  parameters: withSnapshot({}),
+  render: (args) => (
+    <div className="flex flex-col gap-8">
+      <section className="flex flex-col gap-2">
+        <h2 className="text-lg font-medium">Standard controls</h2>
+        <Frame>
+          <F0VideoPlayer
+            {...args}
+            content={{ captions: bigBuckBunnyCaptions }}
+            persistControls
+          />
+        </Frame>
+      </section>
+      <section className="flex flex-col gap-2">
+        <h2 className="text-lg font-medium">With download</h2>
+        <Frame>
+          <F0VideoPlayer
+            {...args}
+            content={{ captions: bigBuckBunnyCaptions }}
+            download={{
+              label: "Download sample video",
+              onClick: fn(),
+            }}
+            persistControls
+          />
+        </Frame>
+      </section>
+    </div>
+  ),
 }
 
 /**

--- a/packages/react/src/components/F0VideoPlayer/__tests__/F0VideoPlayer.test.tsx
+++ b/packages/react/src/components/F0VideoPlayer/__tests__/F0VideoPlayer.test.tsx
@@ -8,8 +8,8 @@ import {
   zeroRender as render,
 } from "@/testing/test-utils"
 
-import { F0VideoPlayer } from "../F0VideoPlayer"
 import { volumeIcon } from "../components/VolumeControl"
+import { F0VideoPlayer } from "../F0VideoPlayer"
 
 const VIDEO_SRC = "https://example.com/video.mp4"
 
@@ -68,6 +68,15 @@ describe("F0VideoPlayer", () => {
     it("sets the poster when provided", () => {
       render(<F0VideoPlayer src={VIDEO_SRC} poster="poster.webp" />)
       expect(getVideo()).toHaveAttribute("poster", "poster.webp")
+    })
+
+    it("accepts a contextual accessible name", () => {
+      render(
+        <F0VideoPlayer src={VIDEO_SRC} ariaLabel="Video player: demo.mp4" />
+      )
+      expect(
+        screen.getByRole("region", { name: "Video player: demo.mp4" })
+      ).toBeInTheDocument()
     })
 
     it("shows a center play overlay while paused and hides it during playback", () => {

--- a/packages/react/src/components/F0VideoPlayer/__tests__/F0VideoPlayer.test.tsx
+++ b/packages/react/src/components/F0VideoPlayer/__tests__/F0VideoPlayer.test.tsx
@@ -8,8 +8,8 @@ import {
   zeroRender as render,
 } from "@/testing/test-utils"
 
-import { F0VideoPlayer } from "../F0VideoPlayer"
 import { volumeIcon } from "../components/VolumeControl"
+import { F0VideoPlayer } from "../F0VideoPlayer"
 
 const VIDEO_SRC = "https://example.com/video.mp4"
 
@@ -70,6 +70,15 @@ describe("F0VideoPlayer", () => {
       expect(getVideo()).toHaveAttribute("poster", "poster.webp")
     })
 
+    it("accepts a contextual accessible name", () => {
+      render(
+        <F0VideoPlayer src={VIDEO_SRC} ariaLabel="Video player: demo.mp4" />
+      )
+      expect(
+        screen.getByRole("region", { name: "Video player: demo.mp4" })
+      ).toBeInTheDocument()
+    })
+
     it("shows a center play overlay while paused and hides it during playback", () => {
       render(<F0VideoPlayer src={VIDEO_SRC} />)
       expect(
@@ -107,6 +116,31 @@ describe("F0VideoPlayer", () => {
 
       fireEvent.loadedData(getVideo())
       expect(screen.getByRole("button", { name: "Play" })).toBeInTheDocument()
+    })
+
+    it("renders an optional download inside the loaded player controls", async () => {
+      const onDownload = vi.fn()
+      const user = userEvent.setup()
+      render(
+        <F0VideoPlayer
+          src={VIDEO_SRC}
+          download={{ label: "Download demo.mp4", onClick: onDownload }}
+        />
+      )
+
+      expect(
+        screen.queryByRole("button", { name: "Download demo.mp4" })
+      ).not.toBeInTheDocument()
+
+      fireEvent.loadedData(getVideo())
+      const downloadButton = screen.getByRole("button", {
+        name: "Download demo.mp4",
+      })
+      downloadButton.focus()
+      await user.keyboard(" ")
+
+      expect(onDownload).toHaveBeenCalledOnce()
+      expect(HTMLMediaElement.prototype.play).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/react/src/components/F0VideoPlayer/components/Controls.tsx
+++ b/packages/react/src/components/F0VideoPlayer/components/Controls.tsx
@@ -1,5 +1,11 @@
 import { F0Button } from "@/components/F0Button"
-import { Maximize, Minimize, SolidPause, SolidPlay } from "@/icons/app"
+import {
+  Download,
+  Maximize,
+  Minimize,
+  SolidPause,
+  SolidPlay,
+} from "@/icons/app"
 import { type LanguageOption } from "@/lib/localized"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
@@ -68,6 +74,10 @@ export interface ControlsProps {
   /** Toggle audio description on/off — used by the bar toggle (single-language case). */
   onToggleAudioDescription: () => void
   onSeek: (time: number) => void
+  download?: {
+    label: string
+    onClick: () => void
+  }
 }
 
 /** Bottom control bar. Pure presentation; every interaction is delegated up. */
@@ -107,6 +117,7 @@ export function Controls({
   onToggleCaptions,
   onToggleAudioDescription,
   onSeek,
+  download,
 }: ControlsProps) {
   const { t } = useI18n()
 
@@ -229,6 +240,17 @@ export function Controls({
           audioDescriptionOn={audioDescriptionOn}
           onAudioDescriptionLanguageChange={onAudioDescriptionLanguageChange}
           onAudioDescriptionOff={onAudioDescriptionOff}
+        />
+      )}
+
+      {download && (
+        <F0Button
+          variant="ghost"
+          size="sm"
+          hideLabel
+          icon={Download}
+          label={download.label}
+          onClick={download.onClick}
         />
       )}
 

--- a/packages/react/src/components/F0VideoPlayer/hooks/useKeyboardShortcuts.ts
+++ b/packages/react/src/components/F0VideoPlayer/hooks/useKeyboardShortcuts.ts
@@ -13,8 +13,8 @@ export interface UseKeyboardShortcutsOptions {
 }
 
 /**
- * Player keyboard shortcuts (active while the wrapper or a non-input descendant
- * holds focus):
+ * Player keyboard shortcuts (active while the wrapper or a non-interactive
+ * descendant holds focus):
  *
  *   Space    → play/pause
  *   ← / →    → seek ±SEEK_STEP_SECONDS (forward seek runs through `seek`'s clamp)
@@ -34,8 +34,14 @@ export function useKeyboardShortcuts({
     (event: React.KeyboardEvent<HTMLElement>) => {
       const target = event.target
       if (target instanceof HTMLElement) {
-        const tag = target.tagName
-        if (tag === "INPUT" || tag === "TEXTAREA" || target.isContentEditable)
+        // Native/custom controls own their activation keys. In particular,
+        // intercepting Space from a button would cancel its native click and
+        // toggle playback instead.
+        if (
+          target.closest(
+            'button, a, input, textarea, select, [role="button"], [contenteditable="true"]'
+          )
+        )
           return
         // Inside a menu, let the menu own its keys (Arrow/Space/Enter).
         if (target.closest('[role="menu"], [role^="menuitem"]')) return

--- a/packages/react/src/components/F0VideoPlayer/internal.tsx
+++ b/packages/react/src/components/F0VideoPlayer/internal.tsx
@@ -37,12 +37,14 @@ import { F0VideoPlayerProps } from "./types"
 export function F0VideoPlayerInternal({
   src,
   poster,
+  ariaLabel,
   silent = false,
   persistControls = false,
   content,
   defaultLanguage,
   autoPlay = false,
   autoFocus = false,
+  download,
   restrictForwardSeek = false,
   onTrackAction,
   onMilestone,
@@ -238,7 +240,7 @@ export function F0VideoPlayerInternal({
         focusRing()
       )}
       role="region"
-      aria-label={t("videoPlayer.regionLabel")}
+      aria-label={ariaLabel ?? t("videoPlayer.regionLabel")}
       tabIndex={0}
       onKeyDown={handleKeyDown}
       // Accessibility signal for the Storybook a11y check: prerecorded video
@@ -383,6 +385,7 @@ export function F0VideoPlayerInternal({
           onToggleCaptions={captions.toggle}
           onToggleAudioDescription={toggleAudioDescription}
           onSeek={seek}
+          download={download}
         />
       )}
     </div>

--- a/packages/react/src/components/F0VideoPlayer/internal.tsx
+++ b/packages/react/src/components/F0VideoPlayer/internal.tsx
@@ -37,6 +37,7 @@ import { F0VideoPlayerProps } from "./types"
 export function F0VideoPlayerInternal({
   src,
   poster,
+  ariaLabel,
   silent = false,
   persistControls = false,
   content,
@@ -238,7 +239,7 @@ export function F0VideoPlayerInternal({
         focusRing()
       )}
       role="region"
-      aria-label={t("videoPlayer.regionLabel")}
+      aria-label={ariaLabel ?? t("videoPlayer.regionLabel")}
       tabIndex={0}
       onKeyDown={handleKeyDown}
       // Accessibility signal for the Storybook a11y check: prerecorded video

--- a/packages/react/src/components/F0VideoPlayer/types.ts
+++ b/packages/react/src/components/F0VideoPlayer/types.ts
@@ -54,6 +54,9 @@ export interface VideoPlayerContent {
 }
 
 export interface F0VideoPlayerProps extends DataAttributes {
+  /** Accessible name for this player region. Defaults to "Video player". */
+  ariaLabel?: string
+
   /**
    * Video source URL. Localizable — pass a per-locale list of dubbed renditions
    * to offer selectable audio languages; an "Audio" selector then appears,
@@ -108,6 +111,15 @@ export interface F0VideoPlayerProps extends DataAttributes {
   autoPlay?: boolean
   /** Focus the player on mount so keyboard shortcuts work immediately. Default `false`. */
   autoFocus?: boolean
+  /**
+   * Optional download action rendered inside the player controls. Native media
+   * downloads remain disabled, so embedded surfaces that allow saving the
+   * source can expose an explicit, keyboard-accessible action here.
+   */
+  download?: {
+    label: string
+    onClick: () => void
+  }
   /**
    * Prevent seeking past the furthest point already watched. Renders a marker at
    * that position and blocks the cursor beyond it. Default `false`.

--- a/packages/react/src/components/F0VideoPlayer/types.ts
+++ b/packages/react/src/components/F0VideoPlayer/types.ts
@@ -54,6 +54,9 @@ export interface VideoPlayerContent {
 }
 
 export interface F0VideoPlayerProps extends DataAttributes {
+  /** Accessible name for this player region. Defaults to "Video player". */
+  ariaLabel?: string
+
   /**
    * Video source URL. Localizable — pass a per-locale list of dubbed renditions
    * to offer selectable audio languages; an "Audio" selector then appears,

--- a/packages/react/src/experimental/Overlays/Tooltip/index.stories.tsx
+++ b/packages/react/src/experimental/Overlays/Tooltip/index.stories.tsx
@@ -3,10 +3,11 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 import { expect, within } from "storybook/test"
 
 import { F0Button } from "@/components/F0Button"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import { Tooltip } from "./index"
 
-const meta: Meta<typeof Tooltip> = {
+const meta = {
   title: "Tooltip",
   component: Tooltip,
   tags: ["autodocs", "experimental"],
@@ -15,11 +16,11 @@ const meta: Meta<typeof Tooltip> = {
       <div className="flex h-32 items-center justify-center p-6">{Story()}</div>
     ),
   ],
-}
+} satisfies Meta<typeof Tooltip>
 
 export default meta
 
-type Story = StoryObj<typeof Tooltip>
+type Story = StoryObj<typeof meta>
 
 export const Basic: Story = {
   args: {
@@ -27,6 +28,11 @@ export const Basic: Story = {
     description: "View a breakdown of planned working hours.",
     children: <F0Button variant="outline" label="Planned hours" />,
   },
+}
+
+export const Snapshot: Story = {
+  args: Basic.args,
+  parameters: withSnapshot({}),
 }
 
 export const WithShortcut: Story = {

--- a/packages/react/src/experimental/Overlays/Tooltip/index.tsx
+++ b/packages/react/src/experimental/Overlays/Tooltip/index.tsx
@@ -25,6 +25,7 @@ type TooltipInternalProps = {
   shortcut?: ComponentProps<typeof Shortcut>["keys"]
   delay?: number
   instant?: boolean
+  onOpen?: () => void
 } & (
   | {
       label: string
@@ -43,6 +44,7 @@ export function TooltipInternal({
   shortcut,
   instant = false,
   delay = 700,
+  onOpen,
 }: TooltipInternalProps) {
   const [open, setOpen] = useState(false)
   const openTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -62,9 +64,10 @@ export function TooltipInternal({
   }, [clearOpenTimeout])
 
   const scheduleOpen = useCallback(() => {
+    onOpen?.()
     clearOpenTimeout()
     openTimeoutRef.current = setTimeout(() => setOpen(true), openDelayMs)
-  }, [clearOpenTimeout, openDelayMs])
+  }, [clearOpenTimeout, onOpen, openDelayMs])
 
   useEffect(() => close, [close])
 
@@ -101,6 +104,7 @@ export function TooltipInternal({
             onPointerDown={() => close()}
             onFocus={(e) => {
               if (isFocusVisible(e.currentTarget)) {
+                onOpen?.()
                 setOpen(true)
               } else {
                 // If focus comes from mouse/touch/programmatic focus, keep closed.
@@ -134,7 +138,7 @@ export function TooltipInternal({
   )
 }
 
-const privateProps = ["delay"] as const
+const privateProps = ["delay", "onOpen"] as const
 
 export type TooltipProps = Omit<
   TooltipInternalProps,

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -506,8 +506,9 @@ export const defaultTranslations = {
     cancelRecording: "Cancel recording",
     dropFilesHere: "Drop your files here",
     removeFile: "Remove",
-    // Transient composer errors (flashed in the textarea, mirroring the AI chat).
+    // Composer errors (upload/voice failures are transient; validation may persist).
     tooManyFilesError: "You can attach up to {{maxFiles}} files at once",
+    fileTooLargeError: "Each file must be {{maxFileSize}} or smaller",
     fileUploadError: "Upload failed",
     micPermissionDenied:
       "Microphone access is blocked. Allow it in your browser settings to dictate.",

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -506,6 +506,7 @@ export const defaultTranslations = {
     cancelRecording: "Cancel recording",
     dropFilesHere: "Drop your files here",
     removeFile: "Remove",
+    removeNamedFile: "Remove {{name}}",
     // Composer errors (upload/voice failures are transient; validation may persist).
     tooManyFilesError: "You can attach up to {{maxFiles}} files at once",
     fileTooLargeError: "Each file must be {{maxFileSize}} or smaller",
@@ -554,6 +555,7 @@ export const defaultTranslations = {
     reply: "Reply",
     react: "Add reaction",
     download: "Download",
+    downloadNamedFile: "Download {{name}}",
     removeQuote: "Remove quote",
     // Editing your own message (within the edit window). `editing` heads the
     // composer chip; `edited` is the muted marker after an edited message body.
@@ -571,7 +573,10 @@ export const defaultTranslations = {
     previousImage: "Previous image",
     nextImage: "Next image",
     openDocument: "Open document",
+    openNamedDocument: "Open {{name}}",
     documentPreview: "Document preview",
+    videoPlayerLabel: "Video player: {{name}}",
+    loadingVideo: "Loading video: {{name}}",
     // Attachment previews in reply quotes + the composer chip (a lone file shows
     // its real name instead of a count).
     photo: "Photo",

--- a/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
@@ -1747,9 +1747,9 @@ export const CommunicationsVideoAttachments: Story = {
 /**
  * Composer attachment gallery. Selecting seven files at once shows immediate
  * local previews for image, video, PDF, spreadsheet, Word and text content
- * while a regular PowerPoint keeps a file icon fallback. Every file uses the
- * same compact square footprint as an image, and that shape remains stable
- * when the simulated upload replaces each local URL.
+ * while a regular PowerPoint keeps a file icon fallback. Files use the same
+ * compact square footprint as an image; video keeps that height but uses a
+ * wider 16:9 thumbnail. Each shape remains stable when local URLs are replaced.
  */
 export const CommunicationsComposerAttachmentPreviews: Story = {
   name: "Communications — composer attachment previews",
@@ -1859,16 +1859,18 @@ export const CommunicationsComposerAttachmentPreviews: Story = {
       ).toHaveLength(7)
 
       const strip = page.getByTestId("chat-composer-attachments")
-      const compactPreviews = [
+      const squarePreviews = [
         page.getByTestId("chat-composer-image-preview"),
-        page.getByTestId("chat-composer-video-preview"),
         ...page.getAllByTestId("chat-composer-document-preview"),
         page.getByTestId("chat-composer-file-preview"),
       ]
-      for (const preview of compactPreviews) {
+      for (const preview of squarePreviews) {
         await expect(preview.getBoundingClientRect().width).toBe(64)
         await expect(preview.getBoundingClientRect().height).toBe(64)
       }
+      const videoPreview = page.getByTestId("chat-composer-video-preview")
+      await expect(videoPreview.getBoundingClientRect().width).toBe(112)
+      await expect(videoPreview.getBoundingClientRect().height).toBe(64)
       await expect(strip.scrollWidth).toBeGreaterThan(strip.clientWidth)
       strip.scrollLeft = strip.scrollWidth
       await expect(strip.scrollLeft).toBeGreaterThan(0)

--- a/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
@@ -908,7 +908,12 @@ export const CommunicationsGroupAvatarFallback: Story = {
             chatHeader: <MockConnectedChatHeader compact />,
           }}
           aiPromotion={args.aiPromotion}
-          sidebar={<ConversationsSidebar initialTab="messages" />}
+          sidebar={
+            <ConversationsSidebar
+              initialTab="messages"
+              autoOpenConvId="grp-reporting"
+            />
+          }
         >
           <Page
             {...PageStories.Default.args}
@@ -922,16 +927,22 @@ export const CommunicationsGroupAvatarFallback: Story = {
     const page = within(canvasElement.closest("body")!)
 
     await step("Use the same fallback in the sidebar and header", async () => {
-      const sidebarFallback = await page.findByTestId(
-        "sidebar-group-avatar-fallback"
-      )
-      await expect(
-        sidebarFallback.getBoundingClientRect().width
-      ).toBeGreaterThan(0)
-      await expect(sidebarFallback).toHaveTextContent("＃")
-      await userEvent.click(
-        await page.findByRole("button", { name: "Leadership" })
-      )
+      for (const groupName of [
+        "Quarterly Reporting",
+        "Release War Room",
+        "Leadership",
+      ]) {
+        const group = await page.findByRole("button", { name: groupName })
+        const sidebarFallback = within(group).getByTestId(
+          "sidebar-group-avatar-fallback"
+        )
+
+        await expect(
+          sidebarFallback.getBoundingClientRect().width
+        ).toBeGreaterThan(0)
+        await expect(sidebarFallback).toHaveTextContent("＃")
+      }
+
       const headerFallback = await page.findByTestId(
         "chat-group-avatar-fallback"
       )
@@ -2239,7 +2250,10 @@ export const Snapshot: Story = {
   ),
   play: async ({ canvas, step }) => {
     await step("Show the group avatar fallback", async () => {
-      const sidebarFallback = await canvas.findByTestId(
+      const leadership = await canvas.findByRole("button", {
+        name: "Leadership",
+      })
+      const sidebarFallback = within(leadership).getByTestId(
         "sidebar-group-avatar-fallback"
       )
       const headerFallback = await canvas.findByTestId(

--- a/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
@@ -1512,11 +1512,11 @@ export const CommunicationsBlankStates: Story = {
 
 /**
  * A group conversation with real-world message receipts and reactions. The
- * final message is mine and carries the identities of its three readers and
- * three reaction users, matching the transport-agnostic production contract.
+ * final message is mine and carries 45 reader identities, forcing the reader
+ * info panel to scroll as a whole, plus three reaction users.
  */
 export const CommunicationsReceiptsAndReactions: Story = {
-  name: "Communications — readers and reaction users",
+  name: "Communications — 40+ readers and reaction users",
   tags: ["f0chat-receipts"],
   render: (args) => (
     <MockAiChatRuntimeProvider>
@@ -1555,21 +1555,21 @@ export const CommunicationsReceiptsAndReactions: Story = {
       addReaction.focus()
       await userEvent.tab({ shift: true })
       await expect(reaction).toHaveFocus()
-      const reactionTooltips = await page.findAllByText(
-        "Grace Liang, Marcus Bennett, Sam Okafor",
-        {},
-        { timeout: 3_000 }
+      const reactionTooltips = (
+        await page.findAllByRole("tooltip", {}, { timeout: 3_000 })
+      ).filter((tooltip) =>
+        tooltip.textContent?.includes("Grace Liang, Marcus Bennett, Sam Okafor")
       )
       const tooltipId = reaction.getAttribute("aria-describedby")
-      const visibleTooltip = tooltipId
+      const describedTooltip = tooltipId
         ? canvasElement.ownerDocument.getElementById(tooltipId)
         : null
       await expect(reactionTooltips.length).toBeGreaterThan(0)
       await expect(tooltipId).toBeTruthy()
-      await expect(visibleTooltip).toHaveTextContent(
+      await expect(describedTooltip).toHaveTextContent(
         "Grace Liang, Marcus Bennett, Sam Okafor"
       )
-      await expect(visibleTooltip!).toBeVisible()
+      await expect(reactionTooltips[0]).toBeVisible()
       await userEvent.tab()
     })
 
@@ -1588,12 +1588,32 @@ export const CommunicationsReceiptsAndReactions: Story = {
 
       const readers = await page.findByRole(
         "list",
-        { name: /Read by 3/i },
+        { name: /Read by 45/i },
         { timeout: 3_000 }
       )
+      const infoPanel = page.getByRole("region", { name: /^Info$/i })
+      await expect(readers.children).toHaveLength(45)
+      await expect(infoPanel.scrollHeight).toBeGreaterThan(
+        infoPanel.clientHeight
+      )
+      await expect(readers.scrollHeight).toBe(readers.clientHeight)
+      await expect(readers).not.toHaveAttribute("tabindex")
       await expect(within(readers).getByText("Grace Liang")).toBeVisible()
       await expect(within(readers).getByText("Marcus Bennett")).toBeVisible()
       await expect(within(readers).getByText("Sam Okafor")).toBeVisible()
+      const backButton = page.getByRole("button", { name: /back/i })
+      await expect(backButton).toHaveFocus()
+      await userEvent.tab()
+      await expect(infoPanel).toHaveFocus()
+      infoPanel.scrollTop = infoPanel.scrollHeight
+      await expect(infoPanel.scrollTop).toBeGreaterThan(0)
+      const lastReader = within(readers).getByText("Demo Reader 42")
+      const infoPanelRect = infoPanel.getBoundingClientRect()
+      const lastReaderRect = lastReader.getBoundingClientRect()
+      await expect(lastReaderRect.top).toBeGreaterThanOrEqual(infoPanelRect.top)
+      await expect(lastReaderRect.bottom).toBeLessThanOrEqual(
+        infoPanelRect.bottom
+      )
     })
   },
 }
@@ -1601,6 +1621,5 @@ export const CommunicationsReceiptsAndReactions: Story = {
 export const Snapshot: Story = {
   ...CommunicationsReceiptsAndReactions,
   name: "Snapshot",
-  play: undefined,
   parameters: withSnapshot({}),
 }

--- a/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
@@ -2110,7 +2110,7 @@ export const CommunicationsReceiptsAndReactions: Story = {
       await userEvent.tab()
     })
 
-    await step("Show the people who read a group message", async () => {
+    await step("Show static reader identities", async () => {
       const message = await canvas.findByText(/And the kickoff deck/)
       await userEvent.hover(message)
       const actionButtons = await canvas.findAllByRole("button", {
@@ -2135,30 +2135,32 @@ export const CommunicationsReceiptsAndReactions: Story = {
       )
       await expect(readers.scrollHeight).toBe(readers.clientHeight)
       await expect(readers).not.toHaveAttribute("tabindex")
-      const grace = within(readers).getByRole("link", {
-        name: /Grace Liang/i,
-      })
-      await expect(grace).toHaveAttribute("href", "/people/u_grace")
+      const graceRow = within(readers).getByText("Grace Liang").parentElement!
+      await expect(graceRow).toBeVisible()
       await expect(within(readers).getByText("Marcus Bennett")).toBeVisible()
       await expect(within(readers).getByText("Sam Okafor")).toBeVisible()
+      await expect(within(readers).queryByRole("link")).not.toBeInTheDocument()
+      await expect(
+        readers.querySelector(
+          '[tabindex], button, a, input, select, textarea, [role="button"], [role="link"], [contenteditable="true"]'
+        )
+      ).not.toBeInTheDocument()
       const backButton = page.getByRole("button", { name: /^back$/i })
       await expect(backButton).toHaveFocus()
 
-      await userEvent.hover(grace)
-      await waitFor(() => expect(page.getByText("Data Analyst")).toBeVisible())
+      await userEvent.hover(graceRow)
+      await new Promise((resolve) => setTimeout(resolve, 200))
+      await expect(page.queryByText("Data Analyst")).not.toBeInTheDocument()
       await expect(
-        page.getByRole("link", { name: /view profile/i })
-      ).toHaveAttribute("href", "/people/u_grace")
-      await userEvent.unhover(grace)
-      await waitFor(() =>
-        expect(page.queryByText("Data Analyst")).not.toBeInTheDocument()
-      )
+        page.queryByRole("link", { name: /view profile/i })
+      ).not.toBeInTheDocument()
 
       await userEvent.tab()
       await expect(infoPanel).toHaveFocus()
       await userEvent.tab()
-      await expect(grace).toHaveFocus()
-      await waitFor(() => expect(page.getByText("Data Analyst")).toBeVisible())
+      await expect(readers.contains(readers.ownerDocument.activeElement)).toBe(
+        false
+      )
       infoPanel.scrollTop = infoPanel.scrollHeight
       await expect(infoPanel.scrollTop).toBeGreaterThan(0)
       const lastReader = within(readers).getByText("Demo Reader 42")

--- a/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { ComponentProps, useCallback, useEffect, useRef, useState } from "react"
+import { expect, userEvent, within } from "storybook/test"
 
 import { F0Button } from "@/components/F0Button"
 import { F0Icon, IconType } from "@/components/F0Icon"
@@ -24,6 +25,8 @@ import { HomeLayout } from "@/layouts/HomeLayout"
 import * as HomeLayoutStories from "@/layouts/HomeLayout/index.stories"
 import { F0Box } from "@/lib/F0Box"
 import { mockTranscribe } from "@/lib/storybook-utils/ai-mocks"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
+import { getEmojiLabel } from "@/lib/emojis"
 import { Page } from "@/patterns/Navigation/Page"
 import * as PageStories from "@/patterns/Navigation/Page/index.stories"
 import { exampleActions } from "@/patterns/Navigation/Sidebar/Chats/index.stories"
@@ -516,7 +519,7 @@ const WelcomeCards = () => {
   return <WelcomeScreenCardsRow cards={cards} />
 }
 
-const meta: Meta<typeof ApplicationFrame> = {
+const meta = {
   title: "App shell/ApplicationFrame",
   component: ApplicationFrame,
   tags: ["autodocs", "experimental"],
@@ -761,11 +764,11 @@ const meta: Meta<typeof ApplicationFrame> = {
     sidebar: <TabbedSidebar />,
     children: <Page {...PageStories.Default.args} />,
   } satisfies ComponentProps<typeof ApplicationFrame>,
-}
+} satisfies Meta<typeof ApplicationFrame>
 
 export default meta
 
-type Story = StoryObj<typeof ApplicationFrame>
+type Story = StoryObj<typeof meta>
 
 const mockChatSlots = {
   chatHeader: <MockConnectedChatHeader />,
@@ -1505,4 +1508,99 @@ export const CommunicationsBlankStates: Story = {
       </MockChatAppProvider>
     </MockAiChatRuntimeProvider>
   ),
+}
+
+/**
+ * A group conversation with real-world message receipts and reactions. The
+ * final message is mine and carries the identities of its three readers and
+ * three reaction users, matching the transport-agnostic production contract.
+ */
+export const CommunicationsReceiptsAndReactions: Story = {
+  name: "Communications — readers and reaction users",
+  tags: ["f0chat-receipts"],
+  render: (args) => (
+    <MockAiChatRuntimeProvider>
+      <MockChatAppProvider>
+        <ApplicationFrame
+          ai={{
+            ...withMockChatSlots(args.ai),
+            side: "left",
+            historyEnabled: false,
+            chatHeader: <MockConnectedChatHeader compact />,
+          }}
+          aiPromotion={args.aiPromotion}
+          sidebar={
+            <ConversationsSidebar
+              initialTab="messages"
+              autoOpenConvId="grp-reporting"
+            />
+          }
+        >
+          <Page
+            {...PageStories.Default.args}
+            header={communicationsPageHeader}
+          />
+        </ApplicationFrame>
+      </MockChatAppProvider>
+    </MockAiChatRuntimeProvider>
+  ),
+  play: async ({ canvas, canvasElement, step }) => {
+    const page = within(canvasElement.closest("body")!)
+    await step("Show the people behind a reaction", async () => {
+      const reaction = await canvas.findByRole("button", {
+        name: `${getEmojiLabel("🎉")}: 3`,
+      })
+      const addReaction = canvas.getByRole("button", { name: /add reaction/i })
+
+      addReaction.focus()
+      await userEvent.tab({ shift: true })
+      await expect(reaction).toHaveFocus()
+      const reactionTooltips = await page.findAllByText(
+        "Grace Liang, Marcus Bennett, Sam Okafor",
+        {},
+        { timeout: 3_000 }
+      )
+      const tooltipId = reaction.getAttribute("aria-describedby")
+      const visibleTooltip = tooltipId
+        ? canvasElement.ownerDocument.getElementById(tooltipId)
+        : null
+      await expect(reactionTooltips.length).toBeGreaterThan(0)
+      await expect(tooltipId).toBeTruthy()
+      await expect(visibleTooltip).toHaveTextContent(
+        "Grace Liang, Marcus Bennett, Sam Okafor"
+      )
+      await expect(visibleTooltip!).toBeVisible()
+      await userEvent.tab()
+    })
+
+    await step("Show the people who read a group message", async () => {
+      const message = await canvas.findByText(/And the kickoff deck/)
+      await userEvent.hover(message)
+      const actionButtons = await canvas.findAllByRole("button", {
+        name: /message actions/i,
+      })
+      await userEvent.click(actionButtons.at(-1)!)
+      await userEvent.click(
+        await page.findByRole("button", {
+          name: /^Info$/i,
+        })
+      )
+
+      const readers = await page.findByRole(
+        "list",
+        { name: /Read by 3/i },
+        { timeout: 3_000 }
+      )
+      await expect(within(readers).getByText("Grace Liang")).toBeVisible()
+      await expect(within(readers).getByText("Marcus Bennett")).toBeVisible()
+      await expect(within(readers).getByText("Sam Okafor")).toBeVisible()
+    })
+  },
+}
+
+export const Snapshot: Story = {
+  ...CommunicationsReceiptsAndReactions,
+  name: "Snapshot",
+  play: undefined,
+  parameters: withSnapshot({}),
 }

--- a/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
@@ -1,7 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
-import { ComponentProps, useCallback, useEffect, useRef, useState } from "react"
-import { expect, userEvent, within } from "storybook/test"
+import {
+  ComponentProps,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+import { expect, userEvent, waitFor, within } from "storybook/test"
 
 import { F0Button } from "@/components/F0Button"
 import { F0Icon, IconType } from "@/components/F0Icon"
@@ -74,7 +81,13 @@ import {
   ThreadListSkeleton,
   useChatHistory,
 } from "@/kits/ai/F0AiChatHistory"
-import { F0Chat, F0ChatProvider } from "@/sds/chat/F0Chat"
+import {
+  F0Chat,
+  F0ChatProvider,
+  isUserMessage,
+  type F0ChatRuntime,
+} from "@/sds/chat/F0Chat"
+import { MessageStatus } from "@/sds/chat/F0Chat/components/MessageStatus"
 import {
   MockChatAppProvider,
   useConversationRuntime,
@@ -966,8 +979,40 @@ export const WithAiAssistant: Story = {
  * `MockChatApp` store (so reads/unreads stay in sync with the sidebar). Wires
  * fullscreen/close to the panel via `useAiChat()`.
  */
-const MockChatPanel = ({ convId }: { convId: string }) => {
+const MockChatPanel = ({
+  convId,
+  receiptPreview,
+}: {
+  convId: string
+  receiptPreview?: "partial"
+}) => {
   const runtime = useConversationRuntime(convId)
+  const previewMessageId = useRef<string | null>(null)
+  if (receiptPreview === "partial" && previewMessageId.current == null) {
+    const lastOwnMessage = [...runtime.messages]
+      .reverse()
+      .find((item) => isUserMessage(item) && item.isMine)
+    previewMessageId.current = lastOwnMessage?.id ?? null
+  }
+
+  const previewRuntime = useMemo<F0ChatRuntime>(() => {
+    if (receiptPreview !== "partial" || previewMessageId.current == null)
+      return runtime
+
+    return {
+      ...runtime,
+      messages: runtime.messages.map((item) =>
+        isUserMessage(item) && item.id === previewMessageId.current
+          ? {
+              ...item,
+              status: "read",
+              readBy: item.readBy?.slice(0, 2),
+              readByCount: undefined,
+            }
+          : item
+      ),
+    }
+  }, [receiptPreview, runtime])
   // Header actions are PER CHANNEL, derived from my role there (what a real
   // host derives from its permission system): admin channels get Edit group
   // (an F0Dialog owned by the host, prefilled with the group name + member
@@ -987,7 +1032,7 @@ const MockChatPanel = ({ convId }: { convId: string }) => {
   const isFullscreen = visualizationMode === "fullscreen"
 
   return (
-    <F0ChatProvider runtime={runtime}>
+    <F0ChatProvider runtime={previewRuntime}>
       <F0Chat
         isFullscreen={isFullscreen}
         onToggleFullscreen={() =>
@@ -1307,6 +1352,7 @@ const OneHistoryTab = ({
 const ConversationsSidebarInner = ({
   initialTab = "home",
   autoOpenConvId,
+  receiptPreview,
   forceEmpty = false,
   withOneTab = true,
   tabsPersistKey,
@@ -1314,6 +1360,8 @@ const ConversationsSidebarInner = ({
   initialTab?: string
   /** Mount this conversation in the side panel on first render (demo only). */
   autoOpenConvId?: string
+  /** Override the opened conversation to preview an incomplete receipt. */
+  receiptPreview?: "partial"
   /** Demo-only: render both lists (Messages + One) empty to show the blank states. */
   forceEmpty?: boolean
   /** Show the "One" tab. Off when the AI chat is reached from the page
@@ -1339,10 +1387,12 @@ const ConversationsSidebarInner = ({
     (convId: string) => {
       setPanelContent({
         id: convId,
-        content: <MockChatPanel convId={convId} />,
+        content: (
+          <MockChatPanel convId={convId} receiptPreview={receiptPreview} />
+        ),
       })
     },
-    [setPanelContent]
+    [receiptPreview, setPanelContent]
   )
 
   // Demo convenience: open a conversation straight away (e.g. the mentions story
@@ -1454,12 +1504,14 @@ const ConversationsSidebarInner = ({
 const ConversationsSidebar = ({
   initialTab,
   autoOpenConvId,
+  receiptPreview,
   forceEmpty,
   withOneTab,
   tabsPersistKey,
 }: {
   initialTab?: string
   autoOpenConvId?: string
+  receiptPreview?: "partial"
   forceEmpty?: boolean
   withOneTab?: boolean
   tabsPersistKey?: string
@@ -1469,6 +1521,7 @@ const ConversationsSidebar = ({
       <ConversationsSidebarInner
         initialTab={initialTab}
         autoOpenConvId={autoOpenConvId}
+        receiptPreview={receiptPreview}
         forceEmpty={forceEmpty}
         withOneTab={withOneTab}
         tabsPersistKey={tabsPersistKey}
@@ -1511,6 +1564,70 @@ export const CommunicationsBlankStates: Story = {
 }
 
 /**
+ * The final group message has only two of the expected 45 receipts. The footer
+ * remains "Sent · time"; reader identities stay available from message Info.
+ */
+export const CommunicationsPartialReceipts: Story = {
+  name: "Communications — partial readers (sent)",
+  tags: ["f0chat-receipts"],
+  render: (args) => (
+    <MockAiChatRuntimeProvider>
+      <MockChatAppProvider>
+        <ApplicationFrame
+          ai={{
+            ...withMockChatSlots(args.ai),
+            side: "left",
+            historyEnabled: false,
+            chatHeader: <MockConnectedChatHeader compact />,
+          }}
+          aiPromotion={args.aiPromotion}
+          sidebar={
+            <ConversationsSidebar
+              initialTab="messages"
+              autoOpenConvId="grp-reporting"
+              receiptPreview="partial"
+            />
+          }
+        >
+          <Page
+            {...PageStories.Default.args}
+            header={communicationsPageHeader}
+          />
+        </ApplicationFrame>
+      </MockChatAppProvider>
+    </MockAiChatRuntimeProvider>
+  ),
+  play: async ({ canvas, canvasElement, step }) => {
+    const page = within(canvasElement.closest("body")!)
+    await step("Keep an incomplete group receipt at sent", async () => {
+      const status = await canvas.findByRole("status")
+      await waitFor(() => expect(status).toHaveTextContent(/^Sent · /i))
+      await expect(status).toHaveAttribute("aria-live", "polite")
+      await expect(status).toHaveAttribute("aria-atomic", "true")
+      await expect(canvas.queryByText(/^Read by 2$/i)).not.toBeInTheDocument()
+    })
+
+    await step("Keep partial reader identities in message Info", async () => {
+      const message = await canvas.findByText(/And the kickoff deck/)
+      await userEvent.hover(message)
+      const actionButtons = await canvas.findAllByRole("button", {
+        name: /message actions/i,
+      })
+      await userEvent.click(actionButtons.at(-1)!)
+      await userEvent.click(
+        await page.findByRole("button", {
+          name: /^Info$/i,
+        })
+      )
+
+      const readers = await page.findByRole("list", { name: /Read by 2/i })
+      await expect(readers).toHaveTextContent("Grace Liang")
+      await expect(readers).toHaveTextContent("Marcus Bennett")
+    })
+  },
+}
+
+/**
  * A group conversation with real-world message receipts and reactions. The
  * final message is mine and carries 45 reader identities, forcing the reader
  * info panel to scroll as a whole, plus three reaction users.
@@ -1546,6 +1663,14 @@ export const CommunicationsReceiptsAndReactions: Story = {
   ),
   play: async ({ canvas, canvasElement, step }) => {
     const page = within(canvasElement.closest("body")!)
+    await step("Summarize the completed group receipt", async () => {
+      const status = await canvas.findByRole("status")
+      await waitFor(() => expect(status).toHaveTextContent(/^Read · /i))
+      await expect(status).toHaveAttribute("aria-live", "polite")
+      await expect(status).toHaveAttribute("aria-atomic", "true")
+      await expect(canvas.queryByText(/^Read by 45$/i)).not.toBeInTheDocument()
+    })
+
     await step("Show the people behind a reaction", async () => {
       const reaction = await canvas.findByRole("button", {
         name: `${getEmojiLabel("🎉")}: 3`,
@@ -1618,8 +1743,98 @@ export const CommunicationsReceiptsAndReactions: Story = {
   },
 }
 
+const ReceiptStatusComparison = () => {
+  const runtime = useConversationRuntime("grp-reporting")
+  const message = [...runtime.messages]
+    .reverse()
+    .find((item) => isUserMessage(item) && item.isMine)
+  if (!message || !isUserMessage(message)) return null
+
+  const partialMessage = {
+    ...message,
+    status: "read" as const,
+    readBy: message.readBy?.slice(0, 2),
+    readByCount: undefined,
+  }
+
+  return (
+    <F0ChatProvider runtime={runtime}>
+      <div className="mx-auto grid w-full max-w-xl gap-4 p-8">
+        <h2 className="text-xl font-semibold text-f1-foreground">
+          Group receipt footer states
+        </h2>
+        <section
+          aria-labelledby="partial-receipts-title"
+          className="rounded-lg border border-solid border-f1-border-secondary bg-f1-background p-4"
+        >
+          <h3
+            id="partial-receipts-title"
+            className="font-medium text-f1-foreground"
+          >
+            Partial group receipts
+          </h3>
+          <MessageStatus message={partialMessage} isGroup />
+        </section>
+        <section
+          aria-labelledby="completed-receipts-title"
+          className="rounded-lg border border-solid border-f1-border-secondary bg-f1-background p-4"
+        >
+          <h3
+            id="completed-receipts-title"
+            className="font-medium text-f1-foreground"
+          >
+            Completed group receipts
+          </h3>
+          <MessageStatus message={message} isGroup />
+        </section>
+      </div>
+    </F0ChatProvider>
+  )
+}
+
 export const Snapshot: Story = {
-  ...CommunicationsReceiptsAndReactions,
   name: "Snapshot",
+  render: (args) => (
+    <MockAiChatRuntimeProvider>
+      <MockChatAppProvider>
+        <ApplicationFrame
+          ai={{
+            ...withMockChatSlots(args.ai),
+            side: "left",
+            historyEnabled: false,
+            chatHeader: <MockConnectedChatHeader compact />,
+          }}
+          aiPromotion={args.aiPromotion}
+          sidebar={
+            <ConversationsSidebar
+              initialTab="messages"
+              autoOpenConvId="grp-reporting"
+            />
+          }
+        >
+          <Page {...PageStories.Default.args} header={communicationsPageHeader}>
+            <ReceiptStatusComparison />
+          </Page>
+        </ApplicationFrame>
+      </MockChatAppProvider>
+    </MockAiChatRuntimeProvider>
+  ),
+  play: async ({ canvas, step }) => {
+    await step("Show partial and completed group receipt footers", async () => {
+      const partial = within(
+        await canvas.findByRole("region", { name: "Partial group receipts" })
+      )
+      const completed = within(
+        await canvas.findByRole("region", { name: "Completed group receipts" })
+      )
+
+      await waitFor(() =>
+        expect(partial.getByRole("status")).toHaveTextContent(/^Sent · /i)
+      )
+      await waitFor(() =>
+        expect(completed.getByRole("status")).toHaveTextContent(/^Read · /i)
+      )
+    })
+  },
   parameters: withSnapshot({}),
 }

--- a/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
@@ -1789,10 +1789,18 @@ export const CommunicationsVideoAttachments: Story = {
 
         const controls = within(player)
         await expect(
-          controls.getByRole("button", { name: "Play" })
+          await controls.findByRole(
+            "button",
+            { name: "Play" },
+            { timeout: 5_000 }
+          )
         ).toBeVisible()
         await expect(
-          controls.getByRole("button", { name: "Enter fullscreen" })
+          await controls.findByRole(
+            "button",
+            { name: "Enter fullscreen" },
+            { timeout: 5_000 }
+          )
         ).toBeVisible()
         const video = player.querySelector("video")
         await expect(video).not.toBeNull()

--- a/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
@@ -93,6 +93,7 @@ import {
   useConversationRuntime,
   useMockChatGroups,
 } from "@/sds/chat/F0Chat/mocks/MockChatApp"
+import { MOCK_MAX_FILE_SIZE_BYTES } from "@/sds/chat/F0Chat/mocks/constants"
 import { SEED_BY_ID } from "@/sds/chat/F0Chat/mocks/mockSeeds"
 import { useDemoHeaderActions } from "@/sds/chat/F0Chat/mocks/useDemoHeaderActions"
 import { Action } from "@/ui/Action"
@@ -1564,6 +1565,99 @@ export const CommunicationsBlankStates: Story = {
 }
 
 /**
+ * The communications composer is configured with the mock runtime's 100 MB
+ * per-file limit. Selecting an oversized file rejects it before upload and
+ * keeps the composer usable.
+ */
+export const CommunicationsFileSizeLimit: Story = {
+  name: "Communications — 100 MB file limit",
+  tags: ["f0chat-files"],
+  render: (args) => (
+    <MockAiChatRuntimeProvider>
+      <MockChatAppProvider>
+        <ApplicationFrame
+          ai={{
+            ...withMockChatSlots(args.ai),
+            side: "left",
+            historyEnabled: false,
+            chatHeader: <MockConnectedChatHeader compact />,
+          }}
+          aiPromotion={args.aiPromotion}
+          sidebar={
+            <ConversationsSidebar
+              initialTab="messages"
+              autoOpenConvId="grp-reporting"
+            />
+          }
+        >
+          <Page
+            {...PageStories.Default.args}
+            header={communicationsPageHeader}
+          />
+        </ApplicationFrame>
+      </MockChatAppProvider>
+    </MockAiChatRuntimeProvider>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const page = within(canvasElement.closest("body")!)
+
+    await step("Reject a file over the 100 MB limit", async () => {
+      await page.findByRole("button", { name: /attach file/i })
+      const fileInput = canvasElement
+        .closest("body")!
+        .querySelector<HTMLInputElement>('input[type="file"]')!
+      const tooLarge = new File(["small"], "oversized-archive.zip", {
+        type: "application/zip",
+      })
+      Object.defineProperty(tooLarge, "size", {
+        value: MOCK_MAX_FILE_SIZE_BYTES + 1,
+      })
+
+      await userEvent.upload(fileInput, tooLarge)
+
+      await page.findByText("Each file must be 100 MB or smaller")
+      await waitFor(() =>
+        expect(
+          page.getByText("Each file must be 100 MB or smaller")
+        ).toBeVisible()
+      )
+      const validationAlert = page
+        .getByText("Each file must be 100 MB or smaller")
+        .closest('[role="alert"]')!
+      await expect(validationAlert).toHaveTextContent(
+        "Each file must be 100 MB or smaller"
+      )
+      await expect(
+        page.queryByText("oversized-archive.zip")
+      ).not.toBeInTheDocument()
+    })
+
+    await step("Paste a file into the composer", async () => {
+      const textarea = page.getByPlaceholderText("Write something here..")
+      const pastedFile = new File(["pasted"], "pasted-notes.txt", {
+        type: "text/plain",
+      })
+      const clipboardData = new DataTransfer()
+      clipboardData.items.add(pastedFile)
+      textarea.focus()
+
+      const pasteEvent = new ClipboardEvent("paste", {
+        bubbles: true,
+        cancelable: true,
+        clipboardData,
+      })
+      await expect(textarea.dispatchEvent(pasteEvent)).toBe(false)
+      await expect(textarea).toHaveFocus()
+
+      await page.findByText("pasted-notes.txt", {}, { timeout: 3_000 })
+      await waitFor(() =>
+        expect(page.getByText("pasted-notes.txt")).toBeVisible()
+      )
+    })
+  },
+}
+
+/**
  * The final group message has only two of the expected 45 receipts. The footer
  * remains "Sent · time"; reader identities stay available from message Info.
  */
@@ -1600,8 +1694,13 @@ export const CommunicationsPartialReceipts: Story = {
   play: async ({ canvas, canvasElement, step }) => {
     const page = within(canvasElement.closest("body")!)
     await step("Keep an incomplete group receipt at sent", async () => {
-      const status = await canvas.findByRole("status")
-      await waitFor(() => expect(status).toHaveTextContent(/^Sent · /i))
+      const receiptLabel = await canvas.findByText(
+        /^Sent · /i,
+        {},
+        { timeout: 3_000 }
+      )
+      const status = receiptLabel.closest<HTMLElement>('[role="status"]')!
+      await expect(status).toHaveTextContent(/^Sent · /i)
       await expect(status).toHaveAttribute("aria-live", "polite")
       await expect(status).toHaveAttribute("aria-atomic", "true")
       await expect(canvas.queryByText(/^Read by 2$/i)).not.toBeInTheDocument()
@@ -1664,8 +1763,13 @@ export const CommunicationsReceiptsAndReactions: Story = {
   play: async ({ canvas, canvasElement, step }) => {
     const page = within(canvasElement.closest("body")!)
     await step("Summarize the completed group receipt", async () => {
-      const status = await canvas.findByRole("status")
-      await waitFor(() => expect(status).toHaveTextContent(/^Read · /i))
+      const receiptLabel = await canvas.findByText(
+        /^Read · /i,
+        {},
+        { timeout: 3_000 }
+      )
+      const status = receiptLabel.closest<HTMLElement>('[role="status"]')!
+      await expect(status).toHaveTextContent(/^Read · /i)
       await expect(status).toHaveAttribute("aria-live", "polite")
       await expect(status).toHaveAttribute("aria-atomic", "true")
       await expect(canvas.queryByText(/^Read by 45$/i)).not.toBeInTheDocument()
@@ -1694,7 +1798,11 @@ export const CommunicationsReceiptsAndReactions: Story = {
       await expect(describedTooltip).toHaveTextContent(
         "Grace Liang, Marcus Bennett, Sam Okafor"
       )
-      await expect(reactionTooltips[0]).toBeVisible()
+      const visibleReactionTooltip =
+        reactionTooltips.find((tooltip) => tooltip !== describedTooltip) ??
+        describedTooltip
+      await expect(visibleReactionTooltip).toBeDefined()
+      await expect(visibleReactionTooltip!).toBeVisible()
       await userEvent.tab()
     })
 
@@ -1723,13 +1831,30 @@ export const CommunicationsReceiptsAndReactions: Story = {
       )
       await expect(readers.scrollHeight).toBe(readers.clientHeight)
       await expect(readers).not.toHaveAttribute("tabindex")
-      await expect(within(readers).getByText("Grace Liang")).toBeVisible()
+      const grace = within(readers).getByRole("link", {
+        name: /Grace Liang/i,
+      })
+      await expect(grace).toHaveAttribute("href", "/people/u_grace")
       await expect(within(readers).getByText("Marcus Bennett")).toBeVisible()
       await expect(within(readers).getByText("Sam Okafor")).toBeVisible()
       const backButton = page.getByRole("button", { name: /back/i })
       await expect(backButton).toHaveFocus()
+
+      await userEvent.hover(grace)
+      await waitFor(() => expect(page.getByText("Data Analyst")).toBeVisible())
+      await expect(
+        page.getByRole("link", { name: /view profile/i })
+      ).toHaveAttribute("href", "/people/u_grace")
+      await userEvent.unhover(grace)
+      await waitFor(() =>
+        expect(page.queryByText("Data Analyst")).not.toBeInTheDocument()
+      )
+
       await userEvent.tab()
       await expect(infoPanel).toHaveFocus()
+      await userEvent.tab()
+      await expect(grace).toHaveFocus()
+      await waitFor(() => expect(page.getByText("Data Analyst")).toBeVisible())
       infoPanel.scrollTop = infoPanel.scrollHeight
       await expect(infoPanel.scrollTop).toBeGreaterThan(0)
       const lastReader = within(readers).getByText("Demo Reader 42")

--- a/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
@@ -28,12 +28,37 @@ import * as Icons from "@/icons/app"
 import ArrowRight from "@/icons/app/ArrowRight"
 import ExternalLink from "@/icons/app/ExternalLink"
 import Marketplace from "@/icons/app/Marketplace"
+import { useAiChat } from "@/kits/ai/F0AiChat"
+import {
+  MockAiChatRuntimeProvider,
+  MockConnectedChatHeader,
+  MockConnectedChatInput,
+  MockConnectedMessagesContainer,
+  useMockAiChatRuntime,
+} from "@/kits/ai/F0AiChat/__stories__/_mock"
+import {
+  type CandidateProfile,
+  type ExpenseProfile,
+  type F0AiChatWelcomeCard,
+  type JobPostingProfile,
+  type RequisitionProfile,
+  type PersonProfile,
+  type UploadedFile,
+  type VacancyProfile,
+} from "@/kits/ai/F0AiChat/types"
+import { F0AiChatCreditsButton } from "@/kits/ai/F0AiChatHeader"
+import {
+  ThreadItem,
+  ThreadListSkeleton,
+  useChatHistory,
+} from "@/kits/ai/F0AiChatHistory"
+import { WelcomeScreenCardsRow } from "@/kits/ai/F0AiChatTextArea/components/WelcomeScreenCardsRow"
 import { HomeLayout } from "@/layouts/HomeLayout"
 import * as HomeLayoutStories from "@/layouts/HomeLayout/index.stories"
+import { getEmojiLabel } from "@/lib/emojis"
 import { F0Box } from "@/lib/F0Box"
 import { mockTranscribe } from "@/lib/storybook-utils/ai-mocks"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
-import { getEmojiLabel } from "@/lib/emojis"
 import { Page } from "@/patterns/Navigation/Page"
 import * as PageStories from "@/patterns/Navigation/Page/index.stories"
 import { exampleActions } from "@/patterns/Navigation/Sidebar/Chats/index.stories"
@@ -55,32 +80,6 @@ import { SearchBar } from "@/patterns/Navigation/Sidebar/Searchbar"
 import { Sidebar } from "@/patterns/Navigation/Sidebar/Sidebar"
 import { SidebarTabPanel } from "@/patterns/Navigation/Sidebar/TabPanel"
 import { SidebarTabs } from "@/patterns/Navigation/Sidebar/Tabs"
-import { DaytimePage } from "@/sds/Home/DaytimePage"
-import { useAiChat } from "@/kits/ai/F0AiChat"
-import {
-  MockAiChatRuntimeProvider,
-  MockConnectedChatHeader,
-  MockConnectedChatInput,
-  MockConnectedMessagesContainer,
-  useMockAiChatRuntime,
-} from "@/kits/ai/F0AiChat/__stories__/_mock"
-import {
-  type CandidateProfile,
-  type ExpenseProfile,
-  type F0AiChatWelcomeCard,
-  type JobPostingProfile,
-  type RequisitionProfile,
-  type PersonProfile,
-  type UploadedFile,
-  type VacancyProfile,
-} from "@/kits/ai/F0AiChat/types"
-import { WelcomeScreenCardsRow } from "@/kits/ai/F0AiChatTextArea/components/WelcomeScreenCardsRow"
-import { F0AiChatCreditsButton } from "@/kits/ai/F0AiChatHeader"
-import {
-  ThreadItem,
-  ThreadListSkeleton,
-  useChatHistory,
-} from "@/kits/ai/F0AiChatHistory"
 import {
   F0Chat,
   F0ChatProvider,
@@ -88,14 +87,15 @@ import {
   type F0ChatRuntime,
 } from "@/sds/chat/F0Chat"
 import { MessageStatus } from "@/sds/chat/F0Chat/components/MessageStatus"
+import { MOCK_MAX_FILE_SIZE_BYTES } from "@/sds/chat/F0Chat/mocks/constants"
 import {
   MockChatAppProvider,
   useConversationRuntime,
   useMockChatGroups,
 } from "@/sds/chat/F0Chat/mocks/MockChatApp"
-import { MOCK_MAX_FILE_SIZE_BYTES } from "@/sds/chat/F0Chat/mocks/constants"
 import { SEED_BY_ID } from "@/sds/chat/F0Chat/mocks/mockSeeds"
 import { useDemoHeaderActions } from "@/sds/chat/F0Chat/mocks/useDemoHeaderActions"
+import { DaytimePage } from "@/sds/Home/DaytimePage"
 import { Action } from "@/ui/Action"
 
 import { ApplicationFrame } from "./index"
@@ -1658,6 +1658,223 @@ export const CommunicationsFileSizeLimit: Story = {
 }
 
 /**
+ * The final group message combines two inline videos and a regular file. Each
+ * F0VideoPlayer takes the full conversation width up to its 36rem media limit,
+ * stacks vertically, and exposes its own playback and fullscreen controls.
+ */
+export const CommunicationsVideoAttachments: Story = {
+  name: "Communications — inline video attachments",
+  tags: ["f0chat-videos"],
+  render: (args) => (
+    <MockAiChatRuntimeProvider>
+      <MockChatAppProvider>
+        <ApplicationFrame
+          ai={{
+            ...withMockChatSlots(args.ai),
+            side: "left",
+            historyEnabled: false,
+            chatHeader: <MockConnectedChatHeader compact />,
+          }}
+          aiPromotion={args.aiPromotion}
+          sidebar={
+            <ConversationsSidebar
+              initialTab="messages"
+              autoOpenConvId="grp-reporting"
+            />
+          }
+        >
+          <Page
+            {...PageStories.Default.args}
+            header={communicationsPageHeader}
+          />
+        </ApplicationFrame>
+      </MockChatAppProvider>
+    </MockAiChatRuntimeProvider>
+  ),
+  play: async ({ canvas, step }) => {
+    await step("Render both videos as wide inline players", async () => {
+      const players = await canvas.findAllByRole(
+        "region",
+        { name: /Video player:/ },
+        { timeout: 5_000 }
+      )
+      await expect(players).toHaveLength(2)
+
+      const widths = players.map(
+        (player) => player.getBoundingClientRect().width
+      )
+      for (const width of widths) {
+        await expect(width).toBeGreaterThan(0)
+        await expect(width).toBeLessThanOrEqual(576)
+      }
+      await expect(Math.abs(widths[0] - widths[1])).toBeLessThanOrEqual(1)
+
+      const cards = players.map(
+        (player) =>
+          player.closest<HTMLElement>('[data-testid="chat-video-attachment"]')!
+      )
+      for (const [index, player] of players.entries()) {
+        const card = cards[index]
+        const column = card.parentElement!
+        await expect(
+          Math.abs(
+            card.getBoundingClientRect().width -
+              Math.min(column.getBoundingClientRect().width, 576)
+          )
+        ).toBeLessThanOrEqual(1)
+
+        const controls = within(player)
+        await expect(
+          controls.getByRole("button", { name: "Play" })
+        ).toBeVisible()
+        await expect(
+          controls.getByRole("button", { name: "Enter fullscreen" })
+        ).toBeVisible()
+        const video = player.querySelector("video")
+        await expect(video).not.toBeNull()
+        await expect(video!).toHaveAttribute("src", "/Big_Buck_Bunny_alt.webm")
+        await expect(video!).toHaveAttribute("poster", "/video-poster.webp")
+      }
+      await expect(cards[1].getBoundingClientRect().top).toBeGreaterThanOrEqual(
+        cards[0].getBoundingClientRect().bottom
+      )
+
+      await expect(canvas.getByText("kickoff-deck.pptx")).toBeVisible()
+    })
+  },
+}
+
+/**
+ * Composer attachment gallery. Selecting seven files at once shows immediate
+ * local previews for image, video, PDF, spreadsheet, Word and text content
+ * while a regular PowerPoint keeps the F0FileItem fallback. The preview shape
+ * remains stable when the simulated upload replaces each local URL.
+ */
+export const CommunicationsComposerAttachmentPreviews: Story = {
+  name: "Communications — composer attachment previews",
+  tags: ["f0chat-composer-attachments"],
+  render: (args) => (
+    <MockAiChatRuntimeProvider>
+      <MockChatAppProvider>
+        <ApplicationFrame
+          ai={{
+            ...withMockChatSlots(args.ai),
+            side: "left",
+            historyEnabled: false,
+            chatHeader: <MockConnectedChatHeader compact />,
+          }}
+          aiPromotion={args.aiPromotion}
+          sidebar={
+            <ConversationsSidebar
+              initialTab="messages"
+              autoOpenConvId="grp-reporting"
+            />
+          }
+        >
+          <Page
+            {...PageStories.Default.args}
+            header={communicationsPageHeader}
+          />
+        </ApplicationFrame>
+      </MockChatAppProvider>
+    </MockAiChatRuntimeProvider>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const page = within(canvasElement.closest("body")!)
+
+    await step("Preview every supported composer attachment", async () => {
+      await page.findByRole("button", { name: /attach file/i })
+      const [videoBlob, imageBlob, pdfBlob, sheetBlob, docxBlob, textBlob] =
+        await Promise.all(
+          [
+            "/Big_Buck_Bunny_alt.webm",
+            "/video-poster.webp",
+            "/f0-pdf-viewer-sample.pdf",
+            "/f0-document-sample.xlsx",
+            "/f0-document-sample.docx",
+            "/f0-document-sample.md",
+          ].map(async (url) => (await fetch(url)).blob())
+        )
+      const files = [
+        new File([videoBlob], "walkthrough.webm", { type: "video/webm" }),
+        new File([imageBlob], "cover.webp", { type: "image/webp" }),
+        new File([pdfBlob], "quarterly-report.pdf", {
+          type: "application/pdf",
+        }),
+        new File([sheetBlob], "raw-data.xlsx", {
+          type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        }),
+        new File([docxBlob], "offer-letter.docx", {
+          type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        }),
+        new File([textBlob], "RELEASE-NOTES.md", { type: "text/markdown" }),
+        new File(["deck"], "kickoff-deck.pptx", {
+          type: "application/vnd.ms-powerpoint",
+        }),
+      ]
+      const fileInput = canvasElement
+        .closest("body")!
+        .querySelector<HTMLInputElement>('input[type="file"]')!
+
+      await userEvent.upload(fileInput, files)
+
+      await expect(
+        await page.findByTestId("chat-composer-image-preview")
+      ).toBeVisible()
+      await expect(
+        page.getByTestId("chat-composer-video-preview")
+      ).toBeVisible()
+      await expect(
+        page.getAllByTestId("chat-composer-document-preview")
+      ).toHaveLength(4)
+      await expect(
+        page.getByTestId("chat-composer-file-preview")
+      ).toHaveTextContent("kickoff-deck.pptx")
+      await expect(
+        page.getAllByTestId("chat-composer-attachment-uploading")
+      ).toHaveLength(7)
+
+      await waitFor(
+        () =>
+          expect(
+            page.queryAllByTestId("chat-composer-attachment-uploading")
+          ).toHaveLength(0),
+        { timeout: 4_000 }
+      )
+      await expect(
+        page.getAllByTestId("chat-composer-image-preview")
+      ).toHaveLength(1)
+      await expect(
+        page.getAllByTestId("chat-composer-video-preview")
+      ).toHaveLength(1)
+      await expect(
+        page.getAllByTestId("chat-composer-document-preview")
+      ).toHaveLength(4)
+      await expect(
+        page.getAllByTestId("chat-composer-file-preview")
+      ).toHaveLength(1)
+      await expect(
+        page.getAllByRole("button", { name: /^Remove /i })
+      ).toHaveLength(7)
+
+      const strip = page.getByTestId("chat-composer-attachments")
+      await expect(strip.scrollWidth).toBeGreaterThan(strip.clientWidth)
+      strip.scrollLeft = strip.scrollWidth
+      await expect(strip.scrollLeft).toBeGreaterThan(0)
+      const lastAttachment = page.getByTestId("chat-composer-file-preview")
+      const stripRect = strip.getBoundingClientRect()
+      const lastAttachmentRect = lastAttachment.getBoundingClientRect()
+      await expect(lastAttachmentRect.left).toBeGreaterThanOrEqual(
+        stripRect.left
+      )
+      await expect(lastAttachmentRect.right).toBeLessThanOrEqual(
+        stripRect.right
+      )
+    })
+  },
+}
+
+/**
  * The final group message has only two of the expected 45 receipts. The footer
  * remains "Sent · time"; reader identities stay available from message Info.
  */
@@ -1798,11 +2015,21 @@ export const CommunicationsReceiptsAndReactions: Story = {
       await expect(describedTooltip).toHaveTextContent(
         "Grace Liang, Marcus Bennett, Sam Okafor"
       )
-      const visibleReactionTooltip =
-        reactionTooltips.find((tooltip) => tooltip !== describedTooltip) ??
-        describedTooltip
-      await expect(visibleReactionTooltip).toBeDefined()
-      await expect(visibleReactionTooltip!).toBeVisible()
+      await waitFor(() => {
+        const visibleReactionTooltip = page
+          .getAllByRole("tooltip")
+          .filter((tooltip) =>
+            tooltip.textContent?.includes(
+              "Grace Liang, Marcus Bennett, Sam Okafor"
+            )
+          )
+          .find((tooltip) => {
+            const rect = tooltip.getBoundingClientRect()
+            return rect.width > 0 && rect.height > 0
+          })
+        expect(visibleReactionTooltip).toBeDefined()
+        expect(visibleReactionTooltip!).toBeVisible()
+      })
       await userEvent.tab()
     })
 
@@ -1837,7 +2064,7 @@ export const CommunicationsReceiptsAndReactions: Story = {
       await expect(grace).toHaveAttribute("href", "/people/u_grace")
       await expect(within(readers).getByText("Marcus Bennett")).toBeVisible()
       await expect(within(readers).getByText("Sam Okafor")).toBeVisible()
-      const backButton = page.getByRole("button", { name: /back/i })
+      const backButton = page.getByRole("button", { name: /^back$/i })
       await expect(backButton).toHaveFocus()
 
       await userEvent.hover(grace)

--- a/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
@@ -1747,8 +1747,9 @@ export const CommunicationsVideoAttachments: Story = {
 /**
  * Composer attachment gallery. Selecting seven files at once shows immediate
  * local previews for image, video, PDF, spreadsheet, Word and text content
- * while a regular PowerPoint keeps the F0FileItem fallback. The preview shape
- * remains stable when the simulated upload replaces each local URL.
+ * while a regular PowerPoint keeps a file icon fallback. Every file uses the
+ * same compact square footprint as an image, and that shape remains stable
+ * when the simulated upload replaces each local URL.
  */
 export const CommunicationsComposerAttachmentPreviews: Story = {
   name: "Communications — composer attachment previews",
@@ -1858,6 +1859,16 @@ export const CommunicationsComposerAttachmentPreviews: Story = {
       ).toHaveLength(7)
 
       const strip = page.getByTestId("chat-composer-attachments")
+      const compactPreviews = [
+        page.getByTestId("chat-composer-image-preview"),
+        page.getByTestId("chat-composer-video-preview"),
+        ...page.getAllByTestId("chat-composer-document-preview"),
+        page.getByTestId("chat-composer-file-preview"),
+      ]
+      for (const preview of compactPreviews) {
+        await expect(preview.getBoundingClientRect().width).toBe(64)
+        await expect(preview.getBoundingClientRect().height).toBe(64)
+      }
       await expect(strip.scrollWidth).toBeGreaterThan(strip.clientWidth)
       strip.scrollLeft = strip.scrollWidth
       await expect(strip.scrollLeft).toBeGreaterThan(0)

--- a/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
@@ -891,6 +891,59 @@ export const CommunicationsPanelLeft: Story = {
 }
 
 /**
+ * A group without an emoji or uploaded image uses the same ＃ fallback in the
+ * conversations sidebar and the open chat header.
+ */
+export const CommunicationsGroupAvatarFallback: Story = {
+  name: "Communications — group avatar fallback",
+  tags: ["f0chat-group-avatar-fallback"],
+  render: (args) => (
+    <MockAiChatRuntimeProvider>
+      <MockChatAppProvider>
+        <ApplicationFrame
+          ai={{
+            ...withMockChatSlots(args.ai),
+            side: "left",
+            historyEnabled: false,
+            chatHeader: <MockConnectedChatHeader compact />,
+          }}
+          aiPromotion={args.aiPromotion}
+          sidebar={<ConversationsSidebar initialTab="messages" />}
+        >
+          <Page
+            {...PageStories.Default.args}
+            header={communicationsPageHeader}
+          />
+        </ApplicationFrame>
+      </MockChatAppProvider>
+    </MockAiChatRuntimeProvider>
+  ),
+  play: async ({ canvasElement, step }) => {
+    const page = within(canvasElement.closest("body")!)
+
+    await step("Use the same fallback in the sidebar and header", async () => {
+      const sidebarFallback = await page.findByTestId(
+        "sidebar-group-avatar-fallback"
+      )
+      await expect(
+        sidebarFallback.getBoundingClientRect().width
+      ).toBeGreaterThan(0)
+      await expect(sidebarFallback).toHaveTextContent("＃")
+      await userEvent.click(
+        await page.findByRole("button", { name: "Leadership" })
+      )
+      const headerFallback = await page.findByTestId(
+        "chat-group-avatar-fallback"
+      )
+      await expect(
+        headerFallback.getBoundingClientRect().width
+      ).toBeGreaterThan(0)
+      await expect(headerFallback).toHaveTextContent("＃")
+    })
+  },
+}
+
+/**
  * The standalone AI assistant: no communications sidebar, the chat docked on the
  * right as a resizable side panel, with the full feature set (credits, file
  * attachments, dictation, entity refs, disclaimer + quick actions footer).
@@ -2173,7 +2226,7 @@ export const Snapshot: Story = {
           sidebar={
             <ConversationsSidebar
               initialTab="messages"
-              autoOpenConvId="grp-reporting"
+              autoOpenConvId="grp-leadership"
             />
           }
         >
@@ -2185,6 +2238,22 @@ export const Snapshot: Story = {
     </MockAiChatRuntimeProvider>
   ),
   play: async ({ canvas, step }) => {
+    await step("Show the group avatar fallback", async () => {
+      const sidebarFallback = await canvas.findByTestId(
+        "sidebar-group-avatar-fallback"
+      )
+      const headerFallback = await canvas.findByTestId(
+        "chat-group-avatar-fallback"
+      )
+
+      await expect(
+        sidebarFallback.getBoundingClientRect().width
+      ).toBeGreaterThan(0)
+      await expect(
+        headerFallback.getBoundingClientRect().width
+      ).toBeGreaterThan(0)
+    })
+
     await step("Show partial and completed group receipt footers", async () => {
       const partial = within(
         await canvas.findByRole("region", { name: "Partial group receipts" })

--- a/packages/react/src/patterns/Navigation/Sidebar/Chats/SidebarChatItem.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/Chats/SidebarChatItem.tsx
@@ -113,7 +113,7 @@ export const SidebarChatItem = ({
               // shrunk inside the bordered avatar box.
               <span
                 aria-hidden={showGroupFallback || undefined}
-                className="flex size-5 items-center justify-center"
+                className="flex size-5 text-lg font-medium items-center justify-center text-f1-foreground-secondary"
                 data-testid={
                   showGroupFallback
                     ? "sidebar-group-avatar-fallback"

--- a/packages/react/src/patterns/Navigation/Sidebar/Chats/SidebarChatItem.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/Chats/SidebarChatItem.tsx
@@ -80,6 +80,15 @@ export const SidebarChatItem = ({
 
   // Status — people only; the consumer provides the emoji/icon + label.
   const status = chat.avatar?.type === "person" ? chat.status : undefined
+  const showGroupFallback =
+    (chat.avatar?.type === "team" || chat.avatar?.type === "company") &&
+    !chat.avatar.src
+  const identityEmoji =
+    chat.avatar?.type === "emoji"
+      ? chat.avatar.emoji
+      : showGroupFallback
+        ? "＃"
+        : null
 
   return (
     <div className="group/row relative">
@@ -99,11 +108,19 @@ export const SidebarChatItem = ({
           <Dots />
         ) : chat.avatar ? (
           <div className="relative flex flex-shrink-0 items-center">
-            {chat.avatar.type === "emoji" ? (
+            {identityEmoji ? (
               // Emoji groups show the glyph alone (no avatar chrome) so it isn't
               // shrunk inside the bordered avatar box.
-              <span className="flex size-5 items-center justify-center">
-                <EmojiImage emoji={chat.avatar.emoji} size="sm" />
+              <span
+                aria-hidden={showGroupFallback || undefined}
+                className="flex size-5 items-center justify-center"
+                data-testid={
+                  showGroupFallback
+                    ? "sidebar-group-avatar-fallback"
+                    : undefined
+                }
+              >
+                <EmojiImage emoji={identityEmoji} size="sm" />
               </span>
             ) : (
               <F0Avatar size="xs" avatar={chat.avatar} />

--- a/packages/react/src/patterns/Navigation/Sidebar/Chats/__tests__/SidebarChatList.test.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/Chats/__tests__/SidebarChatList.test.tsx
@@ -57,6 +57,54 @@ const renderList = (initialActiveChatId?: string) =>
   )
 
 describe("SidebarChatList", () => {
+  it("uses a hash glyph for a group without an emoji or custom image", () => {
+    renderList()
+
+    expect(
+      screen.getByTestId("sidebar-group-avatar-fallback")
+    ).toHaveTextContent("＃")
+    expect(screen.queryByRole("img", { name: "General" })).toBeNull()
+  })
+
+  it("keeps explicit group emoji and custom images", () => {
+    const { container } = render(
+      <SidebarChatProvider
+        initialGroups={[
+          {
+            id: "groups",
+            title: "Groups",
+            chats: [
+              {
+                id: "emoji",
+                label: "Product",
+                avatar: { type: "emoji", emoji: "🧭" },
+              },
+              {
+                id: "image",
+                label: "Design",
+                avatar: {
+                  type: "team",
+                  name: "Design",
+                  src: "/design.png",
+                },
+              },
+            ],
+          },
+        ]}
+      >
+        <SidebarChatList emptyState={defaultEmptyState} />
+      </SidebarChatProvider>
+    )
+
+    expect(
+      screen.queryByTestId("sidebar-group-avatar-fallback")
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole("img", { name: "🧭" })).toBeInTheDocument()
+    expect(
+      container.querySelector('[role="img"][aria-hidden="true"]')
+    ).toBeInTheDocument()
+  })
+
   it("shows a blank state when there are no chats", () => {
     render(
       <SidebarChatProvider initialGroups={[]}>

--- a/packages/react/src/patterns/Navigation/Sidebar/Chats/index.stories.tsx
+++ b/packages/react/src/patterns/Navigation/Sidebar/Chats/index.stories.tsx
@@ -131,7 +131,7 @@ export const exampleGroups: SidebarChatGroup[] = [
       {
         id: "devops-sre",
         label: "DevOps & SRE",
-        // No emoji → company avatar built from the group name (its initials).
+        // No emoji or image → the shared chat fallback is a ＃ glyph.
         avatar: { type: "company", name: "DevOps & SRE" },
         unreadCount: 2,
       },

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
@@ -131,6 +131,7 @@ F0Chat renders a transport-agnostic direct or group conversation. The host provi
 ### Behavior
 
 - WHEN an own group message has `readBy` → THEN F0 displays its list length and shows each reader in the message Info panel.
+- WHEN reader identities exceed the Info panel height → THEN the complete Info content scrolls as one region and the reader list does not create a nested scroll.
 - WHEN `readBy` is unavailable but `readByCount` exists → THEN F0 displays the count without inventing identities.
 - WHEN reaction users are incomplete and `loadReactionUsers` exists → THEN F0 loads and caches identities by channel, message, emoji, and reaction count.
 - WHEN the reaction count or channel changes → THEN F0 invalidates the related identity cache.
@@ -147,7 +148,7 @@ Use a group runtime to provide member mentions, read receipts, and reaction memb
 
 ### Keyboard interaction
 
-The message action menu opens the Info panel with standard button navigation. Reader lists become focusable when their bounded height makes them independently scrollable.
+The message action menu opens the Info panel with standard button navigation. Its content is one focusable region; when many reader identities exceed the available height, that complete region scrolls instead of introducing a nested scroll inside the reader list.
 
 ### Screen reader behavior
 

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
@@ -30,6 +30,23 @@ F0Chat renders a transport-agnostic direct or group conversation. The host provi
     <tbody>
       <tr>
         <td>
+          <code>channel.memberCount</code>
+        </td>
+        <td>
+          <code>number</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>
+          Total group members, including the current user. F0 expects{" "}
+          <code>readBy</code> and <code>readByCount</code> to contain unique
+          other members, and compares them with <code>memberCount - 1</code>{" "}
+          before showing the all-read footer state. Without a member count, F0
+          trusts the host-provided message status.
+        </td>
+      </tr>
+      <tr>
+        <td>
           <code>message.readBy</code>
         </td>
         <td>
@@ -131,6 +148,9 @@ F0Chat renders a transport-agnostic direct or group conversation. The host provi
 ### Behavior
 
 - WHEN an own group message has `readBy` → THEN F0 displays its list length and shows each reader in the message Info panel.
+- WHEN a sent group message is still missing readers → THEN its footer shows `Sent · time` without exposing a count.
+- WHEN every other channel member has read the message → THEN its footer advances to `Read · time`.
+- WHEN `memberCount` is known but receipt data is missing → THEN F0 keeps the footer at `Sent · time`; when `memberCount` is unavailable, F0 trusts the host-provided message status.
 - WHEN reader identities exceed the Info panel height → THEN the complete Info content scrolls as one region and the reader list does not create a nested scroll.
 - WHEN `readBy` is unavailable but `readByCount` exists → THEN F0 displays the count without inventing identities.
 - WHEN reaction users are incomplete and `loadReactionUsers` exists → THEN F0 loads and caches identities by channel, message, emoji, and reaction count.
@@ -152,4 +172,4 @@ The message action menu opens the Info panel with standard button navigation. It
 
 ### Screen reader behavior
 
-Reaction buttons announce their emoji label, count, and pressed state. Group reader lists use the localized “Read by” count as their accessible name.
+Reaction buttons announce their emoji label, count, and pressed state. Group reader lists use the localized “Read by” count as their accessible name. The final-message footer is a polite, atomic status region, so assistive technology announces asynchronous transitions from “Sent” to “Read” together with the message time.

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
@@ -191,9 +191,9 @@ F0Chat renders a transport-agnostic direct or group conversation. The host provi
 - WHEN `maxFileSizeBytes` is omitted → THEN F0 does not impose a file-size limit.
 - WHEN files are pasted into the composer with `Cmd+V` or `Ctrl+V` → THEN F0 uploads them through the same validation path as selected and dropped files.
 - WHEN pasted clipboard content contains no files → THEN F0 preserves the textarea's native text paste behavior.
-- WHEN an image, video, PDF, spreadsheet, Word document, or text file enters the composer → THEN F0 renders a local preview immediately while the upload continues.
+- WHEN an image, video, PDF, spreadsheet, Word document, or text file enters the composer → THEN F0 renders an image-sized square preview immediately while the upload continues.
 - WHEN an uploaded attachment replaces its local composer preview → THEN F0 preserves the preview's stable key and shape, swaps to the host URL, and revokes the temporary object URL.
-- WHEN a composer attachment has no supported preview or its document exceeds the client-side preview limit → THEN F0 keeps the F0FileItem fallback.
+- WHEN a composer attachment has no supported preview or its document exceeds the client-side preview limit → THEN F0 keeps the same compact square footprint with a file-type icon.
 - WHEN a pending composer attachment is removed or its upload fails → THEN F0 revokes its local object URL and does not restore it if the upload resolves later.
 - WHEN several previews exceed the composer width → THEN F0 keeps them in one focusable horizontal strip instead of growing the composer through the transcript.
 - WHEN a completed file has a video MIME type or browser video extension → THEN F0 renders it as an inline F0VideoPlayer with playback and fullscreen controls.

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
@@ -193,6 +193,11 @@ F0Chat renders a transport-agnostic direct or group conversation. The host provi
 - WHEN `maxFileSizeBytes` is omitted → THEN F0 does not impose a file-size limit.
 - WHEN files are pasted into the composer with `Cmd+V` or `Ctrl+V` → THEN F0 uploads them through the same validation path as selected and dropped files.
 - WHEN pasted clipboard content contains no files → THEN F0 preserves the textarea's native text paste behavior.
+- WHEN `:` starts a token in the composer → THEN F0 opens a caret-anchored emoji list and filters it by shortcode, alias, keyword, or name as the query grows.
+- WHEN the emoji autocomplete is open → THEN Arrow Up and Arrow Down move through its options, Enter or Tab inserts the active emoji, and Escape dismisses the current trigger without sending.
+- WHEN an emoji autocomplete option is selected → THEN F0 replaces only the active `:query`, preserves surrounding message text, inserts one separating space, and restores the textarea focus and caret.
+- WHEN an exact shortcode or alias is completed with a closing colon, such as `:smile:` or `:thumbsup:` → THEN F0 converts it in place without requiring the suggestion list.
+- WHEN `:` belongs to another token such as a URL or time → THEN F0 leaves the composer unchanged and does not open emoji suggestions.
 - WHEN an image, PDF, spreadsheet, Word document, or text file enters the composer → THEN F0 renders an image-sized square preview immediately while the upload continues.
 - WHEN a video enters the composer → THEN F0 keeps the same compact height but renders a wider 16:9 preview so its media type is visually distinct.
 - WHEN an uploaded attachment replaces its local composer preview → THEN F0 preserves the preview's stable key and shape, swaps to the host URL, and revokes the temporary object URL.
@@ -202,6 +207,9 @@ F0Chat renders a transport-agnostic direct or group conversation. The host provi
 - WHEN a completed file has a video MIME type or browser video extension → THEN F0 renders it as an inline F0VideoPlayer with playback and fullscreen controls.
 - WHEN one message contains several videos → THEN the players stack vertically and each uses the available width up to 36rem instead of shrinking into a media grid.
 - WHEN a video is still uploading → THEN F0 keeps its file chip and progress state until the upload completes.
+- WHEN a bubble attachment has an inline or document preview → THEN F0 omits the redundant download action from the bubble; download remains available inside the document viewer or video-player controls, while files without a preview and failed previews keep their downloadable file chip.
+- WHEN a voice attachment is narrower than its waveform → THEN the bars compress and any residual excess is clipped inside the seek area, preserving the fixed time/speed slot.
+- WHEN the reader wheels toward older messages → THEN F0 pauses bottom following immediately and keeps it paused through asynchronous attachment growth until the reader returns to the true bottom edge, explicitly jumps to the bottom, or sends a new message.
 
 ### Usage examples
 
@@ -211,18 +219,40 @@ Use a group runtime to provide member mentions, read receipts, and reaction memb
 
 <Canvas of={Stories.Group} />
 
+**Emoji autocomplete**
+
+Type `:` followed by an emoji shortcode or name. Select a result with the
+keyboard or pointer without leaving the composer.
+
+<Canvas of={Stories.EmojiAutocomplete} />
+
+**Document attachments**
+
+Previewable documents open from a snapshot card into their fullscreen viewer.
+Non-previewable files remain downloadable file chips.
+
+<Canvas of={Stories.WithDocumentAttachments} />
+
 **Video attachments**
 
 Videos play directly inside the conversation. The host can provide a poster,
 captions, audio descriptions, and localized sources through the file attachment.
+Download lives in the player controls instead of floating over the bubble.
 
 <Canvas of={Stories.WithVideoAttachments} />
+
+**Compact voice attachments**
+
+In a minimized chat, the waveform yields its width before the duration or
+playback-speed slot can overflow.
+
+<Canvas of={Stories.CompactVoiceAttachment} />
 
 ## Accessibility
 
 ### Keyboard interaction
 
-The message action menu opens the Info panel with standard button navigation. Its content is one focusable region; when many reader identities exceed the available height, that complete region scrolls instead of introducing a nested scroll inside the reader list. The composer attachment strip is also focusable, supports horizontal keyboard scrolling, and receives focus after removing an attachment.
+The message action menu opens the Info panel with standard button navigation. Its content is one focusable region; when many reader identities exceed the available height, that complete region scrolls instead of introducing a nested scroll inside the reader list. The composer attachment strip is also focusable, supports horizontal keyboard scrolling, and receives focus after removing an attachment. Emoji suggestions keep focus in the textarea, expose the active option through `aria-activedescendant`, and use Arrow Up, Arrow Down, Enter, Tab, and Escape without intercepting ordinary message text.
 
 ### Screen reader behavior
 
@@ -230,6 +260,12 @@ Reaction buttons announce their emoji label, count, and pressed state. Group rea
 
 Attachment actions include the filename in their accessible names. Each video
 player is contained in a figure named after its file and exposes a contextual
-player-region name. Prerecorded videos should provide both
+player-region name; its optional download remains keyboard-accessible inside
+the player controls. Prerecorded videos should provide both
 `videoContent.captions` and audio descriptions where the visuals convey
 meaning; use `videoSilent` only when the source genuinely has no audio.
+
+Voice notes expose their waveform as a seek slider. Use the arrow keys to move
+through the recording and Home or End to jump to either edge. The playback
+speed button remains in the tab order and replaces the duration while it has
+keyboard focus; its accessible name includes the current speed.

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
@@ -1,0 +1,154 @@
+import { Canvas, Meta, Controls, Unstyled } from "@storybook/addon-docs/blocks"
+import * as Stories from "./F0Chat.stories"
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
+
+<Meta of={Stories} />
+
+# F0Chat
+
+F0Chat renders a transport-agnostic direct or group conversation. The host provides messages, membership, receipts, reactions, and mutations through `F0ChatRuntime`.
+
+## Anatomy
+
+<Canvas of={Stories.Default} />
+
+<Controls of={Stories.Default} />
+
+### Group receipt and reaction contracts
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Field</th>
+        <th className="text-left">Type</th>
+        <th className="text-left">Default</th>
+        <th className="text-left">Required</th>
+        <th className="text-left">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>message.readBy</code>
+        </td>
+        <td>
+          <code>F0ChatUser[]</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>
+          Other group members who read the message. F0 derives the displayed
+          count from this list.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>message.readByCount</code>
+        </td>
+        <td>
+          <code>number</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>Count fallback for hosts that cannot provide reader identities.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>runtime.loadReactionUsers</code>
+        </td>
+        <td>
+          <code>
+            (messageId: string, emoji: string) =&gt; Promise&lt;F0ChatUser[]&gt;
+          </code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>
+          Resolves complete reaction membership on first hover or keyboard
+          focus.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+## Guidelines
+
+### Design best practices
+
+**When to use**
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Situation</th>
+        <th className="text-left">Use F0Chat when</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Product communications</td>
+        <td>A host integration supplies conversation state and mutations.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+**When not to use**
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Situation</th>
+        <th className="text-left">Use instead</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Static activity history</td>
+        <td>A timeline or activity-feed pattern.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+**Do's and don'ts**
+
+<DoDonts
+  do={{
+    description:
+      "Derive readBy from transport read pointers and exclude the message author.",
+  }}
+  dont={{
+    description:
+      "Treat delivery acknowledgement as proof that a member read the message.",
+  }}
+/>
+
+### Behavior
+
+- WHEN an own group message has `readBy` → THEN F0 displays its list length and shows each reader in the message Info panel.
+- WHEN `readBy` is unavailable but `readByCount` exists → THEN F0 displays the count without inventing identities.
+- WHEN reaction users are incomplete and `loadReactionUsers` exists → THEN F0 loads and caches identities by channel, message, emoji, and reaction count.
+- WHEN the reaction count or channel changes → THEN F0 invalidates the related identity cache.
+
+### Usage examples
+
+**Group communications**
+
+Use a group runtime to provide member mentions, read receipts, and reaction membership.
+
+<Canvas of={Stories.Group} />
+
+## Accessibility
+
+### Keyboard interaction
+
+The message action menu opens the Info panel with standard button navigation. Reader lists become focusable when their bounded height makes them independently scrollable.
+
+### Screen reader behavior
+
+Reaction buttons announce their emoji label, count, and pressed state. Group reader lists use the localized “Read by” count as their accessible name.

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
@@ -185,7 +185,7 @@ F0Chat renders a transport-agnostic direct or group conversation. The host provi
 - WHEN every other channel member has read the message → THEN its footer advances to `Read · time`.
 - WHEN `memberCount` is known but receipt data is missing → THEN F0 keeps the footer at `Sent · time`; when `memberCount` is unavailable, F0 trusts the host-provided message status.
 - WHEN reader identities exceed the Info panel height → THEN the complete Info content scrolls as one region and the reader list does not create a nested scroll.
-- WHEN hovering or focusing a reader identity in message Info → THEN F0 displays the same profile card used by message authors; readers with a profile are links, preserving a persistent keyboard and touch action.
+- WHEN reader identities appear in message Info → THEN each row displays only the reader avatar and name, without links or hover cards.
 - WHEN `readBy` is unavailable but `readByCount` exists → THEN F0 displays the count without inventing identities.
 - WHEN reaction users are incomplete and `loadReactionUsers` exists → THEN F0 loads and caches identities by channel, message, emoji, and reaction count.
 - WHEN the reaction count or channel changes → THEN F0 invalidates the related identity cache.

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
@@ -14,7 +14,7 @@ F0Chat renders a transport-agnostic direct or group conversation. The host provi
 
 <Controls of={Stories.Default} />
 
-### Group receipt and reaction contracts
+### Receipt, reaction, and upload contracts
 
 <Unstyled>
   <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
@@ -86,6 +86,20 @@ F0Chat renders a transport-agnostic direct or group conversation. The host provi
           focus.
         </td>
       </tr>
+      <tr>
+        <td>
+          <code>runtime.maxFileSizeBytes</code>
+        </td>
+        <td>
+          <code>number</code>
+        </td>
+        <td>Unlimited</td>
+        <td>—</td>
+        <td>
+          Maximum size of each selected, dropped, or pasted file, in bytes. The
+          ApplicationFrame mock uses <code>100 * 1024 * 1024</code> (100 MB).
+        </td>
+      </tr>
     </tbody>
   </table>
 </Unstyled>
@@ -152,9 +166,14 @@ F0Chat renders a transport-agnostic direct or group conversation. The host provi
 - WHEN every other channel member has read the message → THEN its footer advances to `Read · time`.
 - WHEN `memberCount` is known but receipt data is missing → THEN F0 keeps the footer at `Sent · time`; when `memberCount` is unavailable, F0 trusts the host-provided message status.
 - WHEN reader identities exceed the Info panel height → THEN the complete Info content scrolls as one region and the reader list does not create a nested scroll.
+- WHEN hovering or focusing a reader identity in message Info → THEN F0 displays the same profile card used by message authors; readers with a profile are links, preserving a persistent keyboard and touch action.
 - WHEN `readBy` is unavailable but `readByCount` exists → THEN F0 displays the count without inventing identities.
 - WHEN reaction users are incomplete and `loadReactionUsers` exists → THEN F0 loads and caches identities by channel, message, emoji, and reaction count.
 - WHEN the reaction count or channel changes → THEN F0 invalidates the related identity cache.
+- WHEN any selected, dropped, or pasted file exceeds `maxFileSizeBytes` → THEN F0 rejects the whole batch before upload and displays the configured limit.
+- WHEN `maxFileSizeBytes` is omitted → THEN F0 does not impose a file-size limit.
+- WHEN files are pasted into the composer with `Cmd+V` or `Ctrl+V` → THEN F0 uploads them through the same validation path as selected and dropped files.
+- WHEN pasted clipboard content contains no files → THEN F0 preserves the textarea's native text paste behavior.
 
 ### Usage examples
 

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
@@ -17,7 +17,7 @@ F0Chat renders a transport-agnostic direct or group conversation. The host provi
 ### Receipt, reaction, and upload contracts
 
 <Unstyled>
-  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+  <table className="dark:text-f1-foreground-inverse/80 mb-8 w-full">
     <thead>
       <tr>
         <th className="text-left">Field</th>
@@ -100,6 +100,23 @@ F0Chat renders a transport-agnostic direct or group conversation. The host provi
           ApplicationFrame mock uses <code>100 * 1024 * 1024</code> (100 MB).
         </td>
       </tr>
+      <tr>
+        <td>
+          <code>file.thumbnailUrl</code>, <code>file.videoContent</code>,{" "}
+          <code>file.videoDefaultLanguage</code>, <code>file.videoSilent</code>
+        </td>
+        <td>
+          <code>string</code>, <code>VideoPlayerContent</code>,{" "}
+          <code>string</code>, <code>boolean</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>
+          Optional poster, accessible caption/description sources, initial
+          language, and genuine no-audio declaration forwarded to F0VideoPlayer
+          when a file has a video MIME type or supported video extension.
+        </td>
+      </tr>
     </tbody>
   </table>
 </Unstyled>
@@ -111,7 +128,7 @@ F0Chat renders a transport-agnostic direct or group conversation. The host provi
 **When to use**
 
 <Unstyled>
-  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+  <table className="dark:text-f1-foreground-inverse/80 mb-8 w-full">
     <thead>
       <tr>
         <th className="text-left">Situation</th>
@@ -130,7 +147,7 @@ F0Chat renders a transport-agnostic direct or group conversation. The host provi
 **When not to use**
 
 <Unstyled>
-  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+  <table className="dark:text-f1-foreground-inverse/80 mb-8 w-full">
     <thead>
       <tr>
         <th className="text-left">Situation</th>
@@ -174,6 +191,14 @@ F0Chat renders a transport-agnostic direct or group conversation. The host provi
 - WHEN `maxFileSizeBytes` is omitted → THEN F0 does not impose a file-size limit.
 - WHEN files are pasted into the composer with `Cmd+V` or `Ctrl+V` → THEN F0 uploads them through the same validation path as selected and dropped files.
 - WHEN pasted clipboard content contains no files → THEN F0 preserves the textarea's native text paste behavior.
+- WHEN an image, video, PDF, spreadsheet, Word document, or text file enters the composer → THEN F0 renders a local preview immediately while the upload continues.
+- WHEN an uploaded attachment replaces its local composer preview → THEN F0 preserves the preview's stable key and shape, swaps to the host URL, and revokes the temporary object URL.
+- WHEN a composer attachment has no supported preview or its document exceeds the client-side preview limit → THEN F0 keeps the F0FileItem fallback.
+- WHEN a pending composer attachment is removed or its upload fails → THEN F0 revokes its local object URL and does not restore it if the upload resolves later.
+- WHEN several previews exceed the composer width → THEN F0 keeps them in one focusable horizontal strip instead of growing the composer through the transcript.
+- WHEN a completed file has a video MIME type or browser video extension → THEN F0 renders it as an inline F0VideoPlayer with playback and fullscreen controls.
+- WHEN one message contains several videos → THEN the players stack vertically and each uses the available width up to 36rem instead of shrinking into a media grid.
+- WHEN a video is still uploading → THEN F0 keeps its file chip and progress state until the upload completes.
 
 ### Usage examples
 
@@ -183,12 +208,25 @@ Use a group runtime to provide member mentions, read receipts, and reaction memb
 
 <Canvas of={Stories.Group} />
 
+**Video attachments**
+
+Videos play directly inside the conversation. The host can provide a poster,
+captions, audio descriptions, and localized sources through the file attachment.
+
+<Canvas of={Stories.WithVideoAttachments} />
+
 ## Accessibility
 
 ### Keyboard interaction
 
-The message action menu opens the Info panel with standard button navigation. Its content is one focusable region; when many reader identities exceed the available height, that complete region scrolls instead of introducing a nested scroll inside the reader list.
+The message action menu opens the Info panel with standard button navigation. Its content is one focusable region; when many reader identities exceed the available height, that complete region scrolls instead of introducing a nested scroll inside the reader list. The composer attachment strip is also focusable, supports horizontal keyboard scrolling, and receives focus after removing an attachment.
 
 ### Screen reader behavior
 
 Reaction buttons announce their emoji label, count, and pressed state. Group reader lists use the localized “Read by” count as their accessible name. The final-message footer is a polite, atomic status region, so assistive technology announces asynchronous transitions from “Sent” to “Read” together with the message time.
+
+Attachment actions include the filename in their accessible names. Each video
+player is contained in a figure named after its file and exposes a contextual
+player-region name. Prerecorded videos should provide both
+`videoContent.captions` and audio descriptions where the visuals convey
+meaning; use `videoSilent` only when the source genuinely has no audio.

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
@@ -191,7 +191,8 @@ F0Chat renders a transport-agnostic direct or group conversation. The host provi
 - WHEN `maxFileSizeBytes` is omitted → THEN F0 does not impose a file-size limit.
 - WHEN files are pasted into the composer with `Cmd+V` or `Ctrl+V` → THEN F0 uploads them through the same validation path as selected and dropped files.
 - WHEN pasted clipboard content contains no files → THEN F0 preserves the textarea's native text paste behavior.
-- WHEN an image, video, PDF, spreadsheet, Word document, or text file enters the composer → THEN F0 renders an image-sized square preview immediately while the upload continues.
+- WHEN an image, PDF, spreadsheet, Word document, or text file enters the composer → THEN F0 renders an image-sized square preview immediately while the upload continues.
+- WHEN a video enters the composer → THEN F0 keeps the same compact height but renders a wider 16:9 preview so its media type is visually distinct.
 - WHEN an uploaded attachment replaces its local composer preview → THEN F0 preserves the preview's stable key and shape, swaps to the host URL, and revokes the temporary object URL.
 - WHEN a composer attachment has no supported preview or its document exceeds the client-side preview limit → THEN F0 keeps the same compact square footprint with a file-type icon.
 - WHEN a pending composer attachment is removed or its upload fails → THEN F0 revokes its local object URL and does not restore it if the upload resolves later.

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.mdx
@@ -178,6 +178,8 @@ F0Chat renders a transport-agnostic direct or group conversation. The host provi
 
 ### Behavior
 
+- WHEN a group has an explicit emoji → THEN the sidebar and chat header render that emoji.
+- WHEN a group has neither an emoji nor a custom team/company image → THEN the sidebar and chat header render `＃` instead of an empty generated avatar.
 - WHEN an own group message has `readBy` → THEN F0 displays its list length and shows each reader in the message Info panel.
 - WHEN a sent group message is still missing readers → THEN its footer shows `Sent · time` without exposing a count.
 - WHEN every other channel member has read the message → THEN its footer advances to `Read · time`.

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
@@ -5,6 +5,7 @@ import { Profiler, type ReactNode, useEffect, useRef, useState } from "react"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import { F0Chat } from "./F0Chat"
+import { MOCK_VIDEO_CAPTIONS, MOCK_VIDEO_DESCRIPTIONS } from "./mocks/constants"
 import { useMockChatRuntime } from "./mocks/createMockChatRuntime"
 import { useChatStorm } from "./mocks/useChatStorm"
 import { useDemoHeaderActions } from "./mocks/useDemoHeaderActions"
@@ -279,7 +280,7 @@ const StormHud = ({
   }, [commitsRef])
 
   return (
-    <div className="absolute right-4 top-16 z-50 flex w-56 flex-col gap-1 rounded-md border border-solid border-f1-border bg-f1-background p-2 font-mono text-xs text-f1-foreground shadow-md">
+    <div className="font-mono absolute right-4 top-16 z-50 flex w-56 flex-col gap-1 rounded-md border border-solid border-f1-border bg-f1-background p-2 text-xs text-f1-foreground shadow-md">
       <div>
         {fps} fps · {eventsPerSecond} ev/s
       </div>
@@ -652,6 +653,70 @@ const DocumentConversation = (): ReactNode => {
   )
 }
 
+/**
+ * Videos play directly in the conversation through F0VideoPlayer. Several
+ * videos in one message stack vertically instead of shrinking into a grid, so
+ * every player uses the available width up to the chat media limit. The
+ * built-in player controls provide inline playback and fullscreen.
+ */
+const VideoConversation = (): ReactNode => {
+  const runtime = useMockChatRuntime({
+    channel: dmChannel,
+    me,
+    others: [ana],
+    initialCount: 4,
+    olderPages: 0,
+    ambientEveryMs: 0,
+    extraMessages: [
+      {
+        id: "video-1",
+        author: ana,
+        body: "Two cuts from today’s walkthrough",
+        createdAt: new Date().toISOString(),
+        isMine: false,
+        attachments: [
+          {
+            kind: "file",
+            url: "/Big_Buck_Bunny_alt.webm",
+            name: "walkthrough.webm",
+            mimeType: "video/webm",
+            thumbnailUrl: "/video-poster.webp",
+            videoContent: {
+              captions: MOCK_VIDEO_CAPTIONS,
+              descriptions: MOCK_VIDEO_DESCRIPTIONS,
+            },
+          },
+          {
+            kind: "file",
+            url: "/Big_Buck_Bunny_alt.webm",
+            name: "deep-dive.webm",
+            mimeType: "video/webm",
+            thumbnailUrl: "/video-poster.webp",
+            videoContent: {
+              captions: MOCK_VIDEO_CAPTIONS,
+              descriptions: MOCK_VIDEO_DESCRIPTIONS,
+            },
+          },
+          {
+            kind: "file",
+            url: "#",
+            name: "source-deck.pptx",
+            mimeType: "application/vnd.ms-powerpoint",
+          },
+        ],
+      },
+    ],
+  })
+
+  return (
+    <Frame>
+      <F0ChatProvider runtime={runtime}>
+        <F0Chat />
+      </F0ChatProvider>
+    </Frame>
+  )
+}
+
 const meta = {
   title: "F0Chat",
   component: F0Chat,
@@ -702,6 +767,13 @@ export const GroupMembershipEvents: Story = {
 export const WithDocumentAttachments: Story = {
   name: "Document attachments",
   render: () => <DocumentConversation />,
+}
+
+/** Inline video attachments: each F0VideoPlayer stays wide, multiple videos
+ * stack vertically, and the player itself provides playback and fullscreen. */
+export const WithVideoAttachments: Story = {
+  name: "Video attachments",
+  render: () => <VideoConversation />,
 }
 
 /** Resilient sending under a bad connection: instant bubble, delayed sending

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { Profiler, type ReactNode, useEffect, useRef, useState } from "react"
 
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
+
 import { F0Chat } from "./F0Chat"
 import { useMockChatRuntime } from "./mocks/createMockChatRuntime"
 import { useChatStorm } from "./mocks/useChatStorm"
@@ -653,7 +655,7 @@ const DocumentConversation = (): ReactNode => {
 const meta = {
   title: "F0Chat",
   component: F0Chat,
-  tags: ["experimental"],
+  tags: ["!autodocs", "experimental"],
   parameters: { layout: "fullscreen" },
 } satisfies Meta<typeof F0Chat>
 
@@ -662,6 +664,11 @@ type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   render: () => <Conversation initialCount={40} />,
+}
+
+export const Snapshot: Story = {
+  render: () => <Conversation initialCount={12} />,
+  parameters: withSnapshot({}),
 }
 
 /** Composer micro-interaction QA. Try, in order: hover a message → Reply (the

--- a/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
+++ b/packages/react/src/sds/chat/F0Chat/F0Chat.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import { Profiler, type ReactNode, useEffect, useRef, useState } from "react"
+import { expect, userEvent, within } from "storybook/test"
 
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
@@ -373,6 +374,47 @@ const Conversation = ({
   )
 }
 
+/** Voice-note regression at the width used by a minimized chat panel. */
+const CompactVoiceConversation = (): ReactNode => {
+  const runtime = useMockChatRuntime({
+    channel: dmChannel,
+    me,
+    others: [ana],
+    initialCount: 0,
+    olderPages: 0,
+    ambientEveryMs: 0,
+    extraMessages: [
+      {
+        id: "compact-voice",
+        author: ana,
+        body: "",
+        createdAt: new Date().toISOString(),
+        isMine: false,
+        attachments: [
+          {
+            kind: "voice",
+            url: "https://interactive-examples.mdn.mozilla.net/media/cc0-audio/t-rex-roar.mp3",
+            durationSeconds: 62,
+            mimeType: "audio/mpeg",
+            name: "voice-note.mp3",
+          },
+        ],
+      },
+    ],
+  })
+
+  return (
+    <div
+      style={{ display: "flex", height: 520, width: 360 }}
+      data-testid="compact-chat-frame"
+    >
+      <F0ChatProvider runtime={runtime}>
+        <F0Chat />
+      </F0ChatProvider>
+    </div>
+  )
+}
+
 // Extra people for the membership demos (system-row members don't need to be
 // existing authors — GetStream resolves them from the channel state the same way).
 const diego: F0ChatUser = {
@@ -546,10 +588,10 @@ const MembershipConversation = (): ReactNode => {
 
 /**
  * Previewable documents (PDF, Excel/CSV, Word, text/markdown) render as a
- * Slack-style card: a content snapshot (lazy — each parser only loads when a
- * card scrolls into view) under a header with the type badge, name and a quick
- * download. Clicking the snapshot opens the fullscreen viewer for that kind.
- * Non-previewable files (PowerPoint, binary .doc…) keep the plain chip.
+ * document card: a content snapshot (lazy — each parser only loads when a card
+ * scrolls into view) under a header with the type badge and name. Clicking the
+ * snapshot opens the fullscreen viewer, where download remains available.
+ * Non-previewable files (PowerPoint, binary .doc…) keep the downloadable chip.
  */
 const DocumentConversation = (): ReactNode => {
   const runtime = useMockChatRuntime({
@@ -732,8 +774,66 @@ export const Default: Story = {
 }
 
 export const Snapshot: Story = {
-  render: () => <Conversation initialCount={12} />,
+  render: () => (
+    <div className="flex flex-col gap-8 bg-f1-background p-4">
+      <section
+        className="flex w-[760px] flex-col gap-2"
+        data-testid="snapshot-default-chat"
+      >
+        <h2 className="text-lg font-medium">Emoji autocomplete</h2>
+        <Conversation initialCount={12} />
+      </section>
+      <section
+        className="flex w-fit flex-col gap-2"
+        data-testid="snapshot-compact-voice"
+      >
+        <h2 className="text-lg font-medium">Compact voice attachment</h2>
+        <CompactVoiceConversation />
+      </section>
+      <section
+        className="flex w-[760px] flex-col gap-2"
+        data-testid="snapshot-documents"
+      >
+        <h2 className="text-lg font-medium">Document attachments</h2>
+        <DocumentConversation />
+      </section>
+      <section
+        className="flex w-[760px] flex-col gap-2"
+        data-testid="snapshot-videos"
+      >
+        <h2 className="text-lg font-medium">Video attachments</h2>
+        <VideoConversation />
+      </section>
+    </div>
+  ),
   parameters: withSnapshot({}),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const defaultChat = within(canvas.getByTestId("snapshot-default-chat"))
+    const composer = defaultChat.getByRole("combobox", {
+      name: /write something here/i,
+    })
+    await userEvent.clear(composer)
+    await userEvent.type(composer, ":smil")
+    await expect(
+      defaultChat.getByRole("listbox", { name: "Add emoji" })
+    ).toBeVisible()
+
+    const compactVoice = within(canvas.getByTestId("snapshot-compact-voice"))
+    await expect(
+      await compactVoice.findByTestId("chat-voice-attachment")
+    ).toBeVisible()
+
+    const documents = within(canvas.getByTestId("snapshot-documents"))
+    await expect(
+      await documents.findAllByTestId("chat-document-attachment")
+    ).not.toHaveLength(0)
+
+    const videos = within(canvas.getByTestId("snapshot-videos"))
+    await expect(
+      await videos.findAllByTestId("chat-video-attachment")
+    ).not.toHaveLength(0)
+  },
 }
 
 /** Composer micro-interaction QA. Try, in order: hover a message → Reply (the
@@ -745,6 +845,80 @@ export const Snapshot: Story = {
 export const ComposerMotion: Story = {
   name: "Composer micro-interactions",
   render: () => <Conversation initialCount={8} />,
+}
+
+/** Minimized-chat regression (360px panel): the waveform compresses before
+ * reaching the fixed time/speed slot instead of overflowing across it. */
+export const CompactVoiceAttachment: Story = {
+  name: "Compact voice attachment",
+  render: () => <CompactVoiceConversation />,
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const frame = canvas.getByTestId("compact-chat-frame")
+    const card = await canvas.findByTestId("chat-voice-attachment")
+    const waveform = await canvas.findByTestId("chat-voice-waveform")
+    const time = await canvas.findByTestId("chat-voice-time")
+
+    const frameRect = frame.getBoundingClientRect()
+    const cardRect = card.getBoundingClientRect()
+    const waveformRect = waveform.getBoundingClientRect()
+    const timeRect = time.getBoundingClientRect()
+
+    await expect(cardRect.right).toBeLessThanOrEqual(frameRect.right)
+    await expect(waveformRect.width).toBeGreaterThan(0)
+    await expect(waveformRect.right).toBeLessThanOrEqual(timeRect.left)
+  },
+}
+
+/** Slack-style inline emoji lookup: type `:` followed by a shortcode or name,
+ * then use arrows + Enter/Tab to replace the query with the selected emoji. */
+export const EmojiAutocomplete: Story = {
+  name: "Composer emoji autocomplete",
+  render: () => <Conversation initialCount={8} />,
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+    const composer = canvas.getByRole("combobox", {
+      name: /write something here/i,
+    })
+
+    await step("Search and select with the keyboard", async () => {
+      await userEvent.type(composer, ":smil")
+      const listbox = canvas.getByRole("listbox", { name: "Add emoji" })
+      const selectedOption = within(listbox).getByRole("option", {
+        name: /:smile:.*Grinning Face with Smiling Eyes/,
+      })
+
+      await expect(listbox).toBeVisible()
+      await expect(composer).toHaveAttribute("aria-expanded", "true")
+      await expect(composer).toHaveAttribute("aria-controls", listbox.id)
+      await expect(composer).toHaveAttribute(
+        "aria-activedescendant",
+        selectedOption.id
+      )
+      await expect(selectedOption).toHaveAttribute("aria-selected", "true")
+
+      await userEvent.keyboard("{Enter}")
+      await expect(composer).toHaveValue("😄 ")
+      await expect(
+        canvas.queryByRole("listbox", { name: "Add emoji" })
+      ).not.toBeInTheDocument()
+      await expect(composer).toHaveAttribute("aria-expanded", "false")
+      await expect(composer).toHaveFocus()
+    })
+
+    await step("Convert a complete alias", async () => {
+      await userEvent.clear(composer)
+      await userEvent.type(composer, ":thumbsup:")
+      await expect(composer).toHaveValue("👍")
+    })
+
+    await step("Leave the visual example open", async () => {
+      await userEvent.type(composer, " :joy")
+      await expect(
+        canvas.getByRole("listbox", { name: "Add emoji" })
+      ).toBeVisible()
+    })
+  },
 }
 
 /** Group chat with functional `@`-mentions (`@here` for everyone + members). */
@@ -763,14 +937,15 @@ export const GroupMembershipEvents: Story = {
 
 /** Document attachments: Slack-style snapshot cards for PDF, Excel/CSV, Word
  * and text/markdown — click to open the fullscreen viewer for each kind.
- * Non-previewable files (ppt) keep the plain chip. */
+ * Non-previewable files (ppt) keep the downloadable chip. */
 export const WithDocumentAttachments: Story = {
   name: "Document attachments",
   render: () => <DocumentConversation />,
 }
 
 /** Inline video attachments: each F0VideoPlayer stays wide, multiple videos
- * stack vertically, and the player itself provides playback and fullscreen. */
+ * stack vertically, and the player itself provides playback, download and
+ * fullscreen. */
 export const WithVideoAttachments: Story = {
   name: "Video attachments",
   render: () => <VideoConversation />,

--- a/packages/react/src/sds/chat/F0Chat/__tests__/ChatDocxAttachment.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/ChatDocxAttachment.test.tsx
@@ -119,6 +119,9 @@ describe("ChatDocumentAttachmentCard (docx)", () => {
     renderChat([docxAttachment])
     const card = screen.getByTestId("chat-document-attachment")
     expect(card).toHaveTextContent("offer-letter.docx")
+    expect(
+      screen.queryByRole("button", { name: "Download offer-letter.docx" })
+    ).not.toBeInTheDocument()
 
     expect(await screen.findByText("Offer of Employment")).toBeInTheDocument()
     await waitFor(() =>

--- a/packages/react/src/sds/chat/F0Chat/__tests__/ChatDocxAttachment.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/ChatDocxAttachment.test.tsx
@@ -130,7 +130,9 @@ describe("ChatDocumentAttachmentCard (docx)", () => {
 
   it("opens the fullscreen viewer on click", async () => {
     renderChat([docxAttachment])
-    fireEvent.click(screen.getByRole("button", { name: "Open document" }))
+    fireEvent.click(
+      screen.getByRole("button", { name: "Open offer-letter.docx" })
+    )
 
     expect(await screen.findByRole("dialog")).toBeInTheDocument()
     // The viewer renders its own copy of the document (generous timeout: the
@@ -160,7 +162,9 @@ describe("ChatDocumentAttachmentCard (docx)", () => {
       ).not.toBeInTheDocument()
     )
     expect(screen.getByText("offer-letter.docx")).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Download" })).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Download offer-letter.docx" })
+    ).toBeInTheDocument()
   })
 
   it("never offers a preview for binary .doc files", () => {

--- a/packages/react/src/sds/chat/F0Chat/__tests__/ChatHeader.actions.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/ChatHeader.actions.test.tsx
@@ -61,6 +61,57 @@ beforeAll(() => {
 })
 
 describe("ChatHeader host actions", () => {
+  it("uses a hash glyph when a group has no emoji or custom image", () => {
+    renderChat(makeRuntime())
+
+    expect(screen.getByTestId("chat-group-avatar-fallback")).toHaveTextContent(
+      "＃"
+    )
+    expect(screen.queryByRole("img", { name: "Product Team" })).toBeNull()
+  })
+
+  it("keeps an explicit group emoji instead of the hash fallback", () => {
+    renderChat(
+      makeRuntime({
+        channel: {
+          id: "c1",
+          type: "group",
+          title: "Product Team",
+          avatar: { type: "emoji", emoji: "🚀" },
+        },
+      })
+    )
+
+    expect(
+      screen.queryByTestId("chat-group-avatar-fallback")
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole("img", { name: "🚀" })).toBeInTheDocument()
+  })
+
+  it("keeps a custom group image instead of the hash fallback", () => {
+    const { container } = renderChat(
+      makeRuntime({
+        channel: {
+          id: "c1",
+          type: "group",
+          title: "Product Team",
+          avatar: {
+            type: "team",
+            name: "Product Team",
+            src: "/product-team.png",
+          },
+        },
+      })
+    )
+
+    expect(
+      screen.queryByTestId("chat-group-avatar-fallback")
+    ).not.toBeInTheDocument()
+    expect(
+      container.querySelector('[role="img"][aria-hidden="true"]')
+    ).toBeInTheDocument()
+  })
+
   it("renders an inline action as its own icon button and fires the callback", () => {
     const onClick = vi.fn()
     const runtime = makeRuntime()

--- a/packages/react/src/sds/chat/F0Chat/__tests__/ChatPdfAttachment.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/ChatPdfAttachment.test.tsx
@@ -160,7 +160,7 @@ describe("ChatDocumentAttachmentCard (pdf)", () => {
     const card = screen.getByTestId("chat-document-attachment")
     expect(card).toHaveTextContent("report.pdf")
     expect(
-      screen.getByRole("button", { name: "Open document" })
+      screen.getByRole("button", { name: "Open report.pdf" })
     ).toBeInTheDocument()
     // The snapshot renders the first page once the lazy chunk resolves, and
     // fades in over the card's skeleton once the page reports its paint.
@@ -187,7 +187,7 @@ describe("ChatDocumentAttachmentCard (pdf)", () => {
 
   it("opens the fullscreen viewer on click and closes it", async () => {
     renderChat([pdfAttachment])
-    fireEvent.click(screen.getByRole("button", { name: "Open document" }))
+    fireEvent.click(screen.getByRole("button", { name: "Open report.pdf" }))
 
     // The dialog announces the file and the (lazy) F0PdfViewer toolbar appears
     // (generous timeout: the viewer chunk resolves through React.lazy).
@@ -224,6 +224,8 @@ describe("ChatDocumentAttachmentCard (pdf)", () => {
       ).not.toBeInTheDocument()
     )
     expect(screen.getByText("broken.pdf")).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Download" })).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Download broken.pdf" })
+    ).toBeInTheDocument()
   })
 })

--- a/packages/react/src/sds/chat/F0Chat/__tests__/ChatPdfAttachment.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/ChatPdfAttachment.test.tsx
@@ -162,6 +162,9 @@ describe("ChatDocumentAttachmentCard (pdf)", () => {
     expect(
       screen.getByRole("button", { name: "Open report.pdf" })
     ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Download report.pdf" })
+    ).not.toBeInTheDocument()
     // The snapshot renders the first page once the lazy chunk resolves, and
     // fades in over the card's skeleton once the page reports its paint.
     await waitFor(() =>
@@ -199,6 +202,7 @@ describe("ChatDocumentAttachmentCard (pdf)", () => {
         { timeout: 5000 }
       )
     ).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "Download" })).toBeInTheDocument()
 
     // Close via the top-band pill (the backdrop shares the same label).
     const closeButtons = screen.getAllByRole("button", { name: "Close" })

--- a/packages/react/src/sds/chat/F0Chat/__tests__/ChatSheetAttachment.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/ChatSheetAttachment.test.tsx
@@ -133,6 +133,9 @@ describe("ChatDocumentAttachmentCard (sheet)", () => {
     renderChat([sheetAttachment])
     const card = screen.getByTestId("chat-document-attachment")
     expect(card).toHaveTextContent("raw-data.xlsx")
+    expect(
+      screen.queryByRole("button", { name: "Download raw-data.xlsx" })
+    ).not.toBeInTheDocument()
 
     // The lazy SheetJS chunk resolves, the workbook parses, cells appear and
     // the snapshot fades in over the skeleton.

--- a/packages/react/src/sds/chat/F0Chat/__tests__/ChatSheetAttachment.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/ChatSheetAttachment.test.tsx
@@ -1,6 +1,5 @@
-import * as XLSX from "xlsx"
-
 import { beforeAll, describe, expect, it, vi } from "vitest"
+import * as XLSX from "xlsx"
 
 import {
   fireEvent,
@@ -147,7 +146,7 @@ describe("ChatDocumentAttachmentCard (sheet)", () => {
 
   it("opens the fullscreen grid with one tab per sheet", async () => {
     renderChat([sheetAttachment])
-    fireEvent.click(screen.getByRole("button", { name: "Open document" }))
+    fireEvent.click(screen.getByRole("button", { name: "Open raw-data.xlsx" }))
 
     // Scope to the dialog — the transcript card shows the same cells.
     const dialog = within(await screen.findByRole("dialog"))
@@ -179,7 +178,9 @@ describe("ChatDocumentAttachmentCard (sheet)", () => {
       ).not.toBeInTheDocument()
     )
     expect(screen.getByText("raw-data.xlsx")).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "Download" })).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Download raw-data.xlsx" })
+    ).toBeInTheDocument()
   })
 
   it("keeps the chip for files too big to parse client-side", () => {

--- a/packages/react/src/sds/chat/F0Chat/__tests__/ChatTextAttachment.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/ChatTextAttachment.test.tsx
@@ -131,7 +131,7 @@ describe("ChatDocumentAttachmentCard (text)", () => {
         mimeType: "text/markdown",
       },
     ])
-    fireEvent.click(screen.getByRole("button", { name: "Open document" }))
+    fireEvent.click(screen.getByRole("button", { name: "Open CHANGELOG.md" }))
 
     expect(await screen.findByRole("dialog")).toBeInTheDocument()
     // The heading renders as an actual <h1> (generous timeout: the viewer
@@ -155,7 +155,7 @@ describe("ChatDocumentAttachmentCard (text)", () => {
         mimeType: "text/plain",
       },
     ])
-    fireEvent.click(screen.getByRole("button", { name: "Open document" }))
+    fireEvent.click(screen.getByRole("button", { name: "Open app.log" }))
 
     expect(await screen.findByRole("dialog")).toBeInTheDocument()
     await waitFor(

--- a/packages/react/src/sds/chat/F0Chat/__tests__/ChatTextAttachment.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/ChatTextAttachment.test.tsx
@@ -113,6 +113,9 @@ describe("ChatDocumentAttachmentCard (text)", () => {
     ])
     const card = screen.getByTestId("chat-document-attachment")
     expect(card).toHaveTextContent("app.log")
+    expect(
+      screen.queryByRole("button", { name: "Download app.log" })
+    ).not.toBeInTheDocument()
 
     expect(await screen.findByText(/plain log line 1/)).toBeInTheDocument()
     await waitFor(() =>
@@ -185,5 +188,8 @@ describe("ChatDocumentAttachmentCard (text)", () => {
       ).not.toBeInTheDocument()
     )
     expect(screen.getByText("notes.txt")).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Download notes.txt" })
+    ).toBeInTheDocument()
   })
 })

--- a/packages/react/src/sds/chat/F0Chat/__tests__/ChatTypingTransitions.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/ChatTypingTransitions.test.tsx
@@ -100,22 +100,24 @@ const replyFrom = (author: F0ChatUser, body: string): F0ChatMessage => ({
 describe("typing indicator transitions", () => {
   it("holds the bubble through the exit window, then removes it", () => {
     const { rerender } = render(chatFor([MARIA]))
-    expect(screen.getByRole("status")).toBeInTheDocument()
+    expect(screen.getByRole("status", { name: /writing/i })).toBeInTheDocument()
 
     // The writer pauses: the row is NOT dropped immediately (it fades out).
     rerender(chatFor([]))
-    expect(screen.getByRole("status")).toBeInTheDocument()
+    expect(screen.getByRole("status", { name: /writing/i })).toBeInTheDocument()
 
     // After the exit window the row is gone.
     act(() => {
       vi.advanceTimersByTime(400)
     })
-    expect(screen.queryByRole("status")).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("status", { name: /writing/i })
+    ).not.toBeInTheDocument()
   })
 
   it("keeps the same bubble when typing resumes within the window", () => {
     const { rerender } = render(chatFor([MARIA]))
-    const bubble = screen.getByRole("status")
+    const bubble = screen.getByRole("status", { name: /writing/i })
 
     rerender(chatFor([]))
     act(() => {
@@ -127,17 +129,19 @@ describe("typing indicator transitions", () => {
     act(() => {
       vi.advanceTimersByTime(400)
     })
-    expect(screen.getByRole("status")).toBe(bubble)
+    expect(screen.getByRole("status", { name: /writing/i })).toBe(bubble)
   })
 
   it("replaces the dots with the typer's message in the same commit", () => {
     const { rerender } = render(chatFor([MARIA]))
-    expect(screen.getByRole("status")).toBeInTheDocument()
+    expect(screen.getByRole("status", { name: /writing/i })).toBeInTheDocument()
 
     // Same tick: typing clears AND the typer's message lands together — the
     // bubble must replace the dots immediately, no hysteresis ghost.
     rerender(chatFor([], [HELLO, replyFrom(MARIA, "On my way!")]))
-    expect(screen.queryByRole("status")).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("status", { name: /writing/i })
+    ).not.toBeInTheDocument()
     expect(screen.getByText("On my way!")).toBeInTheDocument()
   })
 
@@ -147,43 +151,49 @@ describe("typing indicator transitions", () => {
     // typing_stop arrives first (staggered, real backends): the leaving fade
     // starts and the dots are still held...
     rerender(chatFor([]))
-    expect(screen.getByRole("status")).toBeInTheDocument()
+    expect(screen.getByRole("status", { name: /writing/i })).toBeInTheDocument()
     act(() => {
       vi.advanceTimersByTime(100)
     })
     // ...then the message lands within the window: swap immediately.
     rerender(chatFor([], [HELLO, replyFrom(MARIA, "On my way!")]))
-    expect(screen.queryByRole("status")).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("status", { name: /writing/i })
+    ).not.toBeInTheDocument()
     expect(screen.getByText("On my way!")).toBeInTheDocument()
   })
 
   it("hides the dots when the message lands BEFORE the typing_stop (Stream order)", () => {
     const { rerender } = render(chatFor([MARIA]))
-    expect(screen.getByRole("status")).toBeInTheDocument()
+    expect(screen.getByRole("status", { name: /writing/i })).toBeInTheDocument()
 
     // Stream delivers message.new first — MARIA is still in typingUsers when
     // her bubble lands. Her dots must be suppressed immediately, not ghost
     // under the new message until the stop packet arrives.
     rerender(chatFor([MARIA], [HELLO, replyFrom(MARIA, "On my way!")]))
-    expect(screen.queryByRole("status")).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("status", { name: /writing/i })
+    ).not.toBeInTheDocument()
     expect(screen.getByText("On my way!")).toBeInTheDocument()
 
     // The typing_stop finally lands: still no dots, no flash.
     rerender(chatFor([], [HELLO, replyFrom(MARIA, "On my way!")]))
-    expect(screen.queryByRole("status")).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("status", { name: /writing/i })
+    ).not.toBeInTheDocument()
 
     // A NEW typing_start after the stop shows the dots again.
     rerender(chatFor([MARIA], [HELLO, replyFrom(MARIA, "On my way!")]))
-    expect(screen.getByRole("status")).toBeInTheDocument()
+    expect(screen.getByRole("status", { name: /writing/i })).toBeInTheDocument()
   })
 
   it("keeps the dots when someone ELSE's message lands while typing (group)", () => {
     const { rerender } = render(chatFor([MARIA], [HELLO], "group"))
-    expect(screen.getByRole("status")).toBeInTheDocument()
+    expect(screen.getByRole("status", { name: /writing/i })).toBeInTheDocument()
 
     // Otto's message arrives while María is still typing — her dots stay.
     rerender(chatFor([MARIA], [HELLO, replyFrom(OTTO, "Hey all")], "group"))
-    expect(screen.getByRole("status")).toBeInTheDocument()
+    expect(screen.getByRole("status", { name: /writing/i })).toBeInTheDocument()
     expect(screen.getByText("Hey all")).toBeInTheDocument()
   })
 })

--- a/packages/react/src/sds/chat/F0Chat/__tests__/ChatVideoAttachment.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/ChatVideoAttachment.test.tsx
@@ -5,6 +5,7 @@ import {
   zeroRender as render,
   screen,
   waitFor,
+  within,
 } from "@/testing/test-utils"
 
 import { F0Chat } from "../F0Chat"
@@ -26,6 +27,7 @@ vi.mock("@/components/F0VideoPlayer", () => ({
     defaultLanguage,
     silent,
     ariaLabel,
+    download,
     "data-testid": testId,
   }: {
     src: string
@@ -34,6 +36,7 @@ vi.mock("@/components/F0VideoPlayer", () => ({
     defaultLanguage?: string
     silent?: boolean
     ariaLabel?: string
+    download?: { label: string; onClick: () => void }
     "data-testid"?: string
   }) => (
     <div
@@ -57,6 +60,11 @@ vi.mock("@/components/F0VideoPlayer", () => ({
       </video>
       <button type="button">Play</button>
       <button type="button">Enter fullscreen</button>
+      {download && (
+        <button type="button" onClick={download.onClick}>
+          {download.label}
+        </button>
+      )}
     </div>
   ),
 }))
@@ -170,6 +178,26 @@ describe("ChatVideoAttachment", () => {
     expect(
       screen.getAllByRole("button", { name: "Enter fullscreen" })
     ).toHaveLength(2)
+    expect(
+      within(players[0]).getByRole("button", {
+        name: "Download walkthrough.webm",
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getAllByRole("button", {
+        name: "Download walkthrough.webm",
+      })
+    ).toHaveLength(1)
+    expect(
+      within(players[1]).getByRole("button", {
+        name: "Download deep-dive.mp4",
+      })
+    ).toBeInTheDocument()
+    expect(
+      screen.getAllByRole("button", {
+        name: "Download deep-dive.mp4",
+      })
+    ).toHaveLength(1)
   })
 
   it("keeps an uploading video as a file chip until it completes", async () => {

--- a/packages/react/src/sds/chat/F0Chat/__tests__/ChatVideoAttachment.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/ChatVideoAttachment.test.tsx
@@ -1,0 +1,251 @@
+import { beforeAll, describe, expect, it, vi } from "vitest"
+
+import {
+  fireEvent,
+  zeroRender as render,
+  screen,
+  waitFor,
+} from "@/testing/test-utils"
+
+import { F0Chat } from "../F0Chat"
+import { F0ChatProvider } from "../providers/F0ChatProvider"
+import { type F0ChatAttachment, type F0ChatRuntime } from "../types"
+
+vi.mock("react-virtuoso", async (importOriginal) => {
+  const { mockVirtuosoModule } = await import("../mocks/virtuoso-jsdom")
+  return mockVirtuosoModule(
+    await importOriginal<typeof import("react-virtuoso")>()
+  )
+})
+
+vi.mock("@/components/F0VideoPlayer", () => ({
+  F0VideoPlayer: ({
+    src,
+    poster,
+    content,
+    defaultLanguage,
+    silent,
+    ariaLabel,
+    "data-testid": testId,
+  }: {
+    src: string
+    poster?: string
+    content?: { captions?: string }
+    defaultLanguage?: string
+    silent?: boolean
+    ariaLabel?: string
+    "data-testid"?: string
+  }) => (
+    <div
+      role="region"
+      aria-label={ariaLabel ?? "Video player"}
+      data-testid={testId}
+      data-src={src}
+      data-poster={poster}
+      data-captions={content?.captions}
+      data-default-language={defaultLanguage}
+      data-silent={silent}
+    >
+      <video data-testid="mock-video-media">
+        {content?.captions && (
+          <track
+            data-testid="mock-video-captions"
+            kind="captions"
+            src="captions.vtt"
+          />
+        )}
+      </video>
+      <button type="button">Play</button>
+      <button type="button">Enter fullscreen</button>
+    </div>
+  ),
+}))
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+const now = new Date().toISOString()
+
+const makeRuntime = (attachments: F0ChatAttachment[]): F0ChatRuntime => ({
+  currentUserId: "me",
+  channel: {
+    id: "c1",
+    type: "group",
+    title: "Video review",
+    avatar: { type: "company", name: "Video review" },
+    memberCount: 2,
+  },
+  status: "ready",
+  messages: [
+    {
+      id: "m1",
+      author: { id: "me", name: "Me" },
+      body: "Two walkthroughs and the source deck",
+      createdAt: now,
+      isMine: true,
+      status: "sent",
+      attachments,
+    },
+  ],
+  typingUsers: [],
+  hasMoreOlder: false,
+  loadingOlder: false,
+  unreadCount: 0,
+  firstUnreadId: null,
+  sendMessage: vi.fn(),
+  retryMessage: vi.fn(),
+  loadOlder: vi.fn(),
+  toggleReaction: vi.fn(),
+  deleteMessage: vi.fn(),
+  onInputActivity: vi.fn(),
+  markRead: vi.fn(),
+})
+
+const renderChat = (attachments: F0ChatAttachment[]) =>
+  render(
+    <F0ChatProvider runtime={makeRuntime(attachments)}>
+      <F0Chat />
+    </F0ChatProvider>
+  )
+
+const captions = [
+  "WEBVTT",
+  "",
+  "00:00:00.000 --> 00:00:02.000",
+  "A chart appears.",
+].join("\n")
+
+describe("ChatVideoAttachment", () => {
+  it("stacks multiple completed videos as wide inline players", async () => {
+    renderChat([
+      {
+        kind: "file",
+        url: "https://cdn.example.com/walkthrough.webm",
+        name: "walkthrough.webm",
+        mimeType: "video/webm",
+        thumbnailUrl: "https://cdn.example.com/poster.webp",
+        videoContent: { captions },
+        videoDefaultLanguage: "en",
+      },
+      {
+        kind: "file",
+        url: "https://cdn.example.com/deep-dive.mp4",
+        name: "deep-dive.mp4",
+        mimeType: "video/mp4",
+        videoSilent: true,
+      },
+      {
+        kind: "file",
+        url: "https://cdn.example.com/deck.pptx",
+        name: "source-deck.pptx",
+        mimeType: "application/vnd.ms-powerpoint",
+      },
+    ])
+
+    const players = await screen.findAllByRole("region", {
+      name: /Video player:/,
+    })
+    expect(players).toHaveLength(2)
+    expect(players[0]).toHaveAttribute(
+      "data-src",
+      "https://cdn.example.com/walkthrough.webm"
+    )
+    expect(players[0]).toHaveAttribute(
+      "data-poster",
+      "https://cdn.example.com/poster.webp"
+    )
+    expect(players[0]).toHaveAttribute("data-captions", captions)
+    expect(players[0]).toHaveAttribute("data-default-language", "en")
+    expect(players[1]).toHaveAttribute("data-silent", "true")
+
+    const videoCards = screen.getAllByTestId("chat-video-attachment")
+    expect(videoCards).toHaveLength(2)
+    for (const card of videoCards) {
+      expect(card).toHaveClass("w-full", "max-w-xl", "aspect-video")
+    }
+
+    expect(screen.getByText("source-deck.pptx")).toBeInTheDocument()
+    expect(screen.getAllByRole("button", { name: "Play" })).toHaveLength(2)
+    expect(
+      screen.getAllByRole("button", { name: "Enter fullscreen" })
+    ).toHaveLength(2)
+  })
+
+  it("keeps an uploading video as a file chip until it completes", async () => {
+    renderChat([
+      {
+        kind: "file",
+        url: "blob:upload",
+        name: "uploading-video.mp4",
+        mimeType: "video/mp4",
+        progress: 40,
+      },
+    ])
+
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId("chat-video-attachment")
+      ).not.toBeInTheDocument()
+    )
+    expect(screen.getByText("uploading-video.mp4")).toBeInTheDocument()
+  })
+
+  it("recognizes a video URL when the transport omits its MIME type", async () => {
+    renderChat([
+      {
+        kind: "file",
+        url: "https://cdn.example.com/preview.mov?token=123",
+        name: "download",
+      },
+    ])
+
+    expect(
+      await screen.findByTestId("chat-video-attachment")
+    ).toBeInTheDocument()
+  })
+
+  it("falls back to a downloadable file when the media fails", async () => {
+    renderChat([
+      {
+        kind: "file",
+        url: "https://cdn.example.com/unsupported.avi",
+        name: "unsupported.avi",
+        mimeType: "video/x-msvideo",
+      },
+    ])
+
+    fireEvent.error(await screen.findByTestId("mock-video-media"))
+
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId("chat-video-attachment")
+      ).not.toBeInTheDocument()
+    )
+    expect(screen.getByText("unsupported.avi")).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Download unsupported.avi" })
+    ).toBeInTheDocument()
+  })
+
+  it("keeps the player when only its captions fail", async () => {
+    renderChat([
+      {
+        kind: "file",
+        url: "https://cdn.example.com/walkthrough.mp4",
+        name: "walkthrough.mp4",
+        mimeType: "video/mp4",
+        videoContent: { captions },
+      },
+    ])
+
+    fireEvent.error(await screen.findByTestId("mock-video-captions"))
+
+    expect(
+      screen.getByRole("region", {
+        name: "Video player: walkthrough.mp4",
+      })
+    ).toBeInTheDocument()
+    expect(screen.getByTestId("chat-video-attachment")).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/sds/chat/F0Chat/__tests__/ChatVoiceAttachment.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/ChatVoiceAttachment.test.tsx
@@ -45,18 +45,63 @@ describe("ChatVoiceAttachment", () => {
   it("swaps the duration for the speed pill on hover (group classes)", () => {
     render(<ChatVoiceAttachment voice={VOICE} />)
     expect(screen.getByTestId("chat-voice-time").className).toContain(
-      "group-hover/voice:hidden"
+      "group-hover/voice:invisible"
     )
     const pillWrapper = screen.getByTestId("chat-voice-rate").closest("div")
-    expect(pillWrapper?.className).toContain("hidden")
-    expect(pillWrapper?.className).toContain("group-hover/voice:flex")
+    expect(pillWrapper).toHaveClass(
+      "opacity-0",
+      "group-hover/voice:opacity-100",
+      "group-focus-within/voice:opacity-100"
+    )
   })
 
   it("keeps a fixed-width trailing slot so the waveform never resizes", () => {
     render(<ChatVoiceAttachment voice={VOICE} />)
-    expect(screen.getByTestId("chat-voice-time").className).toContain("w-12")
-    const pillWrapper = screen.getByTestId("chat-voice-rate").closest("div")
-    expect(pillWrapper?.className).toContain("w-12")
+    expect(screen.getByTestId("chat-voice-trailing")).toHaveClass(
+      "relative",
+      "w-12",
+      "shrink-0"
+    )
+  })
+
+  it("compacts the waveform before it can overlap the time", () => {
+    render(<ChatVoiceAttachment voice={VOICE} />)
+    const waveform = screen.getByTestId("chat-voice-waveform")
+    const bars = waveform.querySelectorAll("span")
+
+    expect(waveform).toHaveClass("min-w-0", "overflow-hidden", "gap-0.5")
+    expect(bars[0]).toHaveClass("min-w-px", "shrink")
+  })
+
+  it("makes the seek slider keyboard operable", () => {
+    render(<ChatVoiceAttachment voice={VOICE} />)
+    const waveform = screen.getByRole("slider", { name: "Seek" })
+    const audio = document.querySelector("audio") as HTMLAudioElement
+
+    expect(waveform).toHaveAttribute("tabindex", "0")
+    fireEvent.keyDown(waveform, { key: "End" })
+    expect(audio.currentTime).toBe(4)
+    fireEvent.keyDown(waveform, { key: "ArrowLeft" })
+    expect(audio.currentTime).toBe(3)
+    fireEvent.keyDown(waveform, { key: "Home" })
+    expect(audio.currentTime).toBe(0)
+    fireEvent.keyDown(waveform, { key: "ArrowRight" })
+    expect(audio.currentTime).toBe(1)
+  })
+
+  it("keeps playback speed keyboard-focusable when it is visually hidden", () => {
+    render(<ChatVoiceAttachment voice={VOICE} />)
+    const speed = screen.getByRole("button", {
+      name: "Playback speed: 1x",
+    })
+    const wrapper = speed.closest("div")
+
+    speed.focus()
+    expect(speed).toHaveFocus()
+    expect(wrapper).toHaveClass(
+      "group-focus-within/voice:pointer-events-auto",
+      "group-focus-within/voice:opacity-100"
+    )
   })
 
   it("cycles the playback rate 1x → 1.5x → 2x → 0.5x on the speed pill", () => {
@@ -67,6 +112,7 @@ describe("ChatVoiceAttachment", () => {
     expect(pill).toHaveTextContent("1x")
     fireEvent.click(pill)
     expect(pill).toHaveTextContent("1.5x")
+    expect(pill).toHaveAccessibleName("Playback speed: 1.5x")
     expect(audio.playbackRate).toBe(1.5)
     fireEvent.click(pill)
     expect(pill).toHaveTextContent("2x")

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.contract.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.contract.test.tsx
@@ -150,9 +150,8 @@ describe("connection states", () => {
 })
 
 describe("delivery states", () => {
-  // Optimistic footer (WhatsApp): sending/sent/delivered all show the bare
-  // time — the label never changes when the ack lands (zero flicker). A slow
-  // send is the SendingClock's job; only read/failed speak up.
+  // Sending and legacy messages keep the bare time. Once acknowledged, sent
+  // and delivered share "Sent · time"; read advances to "Read · time".
   const bareTimeOf = (message: F0ChatMessage) =>
     new Intl.DateTimeFormat(undefined, {
       hour: "2-digit",
@@ -166,17 +165,20 @@ describe("delivery states", () => {
     expect(screen.queryByText("Sending…")).not.toBeInTheDocument()
   })
 
-  it("does not announce success — sent keeps the bare time", () => {
+  it("shows sent with the time once the message is acknowledged", () => {
     const message = mine("sent")
     renderChat(makeRuntime({ messages: [theirs, message] }))
-    expect(screen.getByText(bareTimeOf(message))).toBeInTheDocument()
-    expect(screen.queryByText(/^Sent/)).not.toBeInTheDocument()
+    expect(
+      screen.getByText(`Sent · ${bareTimeOf(message)}`)
+    ).toBeInTheDocument()
   })
 
-  it("keeps delivered silent too (the Info panel carries that detail)", () => {
+  it("keeps delivered under the sent footer label", () => {
     const message = mine("delivered")
     renderChat(makeRuntime({ messages: [theirs, message] }))
-    expect(screen.getByText(bareTimeOf(message))).toBeInTheDocument()
+    expect(
+      screen.getByText(`Sent · ${bareTimeOf(message)}`)
+    ).toBeInTheDocument()
     expect(screen.queryByText(/^Delivered/)).not.toBeInTheDocument()
   })
 

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.resilience.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.resilience.test.tsx
@@ -330,7 +330,7 @@ describe("typing dots", () => {
     renderChat(
       makeRuntime({ typingUsers: [{ id: "other", name: "María José" }] })
     )
-    const bubble = screen.getByRole("status")
+    const bubble = screen.getByRole("status", { name: "Writing…" })
     expect(bubble.querySelectorAll(".animate-typing-dot")).toHaveLength(3)
   })
 })

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.resilience.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.resilience.test.tsx
@@ -247,7 +247,7 @@ describe("live content transitions", () => {
       makeRuntime({ messages: [withReactions([reaction("👍")])] })
     )
     expect(
-      screen.getByRole("button", { name: getEmojiLabel("👍") })
+      screen.getByRole("button", { name: `${getEmojiLabel("👍")}: 1` })
     ).toBeInTheDocument()
 
     // A second emoji pops in next to the first.
@@ -261,7 +261,7 @@ describe("live content transitions", () => {
       </F0ChatProvider>
     )
     expect(
-      screen.getByRole("button", { name: getEmojiLabel("❤️") })
+      screen.getByRole("button", { name: `${getEmojiLabel("❤️")}: 1` })
     ).toBeInTheDocument()
 
     // Removing one leaves the other (the exit resolves instantly in tests).
@@ -274,11 +274,13 @@ describe("live content transitions", () => {
     )
     await waitFor(() =>
       expect(
-        screen.queryByRole("button", { name: getEmojiLabel("👍") })
+        screen.queryByRole("button", {
+          name: `${getEmojiLabel("👍")}: 1`,
+        })
       ).not.toBeInTheDocument()
     )
     expect(
-      screen.getByRole("button", { name: getEmojiLabel("❤️") })
+      screen.getByRole("button", { name: `${getEmojiLabel("❤️")}: 1` })
     ).toBeInTheDocument()
   })
 

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
@@ -505,12 +505,17 @@ describe("F0Chat", () => {
       name: /photo\.png/i,
     })
     expect(localPreview.getAttribute("src")).toMatch(/^blob:/)
+    const documentPreview = screen.getByTestId("chat-composer-document-preview")
+    expect(documentPreview).toHaveTextContent("report.pdf")
     expect(
-      screen.getByTestId("chat-composer-document-preview")
-    ).toHaveTextContent("report.pdf")
-    expect(
-      screen.getByTestId("chat-composer-video-preview")
-    ).toBeInTheDocument()
+      documentPreview.querySelector('[data-testid="chat-document-attachment"]')
+    ).toHaveStyle({ width: "64px" })
+    const videoPreview = screen.getByTestId("chat-composer-video-preview")
+    expect(videoPreview).toHaveClass("h-16", "w-16")
+    expect(screen.getByTestId("chat-composer-image-preview")).toHaveClass(
+      "h-16",
+      "w-16"
+    )
     await waitFor(() =>
       expect(screen.getByRole("img", { name: /photo\.png/i })).toHaveAttribute(
         "src",

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
@@ -417,6 +417,158 @@ describe("F0Chat", () => {
     )
   })
 
+  it("selects an emoji with Enter before sending the completed message", async () => {
+    const sendMessage = vi.fn()
+    renderChat(makeRuntime({ sendMessage }))
+    const input = screen.getByPlaceholderText(/write something here/i)
+
+    await userEvent.type(input, ":smil")
+    const listbox = screen.getByRole("listbox", { name: /add emoji/i })
+    const selectedOption = within(listbox).getByRole("option", {
+      selected: true,
+    })
+    expect(input).toHaveAttribute("aria-expanded", "true")
+    expect(input).toHaveAttribute("aria-controls", listbox.id)
+    expect(input).toHaveAttribute("aria-activedescendant", selectedOption.id)
+
+    await userEvent.keyboard("{Enter}")
+    expect(input).toHaveValue("😄 ")
+    expect(input).toHaveAttribute("aria-expanded", "false")
+    expect(input).not.toHaveAttribute("aria-activedescendant")
+    expect(sendMessage).not.toHaveBeenCalled()
+
+    await userEvent.keyboard("{Enter}")
+    expect(sendMessage).toHaveBeenCalledOnce()
+    expect(sendMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ body: "😄" })
+    )
+  })
+
+  it("does not select or send when Enter confirms an IME composition", async () => {
+    const sendMessage = vi.fn()
+    renderChat(makeRuntime({ sendMessage }))
+    const input = screen.getByPlaceholderText(/write something here/i)
+
+    await userEvent.type(input, ":smil")
+    fireEvent.compositionStart(input)
+    fireEvent.keyDown(input, {
+      key: "Enter",
+      code: "Enter",
+      isComposing: true,
+    })
+
+    expect(input).toHaveValue(":smil")
+    expect(
+      screen.getByRole("listbox", { name: /add emoji/i })
+    ).toBeInTheDocument()
+    expect(sendMessage).not.toHaveBeenCalled()
+  })
+
+  it("selects the hovered emoji with the pointer and keeps composer focus", async () => {
+    const sendMessage = vi.fn()
+    renderChat(makeRuntime({ sendMessage }))
+    const input = screen.getByPlaceholderText(/write something here/i)
+
+    await userEvent.type(input, ":sm")
+    const listbox = screen.getByRole("listbox", { name: /add emoji/i })
+    const smiley = within(listbox).getByRole("option", {
+      name: /:smiley:/,
+    })
+
+    await userEvent.hover(smiley)
+    expect(smiley).toHaveAttribute("aria-selected", "true")
+    await userEvent.click(smiley)
+
+    expect(input).toHaveValue("😃 ")
+    expect(input).toHaveFocus()
+    expect(input).toHaveProperty("selectionStart", 3)
+    expect(
+      screen.queryByRole("listbox", { name: /add emoji/i })
+    ).not.toBeInTheDocument()
+    expect(sendMessage).not.toHaveBeenCalled()
+  })
+
+  it("closes emoji autocomplete when the composer loses focus", async () => {
+    renderChat(makeRuntime())
+    const input = screen.getByPlaceholderText(/write something here/i)
+    await userEvent.type(input, ":sm")
+    expect(
+      screen.getByRole("listbox", { name: /add emoji/i })
+    ).toBeInTheDocument()
+    await userEvent.click(screen.getByRole("button", { name: /attach file/i }))
+    expect(
+      screen.queryByRole("listbox", { name: /add emoji/i })
+    ).not.toBeInTheDocument()
+  })
+
+  it("converts a closed emoji alias in place without sending", async () => {
+    const sendMessage = vi.fn()
+    renderChat(makeRuntime({ sendMessage }))
+    const input = screen.getByPlaceholderText(/write something here/i)
+
+    await userEvent.type(input, "Great :thumbsup:")
+
+    expect(input).toHaveValue("Great 👍")
+    expect(input).toHaveProperty("selectionStart", 8)
+    expect(sendMessage).not.toHaveBeenCalled()
+  })
+
+  it("keeps mention selection working when emoji autocomplete is enabled", async () => {
+    const sendMessage = vi.fn()
+    renderChat(
+      makeRuntime({
+        channel: {
+          id: "group-1",
+          type: "group",
+          title: "Product",
+          avatar: { type: "team", name: "Product" },
+        },
+        searchMembers: async () => [{ id: "ana", name: "Ana García" }],
+        sendMessage,
+      })
+    )
+    const input = screen.getByPlaceholderText(/write something here/i)
+
+    await userEvent.type(input, "@Ana")
+    await screen.findByRole("option", { name: "Ana García" })
+    await userEvent.keyboard("{Enter}")
+
+    expect(input).toHaveValue("@Ana García ")
+    expect(sendMessage).not.toHaveBeenCalled()
+  })
+
+  it("gives an active emoji query precedence over a pending mention", async () => {
+    const sendMessage = vi.fn()
+    renderChat(
+      makeRuntime({
+        channel: {
+          id: "group-1",
+          type: "group",
+          title: "Product",
+          avatar: { type: "team", name: "Product" },
+        },
+        searchMembers: async () => [{ id: "ana", name: "Ana García" }],
+        sendMessage,
+      })
+    )
+    const input = screen.getByPlaceholderText(/write something here/i)
+
+    await userEvent.type(input, "@Ana")
+    await screen.findByRole("option", { name: "Ana García" })
+    await userEvent.type(input, " :smil")
+
+    screen.getByRole("listbox", { name: /add emoji/i })
+    expect(screen.getAllByRole("listbox")).toHaveLength(1)
+    await userEvent.keyboard("{Enter}")
+
+    expect(input).toHaveValue("@Ana 😄 ")
+    expect(sendMessage).not.toHaveBeenCalled()
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 250))
+    })
+    expect(screen.queryAllByRole("listbox")).toHaveLength(0)
+  })
+
   it("shows an emoji picker button in the composer", () => {
     renderChat(makeRuntime())
     expect(
@@ -531,14 +683,21 @@ describe("F0Chat", () => {
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy()
     // Each pending attachment carries its own remove action.
-    const removeButtons = screen.getAllByRole("button", { name: /^remove /i })
-    expect(removeButtons).toHaveLength(3)
+    const removePhoto = screen.getByRole("button", {
+      name: "Remove photo.png",
+    })
+    expect(
+      screen.getByRole("button", { name: "Remove walkthrough.webm" })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Remove report.pdf" })
+    ).toBeInTheDocument()
     const attachmentStrip = screen.getByRole("region", {
       name: "3 attachments",
     })
     expect(attachmentStrip).toHaveAttribute("tabindex", "0")
     expect(attachmentStrip).toHaveClass("flex-nowrap", "overflow-x-auto")
-    await userEvent.click(removeButtons[0])
+    await userEvent.click(removePhoto)
     expect(
       screen.queryByRole("img", { name: /photo\.png/i })
     ).not.toBeInTheDocument()

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
@@ -6,11 +6,15 @@ import {
   screen,
   userEvent,
   waitFor,
+  within,
 } from "@/testing/test-utils"
+import { getEmojiLabel } from "@/lib/emojis"
 
 import { F0Chat } from "../F0Chat"
+import { resolveMockReactionUsers } from "../mocks/MockChatApp"
+import { initialConvState, SEED_BY_ID, SEEDS } from "../mocks/mockSeeds"
 import { F0ChatProvider } from "../providers/F0ChatProvider"
-import { type F0ChatMessage, type F0ChatRuntime } from "../types"
+import { isUserMessage, type F0ChatMessage, type F0ChatRuntime } from "../types"
 
 // jsdom has no layout — wrap Virtuoso in its official mock context so every
 // row renders (see mocks/virtuoso-jsdom).
@@ -417,7 +421,95 @@ describe("F0Chat", () => {
     expect(screen.getByText(/no messages yet/i)).toBeInTheDocument()
   })
 
-  it("shows the interpolated 'Read by N' count for my read message in a group", () => {
+  it("seeds reader identities on every group message in the application mock", () => {
+    for (const seed of SEEDS.filter((item) => item.type === "group")) {
+      const messages = initialConvState(seed).messages.filter(isUserMessage)
+
+      for (const message of messages) {
+        expect(message.readBy?.length).toBeGreaterThan(0)
+        expect(
+          message.readBy?.some((reader) => reader.id === message.author.id)
+        ).toBe(false)
+      }
+    }
+  })
+
+  it("resolves complete and fallback reaction users in the application mock", () => {
+    const seed = SEED_BY_ID.get("grp-reporting")
+    if (!seed) throw new Error("Expected grp-reporting mock seed")
+
+    const messages = initialConvState(seed).messages
+    const message = messages
+      .filter(isUserMessage)
+      .find((item) => item.reactions?.some(({ emoji }) => emoji === "🎉"))
+    if (!message) throw new Error("Expected a seeded reaction message")
+
+    expect(
+      resolveMockReactionUsers(seed, messages, message.id, "🎉").map(
+        ({ name }) => name
+      )
+    ).toEqual(["Grace Liang", "Marcus Bennett", "Sam Okafor"])
+    expect(resolveMockReactionUsers(seed, messages, message.id, "👍")).toEqual(
+      []
+    )
+    expect(resolveMockReactionUsers(seed, messages, "missing", "🎉")).toEqual(
+      []
+    )
+
+    const fallbackMessages = messages.map((item) =>
+      isUserMessage(item) && item.id === message.id
+        ? {
+            ...item,
+            reactions: [{ emoji: "🎉", count: 2, reactedByMe: false }],
+          }
+        : item
+    )
+    expect(
+      resolveMockReactionUsers(seed, fallbackMessages, message.id, "🎉").map(
+        ({ name }) => name
+      )
+    ).toEqual(["Grace Liang", "Marcus Bennett"])
+  })
+
+  it("shows reader identities in group message info and derives their count", async () => {
+    renderChat(
+      makeRuntime({
+        channel: {
+          id: "g1",
+          type: "group",
+          title: "Product Team",
+          avatar: { type: "team", name: "Product Team" },
+        },
+        messages: [
+          {
+            id: "g-m1",
+            author: { id: "me", name: "Me" },
+            body: "Shipping today",
+            createdAt: now,
+            isMine: true,
+            status: "read",
+            readBy: [
+              { id: "grace", name: "Grace Liang" },
+              { id: "marcus", name: "Marcus Bennett" },
+            ],
+            readByCount: 99,
+          },
+        ],
+      })
+    )
+    expect(screen.getByText(/read by 2/i)).toBeInTheDocument()
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /message actions/i })
+    )
+    await userEvent.click(screen.getByRole("button", { name: /^Info$/i }))
+
+    const readers = screen.getByRole("list", { name: /read by 2/i })
+    expect(within(readers).getByText("Grace Liang")).toBeInTheDocument()
+    expect(within(readers).getByText("Marcus Bennett")).toBeInTheDocument()
+  })
+
+  it("keeps the legacy group read count as a fallback", () => {
     renderChat(
       makeRuntime({
         channel: {
@@ -439,8 +531,52 @@ describe("F0Chat", () => {
         ],
       })
     )
-    // i18n.t("chat.readBy.other", { count: 3 }) → "Read by 3".
     expect(screen.getByText(/read by 3/i)).toBeInTheDocument()
+  })
+
+  it("loads reaction users once across repeated hovers", async () => {
+    const loadReactionUsers = vi.fn().mockResolvedValue([
+      { id: "grace", name: "Grace Liang" },
+      { id: "marcus", name: "Marcus Bennett" },
+    ])
+    renderChat(
+      makeRuntime({
+        messages: [
+          {
+            id: "m-reaction",
+            author: { id: "other", name: "María José" },
+            body: "Great launch",
+            createdAt: now,
+            isMine: false,
+            reactions: [
+              {
+                emoji: "👍",
+                count: 2,
+                reactedByMe: false,
+              },
+            ],
+          },
+        ],
+        loadReactionUsers,
+      })
+    )
+
+    const reaction = screen.getByRole("button", {
+      name: `${getEmojiLabel("👍")}: 2`,
+    })
+    expect(reaction).toHaveAttribute("aria-pressed", "false")
+    await userEvent.hover(reaction)
+    await waitFor(() =>
+      expect(loadReactionUsers).toHaveBeenCalledWith("m-reaction", "👍")
+    )
+    await userEvent.unhover(reaction)
+    await userEvent.hover(reaction)
+    expect(
+      await screen.findAllByText("Grace Liang, Marcus Bennett")
+    ).not.toHaveLength(0)
+    await userEvent.unhover(reaction)
+    await userEvent.hover(reaction)
+    expect(loadReactionUsers).toHaveBeenCalledTimes(1)
   })
 
   it("names the typing users in a group (interpolated label)", () => {

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
@@ -505,6 +505,97 @@ describe("F0Chat", () => {
     expect(screen.getByText("report.pdf")).toBeInTheDocument()
   })
 
+  it("rejects a whole batch when one file exceeds the configured size limit", async () => {
+    vi.useFakeTimers()
+    try {
+      const maxFileSizeBytes = 100 * 1024 * 1024
+      const uploadFiles = vi.fn().mockResolvedValue([])
+      const { container } = renderChat(
+        makeRuntime({ uploadFiles, maxFileSizeBytes })
+      )
+      const fileInput =
+        container.querySelector<HTMLInputElement>("input[type=file]")!
+      const withinLimit = new File(["small"], "notes.txt", {
+        type: "text/plain",
+      })
+      const tooLarge = new File(["small"], "archive.zip", {
+        type: "application/zip",
+      })
+      Object.defineProperty(tooLarge, "size", {
+        value: maxFileSizeBytes + 1,
+      })
+
+      fireEvent.change(fileInput, {
+        target: { files: [withinLimit, tooLarge] },
+      })
+
+      expect(uploadFiles).not.toHaveBeenCalled()
+      expect(
+        screen.getByText("Each file must be 100 MB or smaller")
+      ).toBeInTheDocument()
+
+      act(() => vi.advanceTimersByTime(4_000))
+      expect(
+        screen.getByText("Each file must be 100 MB or smaller")
+      ).toBeInTheDocument()
+
+      vi.useRealTimers()
+      const atLimit = new File(["small"], "at-limit.zip", {
+        type: "application/zip",
+      })
+      Object.defineProperty(atLimit, "size", { value: maxFileSizeBytes })
+      fireEvent.change(fileInput, { target: { files: [atLimit] } })
+
+      expect(uploadFiles).toHaveBeenCalledWith([atLimit])
+      await waitFor(() =>
+        expect(
+          screen.queryByText("Each file must be 100 MB or smaller")
+        ).not.toBeInTheDocument()
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("attaches pasted files without intercepting text-only paste", async () => {
+    const maxFileSizeBytes = 100 * 1024 * 1024
+    const uploadFiles = vi.fn().mockResolvedValue([])
+    renderChat(makeRuntime({ uploadFiles, maxFileSizeBytes }))
+    const textarea = screen.getByPlaceholderText("Write something here..")
+    const pastedFile = new File(["pasted"], "pasted-notes.txt", {
+      type: "text/plain",
+    })
+    const oversizedFile = new File(["large"], "oversized-paste.zip", {
+      type: "application/zip",
+    })
+    Object.defineProperty(oversizedFile, "size", {
+      value: maxFileSizeBytes + 1,
+    })
+
+    expect(
+      fireEvent.paste(textarea, {
+        clipboardData: { files: [pastedFile, oversizedFile] },
+      })
+    ).toBe(false)
+    expect(uploadFiles).not.toHaveBeenCalled()
+    expect(
+      screen.getByText("Each file must be 100 MB or smaller")
+    ).toBeInTheDocument()
+
+    expect(
+      fireEvent.paste(textarea, {
+        clipboardData: { files: [pastedFile] },
+      })
+    ).toBe(false)
+    await waitFor(() => expect(uploadFiles).toHaveBeenCalledWith([pastedFile]))
+
+    expect(
+      fireEvent.paste(textarea, {
+        clipboardData: { files: [] },
+      })
+    ).toBe(true)
+  })
+
   it("renders the empty state when there are no messages", () => {
     renderChat(makeRuntime({ messages: [] }))
     expect(screen.getByText(/no messages yet/i)).toBeInTheDocument()
@@ -644,8 +735,17 @@ describe("F0Chat", () => {
             isMine: true,
             status: "read",
             readBy: [
-              { id: "grace", name: "Grace Liang" },
-              { id: "marcus", name: "Marcus Bennett" },
+              {
+                id: "grace",
+                name: "Grace Liang",
+                subtitle: "Data Analyst",
+                profileHref: "/people/grace",
+              },
+              {
+                id: "marcus",
+                name: "Marcus Bennett",
+                subtitle: "Engineering Manager",
+              },
             ],
             readByCount: 99,
           },
@@ -663,12 +763,45 @@ describe("F0Chat", () => {
     await userEvent.click(screen.getByRole("button", { name: /^Info$/i }))
 
     const readers = screen.getByRole("list", { name: /read by 2/i })
-    expect(screen.getByRole("region", { name: /info/i })).toHaveAttribute(
-      "tabindex",
-      "0"
+    const infoPanel = screen.getByRole("region", { name: /info/i })
+    expect(infoPanel).toHaveAttribute("tabindex", "0")
+    const grace = within(readers).getByRole("link", {
+      name: /Grace Liang/i,
+    })
+    const marcus = within(readers).getByText("Marcus Bennett").parentElement!
+    expect(grace).toHaveAttribute("href", "/people/grace")
+    expect(marcus).toHaveAttribute("tabindex", "0")
+    expect(
+      within(readers).queryByRole("link", { name: /Marcus Bennett/i })
+    ).not.toBeInTheDocument()
+
+    await userEvent.hover(grace)
+    expect(await screen.findByText("Data Analyst")).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: /view profile/i })).toHaveAttribute(
+      "href",
+      "/people/grace"
     )
-    expect(within(readers).getByText("Grace Liang")).toBeInTheDocument()
-    expect(within(readers).getByText("Marcus Bennett")).toBeInTheDocument()
+    await userEvent.unhover(grace)
+    await waitFor(() =>
+      expect(screen.queryByText("Data Analyst")).not.toBeInTheDocument()
+    )
+
+    const backButton = screen.getByRole("button", { name: /back/i })
+    expect(backButton).toHaveFocus()
+    await userEvent.tab()
+    expect(infoPanel).toHaveFocus()
+    await userEvent.tab()
+    expect(grace).toHaveFocus()
+    expect(await screen.findByText("Data Analyst")).toBeInTheDocument()
+
+    await userEvent.tab()
+    expect(marcus).toHaveFocus()
+    expect(await screen.findByText("Engineering Manager")).toBeInTheDocument()
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("link", { name: /view profile/i })
+      ).not.toBeInTheDocument()
+    )
   })
 
   it("shows read with the time once every channel member has read it", () => {

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
@@ -1,8 +1,10 @@
 import { beforeAll, describe, expect, it, vi } from "vitest"
 
 import {
+  act,
   fireEvent,
   zeroRender as render,
+  zeroRenderHook as renderHook,
   screen,
   userEvent,
   waitFor,
@@ -12,7 +14,14 @@ import { getEmojiLabel } from "@/lib/emojis"
 
 import { F0Chat } from "../F0Chat"
 import { resolveMockReactionUsers } from "../mocks/MockChatApp"
-import { initialConvState, SEED_BY_ID, SEEDS } from "../mocks/mockSeeds"
+import {
+  groupReadersFor,
+  initialConvState,
+  ME,
+  SEED_BY_ID,
+  SEEDS,
+} from "../mocks/mockSeeds"
+import { useMockChatStore } from "../mocks/useMockChatApp"
 import { F0ChatProvider } from "../providers/F0ChatProvider"
 import { isUserMessage, type F0ChatMessage, type F0ChatRuntime } from "../types"
 
@@ -145,7 +154,11 @@ describe("F0Chat", () => {
     await userEvent.click(screen.getByRole("button", { name: /info/i }))
     // Menu is replaced in place by the info panel (Delivered row + Back button).
     expect(screen.getByText(/delivered/i)).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: /back/i })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /back/i })).toHaveFocus()
+    expect(screen.getByRole("region", { name: /info/i })).toHaveAttribute(
+      "tabindex",
+      "0"
+    )
     expect(
       screen.queryByRole("button", { name: /^Reply$/i })
     ).not.toBeInTheDocument()
@@ -434,6 +447,71 @@ describe("F0Chat", () => {
     }
   })
 
+  it("seeds more than 40 readers for the application frame overflow demo", () => {
+    const seed = SEED_BY_ID.get("grp-reporting")
+    if (!seed) throw new Error("Expected grp-reporting mock seed")
+
+    const messages = initialConvState(seed).messages.filter(isUserMessage)
+
+    expect(messages.length).toBeGreaterThan(0)
+    for (const message of messages) {
+      expect(message.readBy?.length).toBeGreaterThan(40)
+    }
+
+    const firstParticipant = seed.participants[0]
+    if (!firstParticipant) throw new Error("Expected group participants")
+    const readers = groupReadersFor(
+      {
+        ...seed,
+        participants: [...seed.participants, firstParticipant],
+      },
+      ME.id
+    )
+    expect(new Set(readers?.map(({ id }) => id)).size).toBe(readers?.length)
+
+    const dmSeed = SEED_BY_ID.get("dm-eleanor")
+    if (!dmSeed) throw new Error("Expected dm-eleanor mock seed")
+    expect(groupReadersFor(dmSeed, ME.id)).toBeUndefined()
+  })
+
+  it("adds group readers only when a live message reaches the read state", async () => {
+    vi.useFakeTimers()
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.9)
+
+    try {
+      const { result } = renderHook(() => useMockChatStore())
+      act(() => {
+        result.current.send("grp-reporting", { body: "Receipt state test" })
+      })
+
+      const getSentMessage = (): F0ChatMessage => {
+        const message = result.current.states["grp-reporting"]?.messages
+          .filter(isUserMessage)
+          .find(({ body }) => body === "Receipt state test")
+        if (!message) throw new Error("Expected the live mock message")
+        return message
+      }
+
+      expect(getSentMessage().status).toBe("sending")
+      expect(getSentMessage().readBy).toBeUndefined()
+
+      await act(() => vi.advanceTimersByTimeAsync(400))
+      expect(getSentMessage().status).toBe("sent")
+      expect(getSentMessage().readBy).toBeUndefined()
+
+      await act(() => vi.advanceTimersByTimeAsync(900))
+      expect(getSentMessage().status).toBe("delivered")
+      expect(getSentMessage().readBy).toBeUndefined()
+
+      await act(() => vi.advanceTimersByTimeAsync(900))
+      expect(getSentMessage().status).toBe("read")
+      expect(getSentMessage().readBy).toHaveLength(45)
+    } finally {
+      randomSpy.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
   it("resolves complete and fallback reaction users in the application mock", () => {
     const seed = SEED_BY_ID.get("grp-reporting")
     if (!seed) throw new Error("Expected grp-reporting mock seed")
@@ -505,6 +583,10 @@ describe("F0Chat", () => {
     await userEvent.click(screen.getByRole("button", { name: /^Info$/i }))
 
     const readers = screen.getByRole("list", { name: /read by 2/i })
+    expect(screen.getByRole("region", { name: /info/i })).toHaveAttribute(
+      "tabindex",
+      "0"
+    )
     expect(within(readers).getByText("Grace Liang")).toBeInTheDocument()
     expect(within(readers).getByText("Marcus Bennett")).toBeInTheDocument()
   })

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
@@ -24,6 +24,7 @@ import {
 import { useMockChatStore } from "../mocks/useMockChatApp"
 import { F0ChatProvider } from "../providers/F0ChatProvider"
 import { isUserMessage, type F0ChatMessage, type F0ChatRuntime } from "../types"
+import { formatClock } from "../utils/natural-time"
 
 // jsdom has no layout — wrap Virtuoso in its official mock context so every
 // row renders (see mocks/virtuoso-jsdom).
@@ -134,7 +135,82 @@ describe("F0Chat", () => {
 
   it("shows the read status under the last message (mine)", () => {
     renderChat(makeRuntime())
-    expect(screen.getByText(/^Read/)).toBeInTheDocument()
+    const status = screen.getByRole("status")
+    expect(status).toHaveTextContent(`Read · ${formatClock(new Date(now))}`)
+    expect(status).toHaveAttribute("aria-live", "polite")
+    expect(status).toHaveAttribute("aria-atomic", "true")
+  })
+
+  it("shows sent with the time until a direct message is read", () => {
+    renderChat(
+      makeRuntime({
+        messages: [
+          {
+            id: "sent-message",
+            author: { id: "me", name: "Me" },
+            body: "Waiting for the receipt",
+            createdAt: now,
+            isMine: true,
+            status: "sent",
+          },
+        ],
+      })
+    )
+
+    expect(
+      screen.getByText(`Sent · ${formatClock(new Date(now))}`)
+    ).toBeInTheDocument()
+  })
+
+  it("updates the stable live region from sent to read", () => {
+    const message: F0ChatMessage = {
+      id: "live-status-message",
+      author: { id: "me", name: "Me" },
+      body: "Waiting for the receipt",
+      createdAt: now,
+      isMine: true,
+      status: "sent",
+    }
+    const { rerender } = renderChat(
+      makeRuntime({
+        messages: [message],
+      })
+    )
+    const status = screen.getByRole("status")
+    expect(status).toHaveTextContent(`Sent · ${formatClock(new Date(now))}`)
+
+    rerender(
+      <F0ChatProvider
+        runtime={makeRuntime({
+          messages: [{ ...message, status: "read" }],
+        })}
+      >
+        <F0Chat />
+      </F0ChatProvider>
+    )
+
+    expect(screen.getByRole("status")).toBe(status)
+    expect(status).toHaveTextContent(`Read · ${formatClock(new Date(now))}`)
+  })
+
+  it("keeps the legacy bare time when the message status is omitted", () => {
+    renderChat(
+      makeRuntime({
+        messages: [
+          {
+            id: "legacy-message",
+            author: { id: "me", name: "Me" },
+            body: "No delivery status",
+            createdAt: now,
+            isMine: true,
+          },
+        ],
+      })
+    )
+
+    const status = screen.getByRole("status")
+    expect(status).toHaveTextContent(formatClock(new Date(now)))
+    expect(status).not.toHaveTextContent(/Sent|Read/)
   })
 
   it("deletes a message from its actions menu", async () => {
@@ -549,7 +625,7 @@ describe("F0Chat", () => {
     ).toEqual(["Grace Liang", "Marcus Bennett"])
   })
 
-  it("shows reader identities in group message info and derives their count", async () => {
+  it("keeps a group message sent until every channel member has read it", async () => {
     renderChat(
       makeRuntime({
         channel: {
@@ -557,6 +633,7 @@ describe("F0Chat", () => {
           type: "group",
           title: "Product Team",
           avatar: { type: "team", name: "Product Team" },
+          memberCount: 4,
         },
         messages: [
           {
@@ -575,7 +652,10 @@ describe("F0Chat", () => {
         ],
       })
     )
-    expect(screen.getByText(/read by 2/i)).toBeInTheDocument()
+    expect(
+      screen.getByText(`Sent · ${formatClock(new Date(now))}`)
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/read by 2/i)).not.toBeInTheDocument()
 
     await userEvent.click(
       screen.getByRole("button", { name: /message actions/i })
@@ -591,7 +671,96 @@ describe("F0Chat", () => {
     expect(within(readers).getByText("Marcus Bennett")).toBeInTheDocument()
   })
 
-  it("keeps the legacy group read count as a fallback", () => {
+  it("shows read with the time once every channel member has read it", () => {
+    renderChat(
+      makeRuntime({
+        channel: {
+          id: "g1",
+          type: "group",
+          title: "Product Team",
+          avatar: { type: "team", name: "Product Team" },
+          memberCount: 3,
+        },
+        messages: [
+          {
+            id: "g-m1",
+            author: { id: "me", name: "Me" },
+            body: "Shipping today",
+            createdAt: now,
+            isMine: true,
+            status: "read",
+            readBy: [
+              { id: "grace", name: "Grace Liang" },
+              { id: "marcus", name: "Marcus Bennett" },
+            ],
+          },
+        ],
+      })
+    )
+
+    expect(
+      screen.getByText(`Read · ${formatClock(new Date(now))}`)
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/read by 2/i)).not.toBeInTheDocument()
+  })
+
+  it("keeps a known group sent when receipt data is unavailable", () => {
+    renderChat(
+      makeRuntime({
+        channel: {
+          id: "g1",
+          type: "group",
+          title: "Product Team",
+          avatar: { type: "team", name: "Product Team" },
+          memberCount: 3,
+        },
+        messages: [
+          {
+            id: "g-m1",
+            author: { id: "me", name: "Me" },
+            body: "Shipping today",
+            createdAt: now,
+            isMine: true,
+            status: "read",
+          },
+        ],
+      })
+    )
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      `Sent · ${formatClock(new Date(now))}`
+    )
+  })
+
+  it("shows a single-member group as read without receipt rows", () => {
+    renderChat(
+      makeRuntime({
+        channel: {
+          id: "g1",
+          type: "group",
+          title: "Personal notes",
+          avatar: { type: "team", name: "Personal notes" },
+          memberCount: 1,
+        },
+        messages: [
+          {
+            id: "g-m1",
+            author: { id: "me", name: "Me" },
+            body: "No other readers are expected",
+            createdAt: now,
+            isMine: true,
+            status: "read",
+          },
+        ],
+      })
+    )
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      `Read · ${formatClock(new Date(now))}`
+    )
+  })
+
+  it("trusts the group message status when member count is unavailable", () => {
     renderChat(
       makeRuntime({
         channel: {
@@ -608,11 +777,49 @@ describe("F0Chat", () => {
             createdAt: now,
             isMine: true,
             status: "read",
+            readByCount: 2,
+          },
+        ],
+      })
+    )
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      `Read · ${formatClock(new Date(now))}`
+    )
+  })
+
+  it("keeps the legacy group read count inside the info panel", async () => {
+    renderChat(
+      makeRuntime({
+        channel: {
+          id: "g1",
+          type: "group",
+          title: "Product Team",
+          avatar: { type: "team", name: "Product Team" },
+          memberCount: 4,
+        },
+        messages: [
+          {
+            id: "g-m1",
+            author: { id: "me", name: "Me" },
+            body: "Shipping today",
+            createdAt: now,
+            isMine: true,
+            status: "read",
             readByCount: 3,
           },
         ],
       })
     )
+    expect(
+      screen.getByText(`Read · ${formatClock(new Date(now))}`)
+    ).toBeInTheDocument()
+    expect(screen.queryByText(/read by 3/i)).not.toBeInTheDocument()
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /message actions/i })
+    )
+    await userEvent.click(screen.getByRole("button", { name: /^Info$/i }))
     expect(screen.getByText(/read by 3/i)).toBeInTheDocument()
   })
 

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
@@ -1199,43 +1199,30 @@ describe("F0Chat", () => {
     const readers = screen.getByRole("list", { name: /read by 2/i })
     const infoPanel = screen.getByRole("region", { name: /info/i })
     expect(infoPanel).toHaveAttribute("tabindex", "0")
-    const grace = within(readers).getByRole("link", {
-      name: /Grace Liang/i,
-    })
-    const marcus = within(readers).getByText("Marcus Bennett").parentElement!
-    expect(grace).toHaveAttribute("href", "/people/grace")
-    expect(marcus).toHaveAttribute("tabindex", "0")
+    const graceRow = within(readers).getByText("Grace Liang").parentElement!
+    expect(graceRow).toBeVisible()
+    expect(within(readers).getByText("Marcus Bennett")).toBeVisible()
+    expect(within(readers).queryByRole("link")).not.toBeInTheDocument()
     expect(
-      within(readers).queryByRole("link", { name: /Marcus Bennett/i })
+      readers.querySelector(
+        '[tabindex], button, a, input, select, textarea, [role="button"], [role="link"], [contenteditable="true"]'
+      )
     ).not.toBeInTheDocument()
 
-    await userEvent.hover(grace)
-    expect(await screen.findByText("Data Analyst")).toBeInTheDocument()
-    expect(screen.getByRole("link", { name: /view profile/i })).toHaveAttribute(
-      "href",
-      "/people/grace"
-    )
-    await userEvent.unhover(grace)
-    await waitFor(() =>
-      expect(screen.queryByText("Data Analyst")).not.toBeInTheDocument()
-    )
+    await userEvent.hover(graceRow)
+    await new Promise((resolve) => setTimeout(resolve, 200))
+    expect(screen.queryByText("Data Analyst")).not.toBeInTheDocument()
+    expect(screen.queryByText("Engineering Manager")).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole("link", { name: /view profile/i })
+    ).not.toBeInTheDocument()
 
     const backButton = screen.getByRole("button", { name: /^back$/i })
     expect(backButton).toHaveFocus()
     await userEvent.tab()
     expect(infoPanel).toHaveFocus()
     await userEvent.tab()
-    expect(grace).toHaveFocus()
-    expect(await screen.findByText("Data Analyst")).toBeInTheDocument()
-
-    await userEvent.tab()
-    expect(marcus).toHaveFocus()
-    expect(await screen.findByText("Engineering Manager")).toBeInTheDocument()
-    await waitFor(() =>
-      expect(
-        screen.queryByRole("link", { name: /view profile/i })
-      ).not.toBeInTheDocument()
-    )
+    expect(readers.contains(document.activeElement)).toBe(false)
   })
 
   it("shows read with the time once every channel member has read it", () => {

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
@@ -511,7 +511,7 @@ describe("F0Chat", () => {
       documentPreview.querySelector('[data-testid="chat-document-attachment"]')
     ).toHaveStyle({ width: "64px" })
     const videoPreview = screen.getByTestId("chat-composer-video-preview")
-    expect(videoPreview).toHaveClass("h-16", "w-16")
+    expect(videoPreview).toHaveClass("h-16", "w-28")
     expect(screen.getByTestId("chat-composer-image-preview")).toHaveClass(
       "h-16",
       "w-16"

--- a/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/__tests__/F0Chat.test.tsx
@@ -1,5 +1,6 @@
 import { beforeAll, describe, expect, it, vi } from "vitest"
 
+import { getEmojiLabel } from "@/lib/emojis"
 import {
   act,
   fireEvent,
@@ -10,7 +11,6 @@ import {
   waitFor,
   within,
 } from "@/testing/test-utils"
-import { getEmojiLabel } from "@/lib/emojis"
 
 import { F0Chat } from "../F0Chat"
 import { resolveMockReactionUsers } from "../mocks/MockChatApp"
@@ -23,7 +23,12 @@ import {
 } from "../mocks/mockSeeds"
 import { useMockChatStore } from "../mocks/useMockChatApp"
 import { F0ChatProvider } from "../providers/F0ChatProvider"
-import { isUserMessage, type F0ChatMessage, type F0ChatRuntime } from "../types"
+import {
+  isUserMessage,
+  type F0ChatAttachment,
+  type F0ChatMessage,
+  type F0ChatRuntime,
+} from "../types"
 import { formatClock } from "../utils/natural-time"
 
 // jsdom has no layout — wrap Virtuoso in its official mock context so every
@@ -230,7 +235,7 @@ describe("F0Chat", () => {
     await userEvent.click(screen.getByRole("button", { name: /info/i }))
     // Menu is replaced in place by the info panel (Delivered row + Back button).
     expect(screen.getByText(/delivered/i)).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: /back/i })).toHaveFocus()
+    expect(screen.getByRole("button", { name: /^back$/i })).toHaveFocus()
     expect(screen.getByRole("region", { name: /info/i })).toHaveAttribute(
       "tabindex",
       "0"
@@ -465,14 +470,20 @@ describe("F0Chat", () => {
     expect(screen.getByText("deck.pptx")).toBeInTheDocument()
   })
 
-  it("previews uploaded images as square thumbnails and other files as chips", async () => {
-    // The pdf uploads first — images must still render grouped at the front.
+  it("previews images, videos, and documents immediately in the composer", async () => {
+    // The documents upload first — images must still render grouped at the front.
     const uploadFiles = vi.fn().mockResolvedValue([
       {
         kind: "file",
         url: "blob:doc",
         name: "report.pdf",
         mimeType: "application/pdf",
+      },
+      {
+        kind: "file",
+        url: "blob:video",
+        name: "walkthrough.webm",
+        mimeType: "video/webm",
       },
       { kind: "image", url: "blob:img", name: "photo.png" },
     ])
@@ -483,26 +494,285 @@ describe("F0Chat", () => {
       target: {
         files: [
           new File(["doc"], "report.pdf", { type: "application/pdf" }),
+          new File(["video"], "walkthrough.webm", { type: "video/webm" }),
           new File(["img"], "photo.png", { type: "image/png" }),
         ],
       },
     })
-    // The image resolves to an inline square preview, the pdf to a file chip.
-    const preview = await screen.findByRole("img", { name: /photo\.png/i })
-    expect(preview).toHaveAttribute("src", "blob:img")
-    const chip = screen.getByText("report.pdf")
-    // The image preview comes before the file chip despite uploading second.
+    // Local object URLs make every supported preview visible before the upload
+    // promise swaps them for the host-provided URLs.
+    const localPreview = await screen.findByRole("img", {
+      name: /photo\.png/i,
+    })
+    expect(localPreview.getAttribute("src")).toMatch(/^blob:/)
     expect(
-      preview.compareDocumentPosition(chip) & Node.DOCUMENT_POSITION_FOLLOWING
+      screen.getByTestId("chat-composer-document-preview")
+    ).toHaveTextContent("report.pdf")
+    expect(
+      screen.getByTestId("chat-composer-video-preview")
+    ).toBeInTheDocument()
+    await waitFor(() =>
+      expect(screen.getByRole("img", { name: /photo\.png/i })).toHaveAttribute(
+        "src",
+        "blob:img"
+      )
+    )
+
+    // The image preview comes before the document despite uploading last.
+    const preview = screen.getByRole("img", { name: /photo\.png/i })
+    const document = screen.getByText("report.pdf")
+    expect(
+      preview.compareDocumentPosition(document) &
+        Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy()
     // Each pending attachment carries its own remove action.
-    const removeButtons = screen.getAllByRole("button", { name: /^remove$/i })
-    expect(removeButtons).toHaveLength(2)
+    const removeButtons = screen.getAllByRole("button", { name: /^remove /i })
+    expect(removeButtons).toHaveLength(3)
+    const attachmentStrip = screen.getByRole("region", {
+      name: "3 attachments",
+    })
+    expect(attachmentStrip).toHaveAttribute("tabindex", "0")
+    expect(attachmentStrip).toHaveClass("flex-nowrap", "overflow-x-auto")
     await userEvent.click(removeButtons[0])
     expect(
       screen.queryByRole("img", { name: /photo\.png/i })
     ).not.toBeInTheDocument()
-    expect(screen.getByText("report.pdf")).toBeInTheDocument()
+    await waitFor(() => expect(attachmentStrip).toHaveFocus())
+    expect(document).toBeInTheDocument()
+  })
+
+  it("removes a local preview without restoring it when upload finishes", async () => {
+    let resolveUpload: (attachments: F0ChatAttachment[]) => void = () => {}
+    const uploadFiles = vi.fn(
+      () =>
+        new Promise<F0ChatAttachment[]>((resolve) => {
+          resolveUpload = resolve
+        })
+    )
+    const revokeObjectUrl = vi.spyOn(URL, "revokeObjectURL")
+    const { container } = renderChat(makeRuntime({ uploadFiles }))
+    const fileInput =
+      container.querySelector<HTMLInputElement>("input[type=file]")!
+
+    fireEvent.change(fileInput, {
+      target: {
+        files: [
+          new File(["video"], "walkthrough.webm", { type: "video/webm" }),
+        ],
+      },
+    })
+
+    const preview = await screen.findByTestId("chat-composer-video-preview")
+    const localUrl = preview.querySelector("video")?.getAttribute("src")
+    expect(localUrl).toMatch(/^blob:/)
+    expect(
+      screen.getByTestId("chat-composer-attachment-uploading")
+    ).toBeInTheDocument()
+
+    await userEvent.click(screen.getByRole("button", { name: /^remove /i }))
+    expect(preview).not.toBeInTheDocument()
+    await waitFor(() =>
+      expect(
+        screen.getByPlaceholderText("Write something here..")
+      ).toHaveFocus()
+    )
+    expect(revokeObjectUrl).toHaveBeenCalledWith(localUrl)
+
+    act(() => {
+      resolveUpload([
+        {
+          kind: "file",
+          url: "https://cdn.example.com/walkthrough.webm",
+          name: "walkthrough.webm",
+          mimeType: "video/webm",
+        },
+      ])
+    })
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId("chat-composer-video-preview")
+      ).not.toBeInTheDocument()
+    )
+    revokeObjectUrl.mockRestore()
+  })
+
+  it("releases the local preview URL after a successful upload", async () => {
+    let resolveUpload: (attachments: F0ChatAttachment[]) => void = () => {}
+    const uploadFiles = vi.fn(
+      () =>
+        new Promise<F0ChatAttachment[]>((resolve) => {
+          resolveUpload = resolve
+        })
+    )
+    const revokeObjectUrl = vi.spyOn(URL, "revokeObjectURL")
+    const { container } = renderChat(makeRuntime({ uploadFiles }))
+    const fileInput =
+      container.querySelector<HTMLInputElement>("input[type=file]")!
+
+    fireEvent.change(fileInput, {
+      target: {
+        files: [
+          new File(["video"], "walkthrough.webm", { type: "video/webm" }),
+        ],
+      },
+    })
+
+    const localVideo = (
+      await screen.findByTestId("chat-composer-video-preview")
+    ).querySelector("video")!
+    const localUrl = localVideo.getAttribute("src")
+    expect(localUrl).toMatch(/^blob:/)
+    const removeButton = screen.getByRole("button", {
+      name: "Remove walkthrough.webm",
+    })
+    removeButton.focus()
+
+    act(() => {
+      resolveUpload([
+        {
+          kind: "file",
+          url: "https://cdn.example.com/walkthrough.webm",
+          name: "walkthrough.webm",
+          mimeType: "video/webm",
+        },
+      ])
+    })
+
+    await waitFor(() =>
+      expect(
+        screen.getByTestId("chat-composer-video-preview").querySelector("video")
+      ).toHaveAttribute("src", "https://cdn.example.com/walkthrough.webm")
+    )
+    expect(revokeObjectUrl).toHaveBeenCalledWith(localUrl)
+    expect(removeButton).toHaveFocus()
+    revokeObjectUrl.mockRestore()
+  })
+
+  it("preserves attachment order when concurrent uploads resolve out of order", async () => {
+    const resolvers = new Map<
+      string,
+      (attachments: F0ChatAttachment[]) => void
+    >()
+    const uploadFiles = vi.fn(
+      (files: File[]) =>
+        new Promise<F0ChatAttachment[]>((resolve) => {
+          resolvers.set(files[0]!.name, resolve)
+        })
+    )
+    const { container } = renderChat(makeRuntime({ uploadFiles }))
+    const fileInput =
+      container.querySelector<HTMLInputElement>("input[type=file]")!
+    const first = new File(["first"], "first-batch.zip", {
+      type: "application/zip",
+    })
+    const second = new File(["second"], "second-batch.zip", {
+      type: "application/zip",
+    })
+
+    fireEvent.change(fileInput, { target: { files: [first] } })
+    fireEvent.change(fileInput, { target: { files: [second] } })
+    await screen.findByText("second-batch.zip")
+
+    act(() => {
+      resolvers.get("second-batch.zip")?.([
+        {
+          kind: "file",
+          url: "https://cdn.example.com/second-batch.zip",
+          name: "second-batch.zip",
+          mimeType: "application/zip",
+        },
+      ])
+    })
+    await waitFor(() =>
+      expect(
+        screen.getAllByTestId("chat-composer-attachment-uploading")
+      ).toHaveLength(1)
+    )
+
+    act(() => {
+      resolvers.get("first-batch.zip")?.([
+        {
+          kind: "file",
+          url: "https://cdn.example.com/first-batch.zip",
+          name: "first-batch.zip",
+          mimeType: "application/zip",
+        },
+      ])
+    })
+    await waitFor(() =>
+      expect(
+        screen.queryAllByTestId("chat-composer-attachment-uploading")
+      ).toHaveLength(0)
+    )
+
+    const firstName = screen.getByText("first-batch.zip")
+    const secondName = screen.getByText("second-batch.zip")
+    expect(
+      firstName.compareDocumentPosition(secondName) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
+  it("releases local preview URLs when an upload fails", async () => {
+    let rejectUpload: (error: Error) => void = () => {}
+    const uploadFiles = vi.fn(
+      () =>
+        new Promise<F0ChatAttachment[]>((_resolve, reject) => {
+          rejectUpload = reject
+        })
+    )
+    const revokeObjectUrl = vi.spyOn(URL, "revokeObjectURL")
+    const { container } = renderChat(makeRuntime({ uploadFiles }))
+    const fileInput =
+      container.querySelector<HTMLInputElement>("input[type=file]")!
+
+    fireEvent.change(fileInput, {
+      target: {
+        files: [new File(["image"], "cover.webp", { type: "image/webp" })],
+      },
+    })
+
+    const localImage = await screen.findByRole("img", {
+      name: "cover.webp",
+    })
+    const localUrl = localImage.getAttribute("src")
+    expect(localUrl).toMatch(/^blob:/)
+
+    act(() => rejectUpload(new Error("network failure")))
+
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId("chat-composer-image-preview")
+      ).not.toBeInTheDocument()
+    )
+    expect(screen.getByText("Upload failed")).toBeInTheDocument()
+    expect(revokeObjectUrl).toHaveBeenCalledWith(localUrl)
+    revokeObjectUrl.mockRestore()
+  })
+
+  it("keeps an oversized preview document as an F0FileItem", async () => {
+    const uploadFiles = vi.fn(() => new Promise<F0ChatAttachment[]>(() => {}))
+    const { container } = renderChat(makeRuntime({ uploadFiles }))
+    const fileInput =
+      container.querySelector<HTMLInputElement>("input[type=file]")!
+    const oversizedSheet = new File(["sheet"], "large-report.xlsx", {
+      type: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    })
+    Object.defineProperty(oversizedSheet, "size", {
+      value: 11 * 1024 * 1024,
+    })
+
+    fireEvent.change(fileInput, {
+      target: { files: [oversizedSheet] },
+    })
+
+    expect(
+      await screen.findByTestId("chat-composer-file-preview")
+    ).toHaveTextContent("large-report.xlsx")
+    expect(
+      screen.queryByTestId("chat-composer-document-preview")
+    ).not.toBeInTheDocument()
+    await userEvent.click(screen.getByRole("button", { name: /^remove /i }))
   })
 
   it("rejects a whole batch when one file exceeds the configured size limit", async () => {
@@ -786,7 +1056,7 @@ describe("F0Chat", () => {
       expect(screen.queryByText("Data Analyst")).not.toBeInTheDocument()
     )
 
-    const backButton = screen.getByRole("button", { name: /back/i })
+    const backButton = screen.getByRole("button", { name: /^back$/i })
     expect(backButton).toHaveFocus()
     await userEvent.tab()
     expect(infoPanel).toHaveFocus()

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
@@ -12,19 +12,17 @@ import {
 
 import { F0AvatarAlert } from "@/components/avatars/F0AvatarAlert"
 import { ButtonInternal } from "@/components/F0Button/internal"
-import { F0FileItem } from "@/components/F0FileItem"
 import { ArrowUp, Check, Cross, Microphone, Paperclip } from "@/icons/app"
-import { Picker } from "@/sds/social/Reactions/Picker"
-import { useReducedMotion } from "@/lib/a11y"
-import { useI18n } from "@/lib/providers/i18n"
-import { containsEmojis } from "@/lib/text"
-import { cn } from "@/lib/utils"
 import { RecordingWaveform } from "@/kits/ai/F0AiChatTextArea/components/RecordingWaveform"
 import {
   type RecorderError,
   useAudioRecorder,
 } from "@/kits/ai/F0AiChatTextArea/useAudioRecorder"
-import { Skeleton } from "@/ui/skeleton"
+import { useReducedMotion } from "@/lib/a11y"
+import { useI18n } from "@/lib/providers/i18n"
+import { containsEmojis } from "@/lib/text"
+import { cn } from "@/lib/utils"
+import { Picker } from "@/sds/social/Reactions/Picker"
 
 import { buildHighlightSegments } from "../hooks/highlight-utils"
 import {
@@ -39,28 +37,56 @@ import {
   useChatReply,
 } from "../providers/ChatUIProvider"
 import { useF0Chat } from "../providers/F0ChatProvider"
-import { type F0ChatAttachment } from "../types"
+import {
+  type F0ChatAttachment,
+  type F0ChatFileAttachment,
+  type F0ChatImageAttachment,
+} from "../types"
+import { formatFileSize } from "../utils/attachments"
 import {
   EASE_OUT_SWIFT,
   layoutTransition,
   microEnterTransition,
   microExitTransition,
 } from "../utils/chat-motion"
-import { formatFileSize } from "../utils/attachments"
+import { ChatComposerAttachmentPreview } from "./ChatComposerAttachmentPreview"
 import { ChatEditChip } from "./ChatEditChip"
 import { ChatMentionPopover } from "./ChatMentionPopover"
 import { ChatReplyChip } from "./ChatReplyChip"
 import { ChatTextareaField } from "./ChatTextareaField"
-import { FadeInImage } from "./FadeInImage"
 
-/** A pending composer attachment: a skeleton while it uploads, then a square
- * image preview or an F0FileItem chip once the runtime resolves it. */
+type UploadingAttachment = {
+  id: string
+  status: "uploading"
+  attachment: F0ChatFileAttachment | F0ChatImageAttachment
+}
+
+/** An attachment shown immediately from a local URL while its upload resolves. */
 type PendingAttachment =
-  | { id: string; status: "uploading"; name: string; isImage: boolean }
+  | UploadingAttachment
   | { id: string; status: "ready"; attachment: F0ChatAttachment }
 
 const isImagePending = (att: PendingAttachment): boolean =>
-  att.status === "uploading" ? att.isImage : att.attachment.kind === "image"
+  att.attachment.kind === "image"
+
+const localAttachmentFromFile = (
+  file: File,
+  url: string
+): F0ChatFileAttachment | F0ChatImageAttachment =>
+  file.type.startsWith("image/")
+    ? {
+        kind: "image",
+        url,
+        name: file.name,
+        mimeType: file.type,
+      }
+    : {
+        kind: "file",
+        url,
+        name: file.name,
+        size: file.size,
+        mimeType: file.type,
+      }
 
 /** Composer: auto-growing textarea (no aura), attach, voice dictation, send.
  * Drag & drop is owned by the whole panel (F0Chat) and bridged here. */
@@ -94,6 +120,8 @@ export const ChatComposer = (): ReactNode => {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const highlightRef = useRef<HTMLDivElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const attachmentStripRef = useRef<HTMLDivElement>(null)
+  const localPreviewUrlsRef = useRef(new Set<string>())
 
   // Mentions are available wherever the host provides a member search — both
   // DMs (mention either person) and groups. The `@here` (everyone) option only
@@ -133,6 +161,21 @@ export const ChatComposer = (): ReactNode => {
     containsEmojis(value)
   // Monotonic id for pending attachments (avoids Date.now/random in render).
   const attachmentSeq = useRef(0)
+
+  const releaseLocalPreview = useCallback((url: string) => {
+    if (!localPreviewUrlsRef.current.delete(url)) return
+    URL.revokeObjectURL(url)
+  }, [])
+
+  useEffect(
+    () => () => {
+      for (const url of localPreviewUrlsRef.current) {
+        URL.revokeObjectURL(url)
+      }
+      localPreviewUrlsRef.current.clear()
+    },
+    []
+  )
 
   const isUploading = attachments.some((a) => a.status === "uploading")
 
@@ -311,14 +354,17 @@ export const ChatComposer = (): ReactNode => {
         )
         return
       }
-      // Show a skeleton per file immediately, then swap each for its chip once
-      // the runtime resolves the upload (or drop them + flash an error if it fails).
-      const pending = files.map((file) => ({
-        id: `att-${attachmentSeq.current++}`,
-        status: "uploading" as const,
-        name: file.name,
-        isImage: file.type.startsWith("image/"),
-      }))
+      // Render every previewable format immediately from a local object URL,
+      // then swap it for the host attachment without changing its stable key.
+      const pending = files.map((file): UploadingAttachment => {
+        const url = URL.createObjectURL(file)
+        localPreviewUrlsRef.current.add(url)
+        return {
+          id: `att-${attachmentSeq.current++}`,
+          status: "uploading",
+          attachment: localAttachmentFromFile(file, url),
+        }
+      })
       setAttachments((prev) => [...prev, ...pending])
       const pendingIds = new Set(pending.map((p) => p.id))
       try {
@@ -328,12 +374,22 @@ export const ChatComposer = (): ReactNode => {
           status: "ready",
           attachment,
         }))
-        setAttachments((prev) => [
-          ...prev.filter((a) => !pendingIds.has(a.id)),
-          ...ready,
-        ])
+        setAttachments((prev) => {
+          const readyById = new Map(ready.map((item) => [item.id, item]))
+          return prev.flatMap((item) => {
+            if (!pendingIds.has(item.id)) return [item]
+            const replacement = readyById.get(item.id)
+            return replacement ? [replacement] : []
+          })
+        })
+        for (const item of pending) {
+          releaseLocalPreview(item.attachment.url)
+        }
       } catch {
         setAttachments((prev) => prev.filter((a) => !pendingIds.has(a.id)))
+        for (const item of pending) {
+          releaseLocalPreview(item.attachment.url)
+        }
         showTransientError(i18n.chat.fileUploadError)
       }
     },
@@ -347,7 +403,37 @@ export const ChatComposer = (): ReactNode => {
       i18n.chat.tooManyFilesError,
       i18n.chat.fileTooLargeError,
       i18n.chat.fileUploadError,
+      releaseLocalPreview,
     ]
+  )
+
+  const removeAttachment = useCallback(
+    (id: string) => {
+      const item = attachments.find((attachment) => attachment.id === id)
+      if (item?.status === "uploading") {
+        releaseLocalPreview(item.attachment.url)
+      }
+      setAttachments((prev) =>
+        prev.filter((attachment) => attachment.id !== id)
+      )
+      requestAnimationFrame(() => {
+        const strip = attachmentStripRef.current
+        if (strip) strip.focus()
+        else textareaRef.current?.focus()
+      })
+    },
+    [attachments, releaseLocalPreview]
+  )
+
+  const releaseUploadingPreviews = useCallback(
+    (items: PendingAttachment[]) => {
+      for (const item of items) {
+        if (item.status === "uploading") {
+          releaseLocalPreview(item.attachment.url)
+        }
+      }
+    },
+    [releaseLocalPreview]
   )
 
   // Files dropped anywhere on the panel (F0Chat owns the drop zone) land here.
@@ -378,8 +464,15 @@ export const ChatComposer = (): ReactNode => {
     mentions.seedMentions([])
     setValue("")
     setCursorPosition(0)
+    releaseUploadingPreviews(attachments)
     setAttachments([])
-  }, [setEditingMessage, mentions.close, mentions.seedMentions])
+  }, [
+    setEditingMessage,
+    mentions.close,
+    mentions.seedMentions,
+    releaseUploadingPreviews,
+    attachments,
+  ])
 
   // Entering edit mode reloads the message into the composer — text, existing
   // attachments (as ready chips) and its mentions — then focuses at the end.
@@ -387,13 +480,14 @@ export const ChatComposer = (): ReactNode => {
     if (!editingMessage) return
     setValue(editingMessage.body)
     setCursorPosition(editingMessage.body.length)
-    setAttachments(
-      (editingMessage.attachments ?? []).map((attachment) => ({
+    setAttachments((prev) => {
+      releaseUploadingPreviews(prev)
+      return (editingMessage.attachments ?? []).map((attachment) => ({
         id: `att-${attachmentSeq.current++}`,
         status: "ready" as const,
         attachment,
       }))
-    )
+    })
     const entries: MentionEntry[] = [
       ...(editingMessage.mentions ?? []).map((m) => ({
         id: m.id,
@@ -420,6 +514,7 @@ export const ChatComposer = (): ReactNode => {
     channel.type,
     i18n.chat.mentionEveryone,
     mentions.seedMentions,
+    releaseUploadingPreviews,
   ])
 
   const handleSend = useCallback(() => {
@@ -605,12 +700,9 @@ export const ChatComposer = (): ReactNode => {
             )}
           </AnimatePresence>
 
-          {/* Pending attachments — a skeleton while uploading, then a square
-              image preview (matching the message thumbnails) or an F0FileItem
-              chip, each with a remove action. Each chip fades in and shrinks
-              out (`layout` slides the neighbours into the gap); the whole row
-              collapses when the last one goes (or the message sends). The
-              skeleton→ready swap crossfades inside the chip's stable key. */}
+          {/* Pending attachments render from local object URLs immediately.
+              Previewable documents, videos and images keep their visual shape
+              throughout upload; unsupported files use F0FileItem. */}
           <AnimatePresence initial={false}>
             {attachments.length > 0 && (
               <motion.div
@@ -625,16 +717,26 @@ export const ChatComposer = (): ReactNode => {
                 }}
               >
                 <div
+                  ref={attachmentStripRef}
+                  role="region"
+                  tabIndex={0}
+                  aria-label={i18n.t(
+                    attachments.length === 1
+                      ? "chat.attachmentCount.one"
+                      : "chat.attachmentCount.other",
+                    { count: attachments.length }
+                  )}
                   aria-live="polite"
                   aria-busy={isUploading}
-                  className="flex flex-wrap items-end gap-1 px-1 pt-1"
+                  className="flex flex-nowrap items-end gap-1 overflow-x-auto px-1 pt-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-f1-special-ring"
+                  data-testid="chat-composer-attachments"
                 >
                   <AnimatePresence initial={false} mode="popLayout">
                     {orderedAttachments.map((att) => (
                       <motion.div
                         key={att.id}
                         layout="position"
-                        className="flex"
+                        className="flex shrink-0"
                         initial={
                           shouldReduceMotion
                             ? false
@@ -658,69 +760,16 @@ export const ChatComposer = (): ReactNode => {
                         }}
                       >
                         <motion.div
-                          key={att.status}
                           className="flex"
                           initial={shouldReduceMotion ? false : { opacity: 0 }}
                           animate={{ opacity: 1 }}
                           transition={{ duration: 0.15 }}
                         >
-                          {att.status === "uploading" ? (
-                            <Skeleton
-                              className={cn(
-                                att.isImage
-                                  ? "h-16 w-16 rounded-lg"
-                                  : "h-9 w-36 rounded"
-                              )}
-                            />
-                          ) : att.attachment.kind === "image" ? (
-                            <div className="group/attachment relative flex">
-                              <FadeInImage
-                                src={
-                                  att.attachment.thumbnailUrl ??
-                                  att.attachment.url
-                                }
-                                alt={att.attachment.name}
-                                className="h-16 w-16 rounded-lg border border-solid border-f1-border-secondary object-cover"
-                              />
-                              {/* Remove is hidden until hover; focus also
-                                  reveals it so it stays reachable by keyboard. */}
-                              <div className="absolute right-1 top-1 flex rounded bg-f1-background opacity-0 transition-opacity focus-within:opacity-100 group-hover/attachment:opacity-100">
-                                <ButtonInternal
-                                  variant="outline"
-                                  size="sm"
-                                  hideLabel
-                                  label={i18n.chat.removeFile}
-                                  icon={Cross}
-                                  onClick={() =>
-                                    setAttachments((prev) =>
-                                      prev.filter((a) => a.id !== att.id)
-                                    )
-                                  }
-                                />
-                              </div>
-                            </div>
-                          ) : att.attachment.kind === "file" ? (
-                            <F0FileItem
-                              size="md"
-                              file={{
-                                name: att.attachment.name,
-                                type: att.attachment.mimeType ?? "",
-                              }}
-                              actions={[
-                                {
-                                  label: i18n.chat.removeFile,
-                                  icon: Cross,
-                                  onClick: () =>
-                                    setAttachments((prev) =>
-                                      prev.filter((a) => a.id !== att.id)
-                                    ),
-                                },
-                              ]}
-                            />
-                          ) : // Locations never sit in the composer (uploads
-                          // only) — the narrowing here just satisfies the
-                          // widened attachment union.
-                          null}
+                          <ChatComposerAttachmentPreview
+                            attachment={att.attachment}
+                            uploading={att.status === "uploading"}
+                            onRemove={() => removeAttachment(att.id)}
+                          />
                         </motion.div>
                       </motion.div>
                     ))}

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
@@ -700,9 +700,8 @@ export const ChatComposer = (): ReactNode => {
             )}
           </AnimatePresence>
 
-          {/* Pending attachments render from local object URLs immediately.
-              Previewable documents, videos and images keep their visual shape
-              throughout upload; unsupported files use F0FileItem. */}
+          {/* Pending files render from local object URLs immediately. Their
+              uniform image-sized thumbnails keep the composer compact. */}
           <AnimatePresence initial={false}>
             {attachments.length > 0 && (
               <motion.div

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
@@ -5,6 +5,7 @@ import {
   type ReactNode,
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -25,6 +26,10 @@ import { cn } from "@/lib/utils"
 import { Picker } from "@/sds/social/Reactions/Picker"
 
 import { buildHighlightSegments } from "../hooks/highlight-utils"
+import {
+  replaceClosedEmojiShortcode,
+  useEmojiAutocomplete,
+} from "../hooks/useEmojiAutocomplete"
 import {
   MENTION_EVERYONE_ID,
   type MentionEntry,
@@ -50,8 +55,12 @@ import {
   microExitTransition,
 } from "../utils/chat-motion"
 import { ChatComposerAttachmentPreview } from "./ChatComposerAttachmentPreview"
+import { ChatEmojiAutocomplete } from "./ChatEmojiAutocomplete"
 import { ChatEditChip } from "./ChatEditChip"
-import { ChatMentionPopover } from "./ChatMentionPopover"
+import {
+  ChatMentionPopover,
+  getChatMentionOptionId,
+} from "./ChatMentionPopover"
 import { ChatReplyChip } from "./ChatReplyChip"
 import { ChatTextareaField } from "./ChatTextareaField"
 
@@ -123,25 +132,48 @@ export const ChatComposer = (): ReactNode => {
   const attachmentStripRef = useRef<HTMLDivElement>(null)
   const localPreviewUrlsRef = useRef(new Set<string>())
 
+  const emojiAutocomplete = useEmojiAutocomplete({
+    inputValue: value,
+    setInputValue: setValue,
+    cursorPosition,
+    setCursorPosition,
+    textareaRef,
+  })
   // Mentions are available wherever the host provides a member search — both
-  // DMs (mention either person) and groups. The `@here` (everyone) option only
-  // makes sense in a group, so it's offered there only.
+  // DMs (mention either person) and groups. Emoji lookup owns the active token
+  // while open, so member searches pause until it closes.
   const mentionsEnabled = !!searchMembers
   const mentions = useMentions({
     inputValue: value,
     setInputValue: setValue,
     cursorPosition,
     textareaRef,
-    enabled: mentionsEnabled,
+    enabled: mentionsEnabled && !emojiAutocomplete.isOpen,
     searchMembers,
     everyoneLabel:
       channel.type === "group" ? i18n.chat.mentionEveryone : undefined,
   })
+  const closeEmojiAutocomplete = emojiAutocomplete.close
+  const handleEmojiAutocompleteKeyDown = emojiAutocomplete.handleKeyDown
+  const mentionReactId = useId()
+  const mentionListboxId = `chat-mention-autocomplete-${mentionReactId.replace(/:/g, "")}`
+  const activeMentionCandidate =
+    mentions.results[mentions.selectedIndex] ?? mentions.results[0]
+  const activeMentionOptionId =
+    mentions.isOpen && activeMentionCandidate
+      ? getChatMentionOptionId(mentionListboxId, activeMentionCandidate)
+      : undefined
+
+  useEffect(() => {
+    if (emojiAutocomplete.isOpen) mentions.dismissCurrentTrigger()
+  }, [emojiAutocomplete.isOpen, mentions.dismissCurrentTrigger])
   const highlightSegments = useMemo(
     () =>
       buildHighlightSegments(value, mentions.mentions, {
         cursorPosition,
-        inlineCompletion: mentions.inlineCompletion,
+        inlineCompletion: emojiAutocomplete.isOpen
+          ? null
+          : mentions.inlineCompletion,
         currentUserId,
       }),
     [
@@ -149,6 +181,7 @@ export const ChatComposer = (): ReactNode => {
       mentions.mentions,
       cursorPosition,
       mentions.inlineCompletion,
+      emojiAutocomplete.isOpen,
       currentUserId,
     ]
   )
@@ -296,12 +329,23 @@ export const ChatComposer = (): ReactNode => {
 
   const handleChange = useCallback(
     (next: string, cursorPos: number) => {
-      setValue(next)
-      setCursorPosition(cursorPos)
+      const replacement = replaceClosedEmojiShortcode(next, cursorPos)
+      const nextValue = replacement?.value ?? next
+      const nextCursorPosition = replacement?.cursorPosition ?? cursorPos
+      setValue(nextValue)
+      setCursorPosition(nextCursorPosition)
       onInputActivity()
+      if (replacement) {
+        requestAnimationFrame(() => {
+          textareaRef.current?.setSelectionRange(
+            nextCursorPosition,
+            nextCursorPosition
+          )
+        })
+      }
       // Clearing the text means typing stopped NOW — don't leave the
       // counterpart's dots hanging until the transport's timeout.
-      if (next.trim().length === 0) void stopTyping?.()
+      if (nextValue.trim().length === 0) void stopTyping?.()
     },
     [onInputActivity, stopTyping]
   )
@@ -575,6 +619,7 @@ export const ChatComposer = (): ReactNode => {
       const caret = start + emoji.length
       setValue((prev) => prev.slice(0, start) + emoji + prev.slice(end))
       setCursorPosition(caret)
+      closeEmojiAutocomplete()
       onInputActivity()
       requestAnimationFrame(() => {
         const node = textareaRef.current
@@ -584,11 +629,17 @@ export const ChatComposer = (): ReactNode => {
         }
       })
     },
-    [onInputActivity]
+    [closeEmojiAutocomplete, onInputActivity]
   )
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      // Enter confirms the active IME composition. It must never select an
+      // autocomplete option or send the message while composition is active.
+      if (e.nativeEvent.isComposing) return
+      // Emoji shortcode suggestions take precedence when the active caret token
+      // starts with `:`; Enter/Tab select instead of sending the message.
+      if (handleEmojiAutocompleteKeyDown(e)) return
       // The mention popover consumes navigation keys first (↑↓/Enter/Tab/Esc).
       if (mentions.handleKeyDown(e)) return
       // Escape backs out of an edit (when the popover didn't claim it).
@@ -602,7 +653,13 @@ export const ChatComposer = (): ReactNode => {
         handleSend()
       }
     },
-    [handleSend, mentions, isEditing, cancelEdit]
+    [
+      handleSend,
+      handleEmojiAutocompleteKeyDown,
+      mentions,
+      isEditing,
+      cancelEdit,
+    ]
   )
 
   const startRecording = useCallback(() => {
@@ -617,8 +674,19 @@ export const ChatComposer = (): ReactNode => {
       {/* Centered, width-capped to match the message column in fullscreen. */}
       <div className="mx-auto w-full max-w-content">
         <div className="relative flex flex-col rounded-lg border border-solid border-f1-border bg-f1-background">
+          <ChatEmojiAutocomplete
+            isOpen={emojiAutocomplete.isOpen}
+            results={emojiAutocomplete.results}
+            selectedIndex={emojiAutocomplete.selectedIndex}
+            position={emojiAutocomplete.popoverPosition}
+            listboxId={emojiAutocomplete.listboxId}
+            label={i18n.chat.addEmoji}
+            onSelect={emojiAutocomplete.selectCandidate}
+            onHighlight={emojiAutocomplete.setSelectedIndex}
+          />
           <ChatMentionPopover
-            isOpen={mentions.isOpen}
+            isOpen={mentions.isOpen && !emojiAutocomplete.isOpen}
+            listboxId={mentionListboxId}
             results={mentions.results}
             isLoading={mentions.isLoading}
             selectedIndex={mentions.selectedIndex}
@@ -785,13 +853,26 @@ export const ChatComposer = (): ReactNode => {
             highlightRef={highlightRef}
             value={value}
             placeholder={isRecording ? i18n.chat.listening : placeholder}
+            accessibleLabel={placeholder}
             onChange={handleChange}
             onKeyDown={handleKeyDown}
             onPaste={handlePaste}
+            onBlur={closeEmojiAutocomplete}
             onCursorUpdate={updateCursorPosition}
             onScroll={syncHighlightScroll}
             highlightSegments={highlightSegments}
             hasOverlay={hasOverlay}
+            isAutocompleteOpen={emojiAutocomplete.isOpen || mentions.isOpen}
+            autocompleteListboxId={
+              emojiAutocomplete.isOpen
+                ? emojiAutocomplete.listboxId
+                : mentions.isOpen
+                  ? mentionListboxId
+                  : undefined
+            }
+            activeAutocompleteOptionId={
+              emojiAutocomplete.activeDescendantId ?? activeMentionOptionId
+            }
           />
 
           {/* Recording row ↔ action row: both stacked in the same grid cell

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposer.tsx
@@ -1,5 +1,6 @@
 import { AnimatePresence, motion } from "motion/react"
 import {
+  type ClipboardEvent,
   type KeyboardEvent,
   type ReactNode,
   useCallback,
@@ -45,6 +46,7 @@ import {
   microEnterTransition,
   microExitTransition,
 } from "../utils/chat-motion"
+import { formatFileSize } from "../utils/attachments"
 import { ChatEditChip } from "./ChatEditChip"
 import { ChatMentionPopover } from "./ChatMentionPopover"
 import { ChatReplyChip } from "./ChatReplyChip"
@@ -72,6 +74,7 @@ export const ChatComposer = (): ReactNode => {
     uploadFiles,
     transcribe,
     maxFiles,
+    maxFileSizeBytes,
     channel,
     searchMembers,
     currentUserId,
@@ -145,8 +148,11 @@ export const ChatComposer = (): ReactNode => {
 
   // Transient error flashed in the textarea (too many files, upload/voice
   // failure), auto-cleared after a few seconds — same pattern as the AI chat.
-  const { error: transientError, show: showTransientError } =
-    useTransientError()
+  const {
+    error: transientError,
+    show: showTransientError,
+    clear: clearTransientError,
+  } = useTransientError()
 
   // Mirror the attachment count in a ref so the upload handler can read the
   // current total without depending on it (keeps its identity stable).
@@ -278,6 +284,7 @@ export const ChatComposer = (): ReactNode => {
   const handleUpload = useCallback(
     async (files: File[]) => {
       if (files.length === 0 || !uploadFiles || !canUpload) return
+      clearTransientError()
       // Reject the whole batch when it would exceed the cap — a transient banner
       // is friendlier than silently truncating the user's selection.
       if (
@@ -286,6 +293,21 @@ export const ChatComposer = (): ReactNode => {
       ) {
         showTransientError(
           i18n.chat.tooManyFilesError.replace("{{maxFiles}}", String(maxFiles))
+        )
+        return
+      }
+      // Keep validation transport-agnostic and reject the whole batch before
+      // starting any upload when one file exceeds the host-provided cap.
+      if (
+        maxFileSizeBytes !== undefined &&
+        files.some((file) => file.size > maxFileSizeBytes)
+      ) {
+        showTransientError(
+          i18n.chat.fileTooLargeError.replace(
+            "{{maxFileSize}}",
+            formatFileSize(maxFileSizeBytes)
+          ),
+          { persistent: true }
         )
         return
       }
@@ -319,8 +341,11 @@ export const ChatComposer = (): ReactNode => {
       uploadFiles,
       canUpload,
       maxFiles,
+      maxFileSizeBytes,
+      clearTransientError,
       showTransientError,
       i18n.chat.tooManyFilesError,
+      i18n.chat.fileTooLargeError,
       i18n.chat.fileUploadError,
     ]
   )
@@ -329,6 +354,20 @@ export const ChatComposer = (): ReactNode => {
   useEffect(() => {
     registerFileDropHandler((files) => void handleUpload(files))
   }, [registerFileDropHandler, handleUpload])
+
+  const handlePaste = useCallback(
+    (event: ClipboardEvent<HTMLTextAreaElement>) => {
+      if (!canUpload) return
+      const files = Array.from(event.clipboardData.files)
+      if (files.length === 0) return
+
+      // File pastes (Cmd/Ctrl+V) become attachments. Text-only clipboard
+      // content keeps the textarea's native paste behavior.
+      event.preventDefault()
+      void handleUpload(files)
+    },
+    [canUpload, handleUpload]
+  )
 
   const isEditing = editingMessage !== null
 
@@ -532,14 +571,14 @@ export const ChatComposer = (): ReactNode => {
             ) : null}
           </AnimatePresence>
 
-          {/* Transient error (too many files, upload/voice failure) — flashed
-              briefly, then fades out. Same pattern as the AI chat. */}
+          {/* Composer error. Upload/voice failures fade out; validation errors
+              may persist until the next corrective attachment attempt. */}
           <AnimatePresence initial={false}>
             {transientError && (
               <motion.div
                 key="transient-error"
                 role="alert"
-                aria-live="polite"
+                aria-atomic="true"
                 className="p-1"
                 initial={{ opacity: 0, y: -4 }}
                 animate={{ opacity: 1, y: 0 }}
@@ -700,6 +739,7 @@ export const ChatComposer = (): ReactNode => {
             placeholder={isRecording ? i18n.chat.listening : placeholder}
             onChange={handleChange}
             onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
             onCursorUpdate={updateCursorPosition}
             onScroll={syncHighlightScroll}
             highlightSegments={highlightSegments}

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposerAttachmentPreview.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposerAttachmentPreview.tsx
@@ -93,7 +93,7 @@ export const ChatComposerAttachmentPreview = ({
         <figure
           aria-label={attachment.name}
           aria-busy={uploading}
-          className="group/attachment relative m-0 box-border h-16 w-16 shrink-0 overflow-hidden rounded-lg border border-solid border-f1-border-secondary bg-f1-background-secondary"
+          className="group/attachment relative m-0 box-border h-16 w-28 shrink-0 overflow-hidden rounded-lg border border-solid border-f1-border-secondary bg-f1-background-secondary"
           data-testid="chat-composer-video-preview"
         >
           {/* This is a silent, non-interactive visual preview. Playback and its

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposerAttachmentPreview.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposerAttachmentPreview.tsx
@@ -1,0 +1,227 @@
+import { type ReactNode, useEffect, useState } from "react"
+
+import { ButtonInternal } from "@/components/F0Button/internal"
+import { F0FileItem } from "@/components/F0FileItem"
+import { Cross } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
+import { Spinner } from "@/ui/Spinner"
+
+import { type F0ChatAttachment } from "../types"
+import {
+  documentPreviewKind,
+  isVideoFileAttachment,
+  withinPreviewSizeLimit,
+} from "../utils/attachments"
+import { ChatDocumentAttachmentCard } from "./ChatDocumentAttachmentCard"
+import { ChatLocationAttachment } from "./ChatLocationAttachment"
+import { ChatVoiceAttachment } from "./ChatVoiceAttachment"
+import { FadeInImage } from "./FadeInImage"
+
+const PreviewProgress = (): ReactNode => (
+  <div
+    className="shadow-sm pointer-events-none absolute bottom-2 left-2 z-20 flex rounded bg-f1-background p-1"
+    data-testid="chat-composer-attachment-uploading"
+  >
+    <Spinner size="small" />
+  </div>
+)
+
+/**
+ * Preview for an attachment waiting in the composer. Images and videos use
+ * compact media thumbnails, previewable documents reuse the message snapshot,
+ * and voice/location attachments keep their native representation. Unknown
+ * files deliberately fall back to F0FileItem.
+ */
+export const ChatComposerAttachmentPreview = ({
+  attachment,
+  uploading,
+  onRemove,
+}: {
+  attachment: F0ChatAttachment
+  uploading: boolean
+  onRemove: () => void
+}): ReactNode => {
+  const i18n = useI18n()
+  const [videoPreviewFailed, setVideoPreviewFailed] = useState(false)
+  const attachmentUrl = "url" in attachment ? attachment.url : undefined
+  useEffect(() => setVideoPreviewFailed(false), [attachmentUrl])
+  const removeAction = {
+    label: i18n.t("chat.removeNamedFile", {
+      name:
+        attachment.kind === "location"
+          ? (attachment.name ?? i18n.chat.location)
+          : attachment.kind === "voice"
+            ? i18n.chat.voiceNote
+            : attachment.name,
+    }),
+    icon: Cross,
+    onClick: onRemove,
+  }
+
+  if (attachment.kind === "image") {
+    return (
+      <figure
+        aria-label={attachment.name}
+        aria-busy={uploading}
+        className="group/attachment relative m-0 flex"
+        data-testid="chat-composer-image-preview"
+      >
+        <FadeInImage
+          src={attachment.thumbnailUrl ?? attachment.url}
+          alt={attachment.name}
+          className="h-16 w-16 rounded-lg border border-solid border-f1-border-secondary object-cover"
+        />
+        <div className="absolute right-1 top-1 z-30 flex rounded bg-f1-background opacity-0 transition-opacity focus-within:opacity-100 group-hover/attachment:opacity-100">
+          <ButtonInternal
+            variant="outline"
+            size="sm"
+            hideLabel
+            label={removeAction.label}
+            icon={removeAction.icon}
+            onClick={removeAction.onClick}
+          />
+        </div>
+        {uploading && <PreviewProgress />}
+        <figcaption className="sr-only">{attachment.name}</figcaption>
+      </figure>
+    )
+  }
+
+  if (attachment.kind === "file") {
+    if (isVideoFileAttachment(attachment) && !videoPreviewFailed) {
+      return (
+        <figure
+          aria-label={attachment.name}
+          aria-busy={uploading}
+          className="group/attachment relative m-0 aspect-video w-72 max-w-full overflow-hidden rounded-lg border border-solid border-f1-border-secondary bg-f1-background-secondary"
+          data-testid="chat-composer-video-preview"
+        >
+          {/* This is a silent, non-interactive visual preview. Playback and its
+              accessible captions remain in F0VideoPlayer after sending. */}
+          {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+          <video
+            src={attachment.url}
+            poster={attachment.thumbnailUrl}
+            muted
+            playsInline
+            preload="auto"
+            onError={() => setVideoPreviewFailed(true)}
+            onLoadedMetadata={(event) => {
+              // Browsers often paint black at exactly 0s until playback starts.
+              // Keep a host poster intact; otherwise seek to a decoded frame.
+              if (
+                !attachment.thumbnailUrl &&
+                event.currentTarget.currentTime === 0
+              ) {
+                const { duration } = event.currentTarget
+                event.currentTarget.currentTime = Number.isFinite(duration)
+                  ? Math.min(1, duration / 2)
+                  : 1
+              }
+            }}
+            aria-hidden="true"
+            className="pointer-events-none h-full w-full object-cover"
+          />
+          <div className="absolute right-1 top-1 z-30 flex rounded bg-f1-background opacity-0 transition-opacity focus-within:opacity-100 group-hover/attachment:opacity-100">
+            <ButtonInternal
+              variant="outline"
+              size="sm"
+              hideLabel
+              label={removeAction.label}
+              icon={removeAction.icon}
+              onClick={removeAction.onClick}
+            />
+          </div>
+          {uploading && <PreviewProgress />}
+          <figcaption className="sr-only">{attachment.name}</figcaption>
+        </figure>
+      )
+    }
+
+    const documentKind = documentPreviewKind(attachment)
+    if (documentKind && withinPreviewSizeLimit(attachment, documentKind)) {
+      return (
+        <div
+          aria-busy={uploading}
+          className="relative flex"
+          data-testid="chat-composer-document-preview"
+        >
+          <ChatDocumentAttachmentCard
+            file={attachment}
+            kind={documentKind}
+            cornerClass="rounded-lg"
+            action={removeAction}
+            previewDisabled={uploading}
+          />
+          {uploading && <PreviewProgress />}
+        </div>
+      )
+    }
+
+    return (
+      <div
+        aria-busy={uploading}
+        className="relative flex"
+        data-testid="chat-composer-file-preview"
+      >
+        <F0FileItem
+          size="md"
+          file={{
+            name: attachment.name,
+            type: attachment.mimeType ?? "",
+          }}
+          actions={[removeAction]}
+        />
+        {uploading && <PreviewProgress />}
+      </div>
+    )
+  }
+
+  if (attachment.kind === "voice") {
+    return (
+      <div
+        aria-busy={uploading}
+        className="group/attachment relative flex"
+        data-testid="chat-composer-voice-preview"
+      >
+        <ChatVoiceAttachment
+          voice={attachment}
+          cornerClass="rounded-lg"
+          className="pr-12"
+        />
+        <div className="absolute right-1 top-1 z-30 flex rounded bg-f1-background opacity-0 transition-opacity focus-within:opacity-100 group-hover/attachment:opacity-100">
+          <ButtonInternal
+            variant="outline"
+            size="sm"
+            hideLabel
+            label={removeAction.label}
+            icon={removeAction.icon}
+            onClick={removeAction.onClick}
+          />
+        </div>
+        {uploading && <PreviewProgress />}
+      </div>
+    )
+  }
+
+  return (
+    <div
+      aria-busy={uploading}
+      className="group/attachment relative flex"
+      data-testid="chat-composer-location-preview"
+    >
+      <ChatLocationAttachment location={attachment} cornerClass="rounded-lg" />
+      <div className="absolute right-1 top-1 z-30 flex rounded bg-f1-background opacity-0 transition-opacity focus-within:opacity-100 group-hover/attachment:opacity-100">
+        <ButtonInternal
+          variant="outline"
+          size="sm"
+          hideLabel
+          label={removeAction.label}
+          icon={removeAction.icon}
+          onClick={removeAction.onClick}
+        />
+      </div>
+      {uploading && <PreviewProgress />}
+    </div>
+  )
+}

--- a/packages/react/src/sds/chat/F0Chat/components/ChatComposerAttachmentPreview.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatComposerAttachmentPreview.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode, useEffect, useState } from "react"
 
+import { F0AvatarFile } from "@/components/avatars/F0AvatarFile"
 import { ButtonInternal } from "@/components/F0Button/internal"
-import { F0FileItem } from "@/components/F0FileItem"
 import { Cross } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 import { Spinner } from "@/ui/Spinner"
@@ -30,7 +30,7 @@ const PreviewProgress = (): ReactNode => (
  * Preview for an attachment waiting in the composer. Images and videos use
  * compact media thumbnails, previewable documents reuse the message snapshot,
  * and voice/location attachments keep their native representation. Unknown
- * files deliberately fall back to F0FileItem.
+ * files use the same square footprint with their file-type avatar.
  */
 export const ChatComposerAttachmentPreview = ({
   attachment,
@@ -63,7 +63,7 @@ export const ChatComposerAttachmentPreview = ({
       <figure
         aria-label={attachment.name}
         aria-busy={uploading}
-        className="group/attachment relative m-0 flex"
+        className="group/attachment relative m-0 flex h-16 w-16 shrink-0"
         data-testid="chat-composer-image-preview"
       >
         <FadeInImage
@@ -93,7 +93,7 @@ export const ChatComposerAttachmentPreview = ({
         <figure
           aria-label={attachment.name}
           aria-busy={uploading}
-          className="group/attachment relative m-0 aspect-video w-72 max-w-full overflow-hidden rounded-lg border border-solid border-f1-border-secondary bg-f1-background-secondary"
+          className="group/attachment relative m-0 box-border h-16 w-16 shrink-0 overflow-hidden rounded-lg border border-solid border-f1-border-secondary bg-f1-background-secondary"
           data-testid="chat-composer-video-preview"
         >
           {/* This is a silent, non-interactive visual preview. Playback and its
@@ -152,6 +152,7 @@ export const ChatComposerAttachmentPreview = ({
             cornerClass="rounded-lg"
             action={removeAction}
             previewDisabled={uploading}
+            compact
           />
           {uploading && <PreviewProgress />}
         </div>
@@ -161,18 +162,28 @@ export const ChatComposerAttachmentPreview = ({
     return (
       <div
         aria-busy={uploading}
-        className="relative flex"
+        className="group/attachment relative box-border flex h-16 w-16 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-solid border-f1-border-secondary bg-f1-background-secondary"
         data-testid="chat-composer-file-preview"
       >
-        <F0FileItem
-          size="md"
+        <F0AvatarFile
           file={{
             name: attachment.name,
             type: attachment.mimeType ?? "",
           }}
-          actions={[removeAction]}
+          size="md"
         />
+        <div className="absolute right-1 top-1 z-30 flex rounded bg-f1-background opacity-0 transition-opacity focus-within:opacity-100 group-hover/attachment:opacity-100">
+          <ButtonInternal
+            variant="outline"
+            size="sm"
+            hideLabel
+            label={removeAction.label}
+            icon={removeAction.icon}
+            onClick={removeAction.onClick}
+          />
+        </div>
         {uploading && <PreviewProgress />}
+        <span className="sr-only">{attachment.name}</span>
       </div>
     )
   }

--- a/packages/react/src/sds/chat/F0Chat/components/ChatDocumentAttachmentCard.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatDocumentAttachmentCard.tsx
@@ -13,11 +13,12 @@ import {
 import { F0AvatarFile } from "@/components/avatars/F0AvatarFile"
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { F0FileItem } from "@/components/F0FileItem"
+import { type IconType } from "@/components/F0Icon"
 import { Download } from "@/icons/app"
-import { OneEllipsis } from "@/lib/OneEllipsis/OneEllipsis"
 import { useReducedMotion } from "@/lib/a11y"
+import { OneEllipsis } from "@/lib/OneEllipsis/OneEllipsis"
 import { useI18n } from "@/lib/providers/i18n"
-import { cn } from "@/lib/utils"
+import { cn, focusRing } from "@/lib/utils"
 import { Skeleton } from "@/ui/skeleton"
 
 import { useChatDocumentPreview } from "../providers/ChatUIProvider"
@@ -67,11 +68,21 @@ export const ChatDocumentAttachmentCard = ({
   file,
   kind,
   cornerClass = "rounded-xl",
+  action,
+  previewDisabled = false,
 }: {
   file: F0ChatFileAttachment
   kind: ChatDocumentKind
   /** Chained-corner classes mirroring the bubble (see `bubbleCornerClass`). */
   cornerClass?: string
+  /** Override the default download action, e.g. Remove inside the composer. */
+  action?: {
+    label: string
+    icon: IconType
+    onClick: () => void
+  }
+  /** Prevent opening a transient local URL before its upload completes. */
+  previewDisabled?: boolean
 }): ReactNode => {
   const i18n = useI18n()
   const reducedMotion = useReducedMotion()
@@ -80,19 +91,18 @@ export const ChatDocumentAttachmentCard = ({
   const inView = useInViewport(containerRef)
   const [failed, setFailed] = useState(false)
   const [rendered, setRendered] = useState(false)
+  const attachmentAction = action ?? {
+    label: i18n.t("chat.downloadNamedFile", { name: file.name }),
+    icon: Download,
+    onClick: () => triggerDownload(file.url, file.name),
+  }
 
   if (failed) {
     return (
       <F0FileItem
         size="md"
         file={{ name: file.name, type: file.mimeType ?? "" }}
-        actions={[
-          {
-            label: i18n.chat.download,
-            icon: Download,
-            onClick: () => triggerDownload(file.url, file.name),
-          },
-        ]}
+        actions={[attachmentAction]}
       />
     )
   }
@@ -107,7 +117,7 @@ export const ChatDocumentAttachmentCard = ({
       style={{ width: CARD_WIDTH }}
       data-testid="chat-document-attachment"
     >
-      <div className="flex items-center gap-2 py-2 px-2">
+      <div className="flex items-center gap-2 px-2 py-2">
         <F0AvatarFile
           file={{ name: file.name, type: file.mimeType ?? "" }}
           size="md"
@@ -119,16 +129,20 @@ export const ChatDocumentAttachmentCard = ({
           variant="ghost"
           size="sm"
           hideLabel
-          icon={Download}
-          label={i18n.chat.download}
-          onClick={() => triggerDownload(file.url, file.name)}
+          icon={attachmentAction.icon}
+          label={attachmentAction.label}
+          onClick={attachmentAction.onClick}
         />
       </div>
       <button
         type="button"
         onClick={() => openDocumentPreview(file)}
-        aria-label={i18n.chat.openDocument}
-        className="relative block w-full overflow-hidden border-0 border-t border-solid border-f1-border-secondary bg-f1-background-secondary p-0 transition-opacity hover:opacity-90"
+        disabled={previewDisabled}
+        aria-label={i18n.t("chat.openNamedDocument", { name: file.name })}
+        className={cn(
+          "relative block w-full overflow-hidden border-0 border-t border-solid border-f1-border-secondary bg-f1-background-secondary p-0 transition-opacity enabled:hover:opacity-90",
+          focusRing("focus-visible:ring-inset")
+        )}
         style={{ height: THUMB_HEIGHT }}
       >
         {/* Skeleton lives UNDER the snapshot; the rendered content fades in

--- a/packages/react/src/sds/chat/F0Chat/components/ChatDocumentAttachmentCard.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatDocumentAttachmentCard.tsx
@@ -57,12 +57,11 @@ const useInViewport = (ref: RefObject<HTMLElement | null>): boolean => {
 }
 
 /**
- * Slack-style document card: a header (type badge + name + download) over a
- * cropped snapshot of the content — the first PDF page, the first sheet's
- * cells, the first Word page, or the first lines of text. Clicking the
- * snapshot opens the fullscreen viewer ({@link ChatDocumentPreview}); a
- * document that can't load falls back to the plain file chip so download
- * always stays available.
+ * Document card with a type badge and name over a cropped snapshot of the
+ * content — the first PDF page, the first sheet's cells, the first Word page,
+ * or the first lines of text. Clicking the snapshot opens the fullscreen
+ * viewer ({@link ChatDocumentPreview}), which owns its download action. A
+ * document that can't load falls back to the plain downloadable file chip.
  */
 export const ChatDocumentAttachmentCard = ({
   file,
@@ -76,7 +75,7 @@ export const ChatDocumentAttachmentCard = ({
   kind: ChatDocumentKind
   /** Chained-corner classes mirroring the bubble (see `bubbleCornerClass`). */
   cornerClass?: string
-  /** Override the default download action, e.g. Remove inside the composer. */
+  /** Optional card action, e.g. Remove inside the composer. */
   action?: {
     label: string
     icon: IconType
@@ -94,7 +93,7 @@ export const ChatDocumentAttachmentCard = ({
   const inView = useInViewport(containerRef)
   const [failed, setFailed] = useState(false)
   const [rendered, setRendered] = useState(false)
-  const attachmentAction = action ?? {
+  const fallbackAction = action ?? {
     label: i18n.t("chat.downloadNamedFile", { name: file.name }),
     icon: Download,
     onClick: () => triggerDownload(file.url, file.name),
@@ -121,9 +120,9 @@ export const ChatDocumentAttachmentCard = ({
               variant="outline"
               size="sm"
               hideLabel
-              icon={attachmentAction.icon}
-              label={attachmentAction.label}
-              onClick={attachmentAction.onClick}
+              icon={fallbackAction.icon}
+              label={fallbackAction.label}
+              onClick={fallbackAction.onClick}
             />
           </div>
           <span className="sr-only">{file.name}</span>
@@ -135,7 +134,7 @@ export const ChatDocumentAttachmentCard = ({
       <F0FileItem
         size="md"
         file={{ name: file.name, type: file.mimeType ?? "" }}
-        actions={[attachmentAction]}
+        actions={[fallbackAction]}
       />
     )
   }
@@ -160,14 +159,16 @@ export const ChatDocumentAttachmentCard = ({
           <OneEllipsis className="grow text-sm font-medium text-f1-foreground">
             {file.name}
           </OneEllipsis>
-          <ButtonInternal
-            variant="ghost"
-            size="sm"
-            hideLabel
-            icon={attachmentAction.icon}
-            label={attachmentAction.label}
-            onClick={attachmentAction.onClick}
-          />
+          {action && (
+            <ButtonInternal
+              variant="ghost"
+              size="sm"
+              hideLabel
+              icon={action.icon}
+              label={action.label}
+              onClick={action.onClick}
+            />
+          )}
         </div>
       )}
       <button
@@ -229,16 +230,16 @@ export const ChatDocumentAttachmentCard = ({
           </div>
         )}
       </button>
-      {compact && (
+      {compact && action && (
         <>
           <div className="absolute right-1 top-1 z-30 flex rounded bg-f1-background opacity-0 transition-opacity focus-within:opacity-100 group-hover/attachment:opacity-100">
             <ButtonInternal
               variant="outline"
               size="sm"
               hideLabel
-              icon={attachmentAction.icon}
-              label={attachmentAction.label}
-              onClick={attachmentAction.onClick}
+              icon={action.icon}
+              label={action.label}
+              onClick={action.onClick}
             />
           </div>
           <span className="sr-only">{file.name}</span>

--- a/packages/react/src/sds/chat/F0Chat/components/ChatDocumentAttachmentCard.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatDocumentAttachmentCard.tsx
@@ -70,6 +70,7 @@ export const ChatDocumentAttachmentCard = ({
   cornerClass = "rounded-xl",
   action,
   previewDisabled = false,
+  compact = false,
 }: {
   file: F0ChatFileAttachment
   kind: ChatDocumentKind
@@ -83,6 +84,8 @@ export const ChatDocumentAttachmentCard = ({
   }
   /** Prevent opening a transient local URL before its upload completes. */
   previewDisabled?: boolean
+  /** Render as a square thumbnail in compact surfaces such as the composer. */
+  compact?: boolean
 }): ReactNode => {
   const i18n = useI18n()
   const reducedMotion = useReducedMotion()
@@ -96,8 +99,38 @@ export const ChatDocumentAttachmentCard = ({
     icon: Download,
     onClick: () => triggerDownload(file.url, file.name),
   }
+  const cardWidth = compact ? 64 : CARD_WIDTH
+  const thumbHeight = compact ? "100%" : THUMB_HEIGHT
 
   if (failed) {
+    if (compact) {
+      return (
+        <div
+          className={cn(
+            "group/attachment relative box-border flex h-16 w-16 items-center justify-center overflow-hidden border border-solid border-f1-border-secondary bg-f1-background-secondary",
+            cornerClass
+          )}
+          data-testid="chat-document-attachment"
+        >
+          <F0AvatarFile
+            file={{ name: file.name, type: file.mimeType ?? "" }}
+            size="md"
+          />
+          <div className="absolute right-1 top-1 z-30 flex rounded bg-f1-background opacity-0 transition-opacity focus-within:opacity-100 group-hover/attachment:opacity-100">
+            <ButtonInternal
+              variant="outline"
+              size="sm"
+              hideLabel
+              icon={attachmentAction.icon}
+              label={attachmentAction.label}
+              onClick={attachmentAction.onClick}
+            />
+          </div>
+          <span className="sr-only">{file.name}</span>
+        </div>
+      )
+    }
+
     return (
       <F0FileItem
         size="md"
@@ -111,39 +144,43 @@ export const ChatDocumentAttachmentCard = ({
     <div
       ref={containerRef}
       className={cn(
-        "flex max-w-full flex-col overflow-hidden border border-solid border-f1-border-secondary bg-f1-background",
+        "group/attachment relative flex max-w-full flex-col overflow-hidden border border-solid border-f1-border-secondary bg-f1-background",
+        compact && "box-border h-16 w-16",
         cornerClass
       )}
-      style={{ width: CARD_WIDTH }}
+      style={{ width: cardWidth }}
       data-testid="chat-document-attachment"
     >
-      <div className="flex items-center gap-2 px-2 py-2">
-        <F0AvatarFile
-          file={{ name: file.name, type: file.mimeType ?? "" }}
-          size="md"
-        />
-        <OneEllipsis className="grow text-sm font-medium text-f1-foreground">
-          {file.name}
-        </OneEllipsis>
-        <ButtonInternal
-          variant="ghost"
-          size="sm"
-          hideLabel
-          icon={attachmentAction.icon}
-          label={attachmentAction.label}
-          onClick={attachmentAction.onClick}
-        />
-      </div>
+      {!compact && (
+        <div className="flex items-center gap-2 px-2 py-2">
+          <F0AvatarFile
+            file={{ name: file.name, type: file.mimeType ?? "" }}
+            size="md"
+          />
+          <OneEllipsis className="grow text-sm font-medium text-f1-foreground">
+            {file.name}
+          </OneEllipsis>
+          <ButtonInternal
+            variant="ghost"
+            size="sm"
+            hideLabel
+            icon={attachmentAction.icon}
+            label={attachmentAction.label}
+            onClick={attachmentAction.onClick}
+          />
+        </div>
+      )}
       <button
         type="button"
         onClick={() => openDocumentPreview(file)}
         disabled={previewDisabled}
         aria-label={i18n.t("chat.openNamedDocument", { name: file.name })}
         className={cn(
-          "relative block w-full overflow-hidden border-0 border-t border-solid border-f1-border-secondary bg-f1-background-secondary p-0 transition-opacity enabled:hover:opacity-90",
+          "relative block w-full overflow-hidden border-0 border-solid border-f1-border-secondary bg-f1-background-secondary p-0 transition-opacity enabled:hover:opacity-90",
+          !compact && "border-t",
           focusRing("focus-visible:ring-inset")
         )}
-        style={{ height: THUMB_HEIGHT }}
+        style={{ height: thumbHeight }}
       >
         {/* Skeleton lives UNDER the snapshot; the rendered content fades in
             over it (no hard swap) once the renderer paints. */}
@@ -161,7 +198,7 @@ export const ChatDocumentAttachmentCard = ({
               {kind === "pdf" && (
                 <ChatPdfThumbnail
                   url={file.url}
-                  width={CARD_WIDTH - 2}
+                  width={cardWidth - 2}
                   onError={() => setFailed(true)}
                   onRendered={() => setRendered(true)}
                 />
@@ -176,7 +213,7 @@ export const ChatDocumentAttachmentCard = ({
               {kind === "docx" && (
                 <ChatDocxThumbnail
                   url={file.url}
-                  width={CARD_WIDTH - 2}
+                  width={cardWidth - 2}
                   onError={() => setFailed(true)}
                   onRendered={() => setRendered(true)}
                 />
@@ -192,6 +229,21 @@ export const ChatDocumentAttachmentCard = ({
           </div>
         )}
       </button>
+      {compact && (
+        <>
+          <div className="absolute right-1 top-1 z-30 flex rounded bg-f1-background opacity-0 transition-opacity focus-within:opacity-100 group-hover/attachment:opacity-100">
+            <ButtonInternal
+              variant="outline"
+              size="sm"
+              hideLabel
+              icon={attachmentAction.icon}
+              label={attachmentAction.label}
+              onClick={attachmentAction.onClick}
+            />
+          </div>
+          <span className="sr-only">{file.name}</span>
+        </>
+      )}
     </div>
   )
 }

--- a/packages/react/src/sds/chat/F0Chat/components/ChatEmojiAutocomplete.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatEmojiAutocomplete.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useLayoutEffect, useRef } from "react"
+
+import { EmojiImage } from "@/lib/emojis"
+import { OneEllipsis } from "@/lib/OneEllipsis"
+import { cn } from "@/lib/utils"
+
+import {
+  type EmojiAutocompleteCandidate,
+  getEmojiAutocompleteOptionId,
+} from "../hooks/useEmojiAutocomplete"
+import { type PopoverPosition } from "../hooks/useMentions"
+
+export type ChatEmojiAutocompleteProps = {
+  isOpen: boolean
+  results: EmojiAutocompleteCandidate[]
+  selectedIndex: number
+  position: PopoverPosition
+  listboxId: string
+  label: string
+  onSelect: (candidate: EmojiAutocompleteCandidate) => void
+  onHighlight: (index: number) => void
+}
+
+/**
+ * Slack-style `:` emoji autocomplete. Focus remains in the textarea while the
+ * active row follows keyboard or pointer navigation.
+ */
+export function ChatEmojiAutocomplete({
+  isOpen,
+  results,
+  selectedIndex,
+  position,
+  listboxId,
+  label,
+  onSelect,
+  onHighlight,
+}: ChatEmojiAutocompleteProps) {
+  const listRef = useRef<HTMLDivElement>(null)
+  const selectedItemRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    selectedItemRef.current?.scrollIntoView({ block: "nearest" })
+  }, [selectedIndex])
+
+  useLayoutEffect(() => {
+    const element = listRef.current
+    const parent = element?.offsetParent as HTMLElement | null
+    if (!element || !parent) return
+    const overflow =
+      element.offsetLeft + element.offsetWidth - parent.clientWidth
+    if (overflow > 0) {
+      element.style.left = `${Math.max(0, element.offsetLeft - overflow)}px`
+    }
+  }, [position])
+
+  if (!isOpen || results.length === 0) return null
+
+  return (
+    <div
+      ref={listRef}
+      id={listboxId}
+      role="listbox"
+      aria-label={label}
+      style={{
+        position: "absolute",
+        bottom: position ? `${position.bottom}px` : "100%",
+        left: position ? `${position.left}px` : 0,
+      }}
+      className={cn(
+        "z-50",
+        "w-72 max-h-[328px] overflow-y-auto",
+        "rounded-lg border border-solid border-f1-border-secondary",
+        "bg-f1-background shadow-md",
+        "p-1"
+      )}
+    >
+      {results.map((candidate, index) => {
+        const isSelected = index === selectedIndex
+        return (
+          <div
+            key={candidate.id}
+            ref={isSelected ? selectedItemRef : undefined}
+            id={getEmojiAutocompleteOptionId(listboxId, candidate.id)}
+            role="option"
+            aria-selected={isSelected}
+            className={cn(
+              "flex cursor-pointer items-center gap-2 rounded p-2",
+              "transition-colors",
+              isSelected
+                ? "bg-f1-background-secondary"
+                : "hover:bg-f1-background-secondary-hover"
+            )}
+            onMouseEnter={() => onHighlight(index)}
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => onSelect(candidate)}
+          >
+            <span className="flex size-6 shrink-0 items-center justify-center">
+              <EmojiImage emoji={candidate.native} size="md" alt="" />
+            </span>
+            <div className="flex min-w-0 flex-1 items-baseline gap-2">
+              <OneEllipsis className="shrink-0 font-medium text-f1-foreground">
+                {`:${candidate.id}:`}
+              </OneEllipsis>
+              <OneEllipsis className="text-sm text-f1-foreground-secondary">
+                {candidate.name}
+              </OneEllipsis>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/packages/react/src/sds/chat/F0Chat/components/ChatHeader.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatHeader.tsx
@@ -105,7 +105,7 @@ export const ChatHeader = ({
           // full size instead of shrunk inside the bordered avatar box.
           <span
             aria-hidden={showGroupFallback || undefined}
-            className="flex size-6 items-center justify-center"
+            className="flex size-5 text-lg items-center font-medium justify-center text-f1-foreground-secondary"
             data-testid={
               showGroupFallback ? "chat-group-avatar-fallback" : undefined
             }

--- a/packages/react/src/sds/chat/F0Chat/components/ChatHeader.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatHeader.tsx
@@ -62,6 +62,16 @@ export const ChatHeader = ({
   })
   // DMs show a presence dot (green online / grey offline).
   const showPresence = channel.type === "dm" && channel.presence !== undefined
+  const showGroupFallback =
+    channel.type === "group" &&
+    (channel.avatar.type === "team" || channel.avatar.type === "company") &&
+    !channel.avatar.src
+  const identityEmoji =
+    channel.avatar.type === "emoji"
+      ? channel.avatar.emoji
+      : showGroupFallback
+        ? "＃"
+        : null
 
   // Search is the ONLY built-in action. Everything else — pin, mute, edit
   // group… — comes from the host through `actions`, so each channel offers
@@ -90,11 +100,17 @@ export const ChatHeader = ({
   const identity = (
     <div className="flex min-w-0 items-center gap-2">
       <div className="relative shrink-0 flex">
-        {channel.avatar.type === "emoji" ? (
+        {identityEmoji ? (
           // Emoji groups show the glyph alone (no avatar chrome) so it reads at
           // full size instead of shrunk inside the bordered avatar box.
-          <span className="flex size-6 items-center justify-center">
-            <EmojiImage emoji={channel.avatar.emoji} size="sm" />
+          <span
+            aria-hidden={showGroupFallback || undefined}
+            className="flex size-6 items-center justify-center"
+            data-testid={
+              showGroupFallback ? "chat-group-avatar-fallback" : undefined
+            }
+          >
+            <EmojiImage emoji={identityEmoji} size="sm" />
           </span>
         ) : (
           <F0Avatar size="sm" avatar={channel.avatar} />

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMentionPopover.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMentionPopover.tsx
@@ -14,6 +14,7 @@ import {
 
 export type ChatMentionPopoverProps = {
   isOpen: boolean
+  listboxId: string
   /** Rows to display: the "everyone" option (when matching) then members. */
   results: MentionCandidate[]
   isLoading: boolean
@@ -24,6 +25,14 @@ export type ChatMentionPopoverProps = {
   everyoneDescription: string
 }
 
+const optionId = (listboxId: string, candidate: MentionCandidate): string => {
+  const key =
+    candidate.kind === "everyone" ? "everyone" : `user-${candidate.user.id}`
+  return `${listboxId}-option-${key.replace(/[^a-zA-Z0-9_-]/g, "-")}`
+}
+
+export const getChatMentionOptionId = optionId
+
 /**
  * Inline `@`-mention autocomplete, positioned above the textarea — the comms
  * twin of the AI chat's MentionPopover (same chrome, positioning and skeletons).
@@ -31,6 +40,7 @@ export type ChatMentionPopoverProps = {
  */
 export function ChatMentionPopover({
   isOpen,
+  listboxId,
   results,
   isLoading,
   selectedIndex,
@@ -63,6 +73,7 @@ export function ChatMentionPopover({
   return (
     <div
       ref={listRef}
+      id={listboxId}
       role="listbox"
       style={{
         position: "absolute",
@@ -85,6 +96,7 @@ export function ChatMentionPopover({
           <div
             key={key}
             ref={isSelected ? selectedItemRef : undefined}
+            id={optionId(listboxId, candidate)}
             role="option"
             aria-selected={isSelected}
             className={cn(

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageAttachments.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageAttachments.tsx
@@ -15,22 +15,26 @@ import {
 } from "../types"
 import {
   documentPreviewKind,
+  isVideoFileAttachment,
   withinPreviewSizeLimit,
 } from "../utils/attachments"
 import { triggerDownload } from "../utils/download"
 import { bubbleCornerClass } from "./ChatBubble"
 import { ChatDocumentAttachmentCard } from "./ChatDocumentAttachmentCard"
 import { ChatLocationAttachment } from "./ChatLocationAttachment"
+import { ChatVideoAttachment } from "./ChatVideoAttachment"
 import { ChatVoiceAttachment } from "./ChatVoiceAttachment"
 import { FadeInImage } from "./FadeInImage"
 
 /**
  * Attachments shown above a message bubble — images render inline (clickable to
- * open the in-chat lightbox); previewable documents (pdf/sheet/docx/text) get a
- * Slack-style snapshot card (clickable to open the fullscreen viewer); other
- * files use {@link F0FileItem} with a download action, mirroring the AI chat's
- * file rendering. A lone image, location, voice and document cards follow the
- * bubble's chained corners (run-aware); file chips can't.
+ * open the in-chat lightbox); videos render as wide, inline F0VideoPlayers;
+ * previewable documents (pdf/sheet/docx/text) get a Slack-style snapshot card
+ * (clickable to open the fullscreen viewer); other files use
+ * {@link F0FileItem} with a download action, mirroring the AI chat's file
+ * rendering. Multiple videos stack vertically so each keeps the largest useful
+ * playback area. A lone image, video, location, voice and document cards follow
+ * the bubble's chained corners (run-aware); file chips can't.
  */
 export const ChatMessageAttachments = ({
   message,
@@ -55,16 +59,21 @@ export const ChatMessageAttachments = ({
   const files = attachments.filter(
     (a): a is F0ChatFileAttachment => a.kind === "file"
   )
+  // A completed browser-compatible video becomes an inline player. While it is
+  // uploading it intentionally stays a file chip, keeping progress feedback.
+  const videoFiles = files.filter(
+    (file) => file.progress === undefined && isVideoFileAttachment(file)
+  )
+  const nonVideoFiles = files.filter((file) => !videoFiles.includes(file))
   // Previewable documents get the Slack-style snapshot card (a document still
-  // uploading, or too big to parse client-side, keeps the plain chip). `files`
-  // stays whole for the corner math below.
-  const documentFiles = files.flatMap((file) => {
+  // uploading, or too big to parse client-side, keeps the plain chip).
+  const documentFiles = nonVideoFiles.flatMap((file) => {
     if (file.progress !== undefined) return []
     const docKind = documentPreviewKind(file)
     if (!docKind || !withinPreviewSizeLimit(file, docKind)) return []
     return [{ file, docKind }]
   })
-  const plainFiles = files.filter(
+  const plainFiles = nonVideoFiles.filter(
     (file) => !documentFiles.some((entry) => entry.file === file)
   )
   const locations = attachments.filter(
@@ -82,26 +91,47 @@ export const ChatMessageAttachments = ({
   // caption bubble, no further message of the run).
   const captionBelow =
     message.body.trim().length > 0 || Boolean(message.replyTo)
-  const belowMedia =
+  const belowImages =
     files.length > 0 || voices.length > 0 || captionBelow || !isLastOfRun
   const imageCorners = bubbleCornerClass(
     isMine,
     isFirstOfRun,
-    locations.length === 0 && !belowMedia
+    locations.length === 0 && !belowImages
   )
-  const locationCorners = (index: number): string =>
+  const belowVideos =
+    locations.length > 0 ||
+    voices.length > 0 ||
+    nonVideoFiles.length > 0 ||
+    captionBelow ||
+    !isLastOfRun
+  const videoCorners = (index: number): string =>
     bubbleCornerClass(
       isMine,
       isFirstOfRun && images.length === 0 && index === 0,
-      index === locations.length - 1 && !belowMedia
+      index === videoFiles.length - 1 && !belowVideos
+    )
+  const belowLocations =
+    voices.length > 0 ||
+    nonVideoFiles.length > 0 ||
+    captionBelow ||
+    !isLastOfRun
+  const locationCorners = (index: number): string =>
+    bubbleCornerClass(
+      isMine,
+      isFirstOfRun &&
+        images.length === 0 &&
+        videoFiles.length === 0 &&
+        index === 0,
+      index === locations.length - 1 && !belowLocations
     )
   // Voice notes stack after the locations, before the files/caption.
-  const belowVoices = files.length > 0 || captionBelow || !isLastOfRun
+  const belowVoices = nonVideoFiles.length > 0 || captionBelow || !isLastOfRun
   const voiceCorners = (index: number): string =>
     bubbleCornerClass(
       isMine,
       isFirstOfRun &&
         images.length === 0 &&
+        videoFiles.length === 0 &&
         locations.length === 0 &&
         index === 0,
       index === voices.length - 1 && !belowVoices
@@ -113,6 +143,7 @@ export const ChatMessageAttachments = ({
       isMine,
       isFirstOfRun &&
         images.length === 0 &&
+        videoFiles.length === 0 &&
         locations.length === 0 &&
         voices.length === 0 &&
         index === 0,
@@ -170,6 +201,13 @@ export const ChatMessageAttachments = ({
           ))}
         </div>
       )}
+      {videoFiles.map((file, i) => (
+        <ChatVideoAttachment
+          key={`${file.url}-${i}`}
+          file={file}
+          cornerClass={videoCorners(i)}
+        />
+      ))}
       {locations.map((location, i) => (
         <ChatLocationAttachment
           key={`${location.latitude},${location.longitude}-${i}`}

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageInfo.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageInfo.tsx
@@ -7,8 +7,9 @@ import { ButtonInternal } from "@/components/F0Button/internal"
 import { cn, focusRing } from "@/lib/utils"
 
 import { useF0Chat } from "../providers/F0ChatProvider"
-import { type F0ChatMessage } from "../types"
+import { type F0ChatMessage, type F0ChatUser } from "../types"
 import { formatSeparator } from "../utils/natural-time"
+import { ChatUserHoverCard } from "./ChatUserHoverCard"
 
 const InfoRow = ({
   label,
@@ -26,6 +27,43 @@ const InfoRow = ({
     )}
   </div>
 )
+
+const ReaderIdentity = ({ user }: { user: F0ChatUser }): ReactNode => {
+  const className = cn(
+    "flex w-full items-center gap-2 rounded-md px-0 py-1.5 text-f1-foreground no-underline",
+    focusRing("focus-visible:ring-inset")
+  )
+  const content = (
+    <>
+      <F0Avatar
+        size="sm"
+        avatar={
+          user.avatar ?? {
+            type: "person",
+            firstName: user.name,
+            lastName: "",
+          }
+        }
+      />
+      <span className="text-base font-normal">{user.name}</span>
+      {user.subtitle && <span className="sr-only">, {user.subtitle}</span>}
+    </>
+  )
+
+  return (
+    <ChatUserHoverCard user={user}>
+      {user.profileHref ? (
+        <a className={className} href={user.profileHref}>
+          {content}
+        </a>
+      ) : (
+        <span className={className} tabIndex={0}>
+          {content}
+        </span>
+      )}
+    </ChatUserHoverCard>
+  )
+}
 
 /**
  * Message-info panel shown in place of the actions menu (a back arrow returns to
@@ -101,23 +139,8 @@ export const ChatMessageInfoView = ({
                     role="list"
                   >
                     {message.readBy.map((user) => (
-                      <li
-                        key={user.id}
-                        className="flex items-center gap-2 rounded-md px-0 py-1.5"
-                      >
-                        <F0Avatar
-                          size="sm"
-                          avatar={
-                            user.avatar ?? {
-                              type: "person",
-                              firstName: user.name,
-                              lastName: "",
-                            }
-                          }
-                        />
-                        <span className="text-base font-normal text-f1-foreground">
-                          {user.name}
-                        </span>
+                      <li key={user.id}>
+                        <ReaderIdentity user={user} />
                       </li>
                     ))}
                   </ul>

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageInfo.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageInfo.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode } from "react"
+import { useEffect, useRef, type ReactNode } from "react"
 
 import { ArrowLeft } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
@@ -41,6 +41,7 @@ export const ChatMessageInfoView = ({
 }): ReactNode => {
   const i18n = useI18n()
   const { channel } = useF0Chat()
+  const backButtonRef = useRef<HTMLButtonElement | HTMLAnchorElement>(null)
   const labels = {
     today: i18n.date.groups.today,
     yesterday: i18n.date.groups.yesterday,
@@ -54,10 +55,15 @@ export const ChatMessageInfoView = ({
     { count: readByCount }
   )
 
+  useEffect(() => {
+    backButtonRef.current?.focus()
+  }, [])
+
   return (
     <div className="flex flex-col">
       <div className="flex items-center gap-1 border-0 border-b border-solid border-f1-border-secondary px-2 py-2.5">
         <ButtonInternal
+          ref={backButtonRef}
           icon={ArrowLeft}
           onClick={onBack}
           label={i18n.chat.back}
@@ -70,55 +76,62 @@ export const ChatMessageInfoView = ({
         </span>
       </div>
 
-      <div className="flex flex-col gap-4 px-3 py-3">
-        <InfoRow
-          label={i18n.chat.delivered}
-          value={formatSeparator(new Date(message.createdAt), now, labels)}
-        />
-        {message.isMine &&
-          (isGroup ? (
-            <div className="flex flex-col gap-2">
-              <InfoRow label={readByLabel} />
-              {message.readBy && message.readBy.length > 0 && (
-                <ul
-                  aria-label={readByLabel}
-                  className={cn(
-                    "m-0 flex max-h-64 list-none flex-col gap-1 overflow-y-auto rounded p-0",
-                    focusRing("focus-visible:ring-inset")
-                  )}
-                  tabIndex={0}
-                >
-                  {message.readBy.map((user) => (
-                    <li
-                      key={user.id}
-                      className="flex items-center gap-2 rounded-md px-0 py-1.5"
-                    >
-                      <F0Avatar
-                        size="sm"
-                        avatar={
-                          user.avatar ?? {
-                            type: "person",
-                            firstName: user.name,
-                            lastName: "",
+      <div
+        aria-label={i18n.chat.info}
+        className={cn(
+          "max-h-80 overflow-y-auto rounded-b-lg",
+          focusRing("focus-visible:ring-inset")
+        )}
+        role="region"
+        tabIndex={0}
+      >
+        <div className="flex flex-col gap-4 px-3 py-3">
+          <InfoRow
+            label={i18n.chat.delivered}
+            value={formatSeparator(new Date(message.createdAt), now, labels)}
+          />
+          {message.isMine &&
+            (isGroup ? (
+              <div className="flex flex-col gap-2">
+                <InfoRow label={readByLabel} />
+                {message.readBy && message.readBy.length > 0 && (
+                  <ul
+                    aria-label={readByLabel}
+                    className="m-0 flex list-none flex-col gap-1 p-0"
+                    role="list"
+                  >
+                    {message.readBy.map((user) => (
+                      <li
+                        key={user.id}
+                        className="flex items-center gap-2 rounded-md px-0 py-1.5"
+                      >
+                        <F0Avatar
+                          size="sm"
+                          avatar={
+                            user.avatar ?? {
+                              type: "person",
+                              firstName: user.name,
+                              lastName: "",
+                            }
                           }
-                        }
-                      />
-                      <span className="text-base font-normal text-f1-foreground">
-                        {user.name}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </div>
-          ) : (
-            message.readAt && (
-              <InfoRow
-                label={i18n.chat.read}
-                value={formatSeparator(new Date(message.readAt), now, labels)}
-              />
-            )
-          ))}
+                        />
+                        <span className="text-base font-normal text-f1-foreground">
+                          {user.name}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            ) : (
+              message.readAt && (
+                <InfoRow
+                  label={i18n.chat.read}
+                  value={formatSeparator(new Date(message.readAt), now, labels)}
+                />
+              )
+            ))}
+        </div>
       </div>
     </div>
   )

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageInfo.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageInfo.tsx
@@ -9,7 +9,6 @@ import { cn, focusRing } from "@/lib/utils"
 import { useF0Chat } from "../providers/F0ChatProvider"
 import { type F0ChatMessage, type F0ChatUser } from "../types"
 import { formatSeparator } from "../utils/natural-time"
-import { ChatUserHoverCard } from "./ChatUserHoverCard"
 
 const InfoRow = ({
   label,
@@ -29,12 +28,8 @@ const InfoRow = ({
 )
 
 const ReaderIdentity = ({ user }: { user: F0ChatUser }): ReactNode => {
-  const className = cn(
-    "flex w-full items-center gap-2 rounded-md px-0 py-1.5 text-f1-foreground no-underline",
-    focusRing("focus-visible:ring-inset")
-  )
-  const content = (
-    <>
+  return (
+    <div className="flex w-full items-center gap-2 px-0 py-1.5 text-f1-foreground">
       <F0Avatar
         size="sm"
         avatar={
@@ -46,22 +41,7 @@ const ReaderIdentity = ({ user }: { user: F0ChatUser }): ReactNode => {
         }
       />
       <span className="text-base font-normal">{user.name}</span>
-      {user.subtitle && <span className="sr-only">, {user.subtitle}</span>}
-    </>
-  )
-
-  return (
-    <ChatUserHoverCard user={user}>
-      {user.profileHref ? (
-        <a className={className} href={user.profileHref}>
-          {content}
-        </a>
-      ) : (
-        <span className={className} tabIndex={0}>
-          {content}
-        </span>
-      )}
-    </ChatUserHoverCard>
+    </div>
   )
 }
 

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageInfo.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageInfo.tsx
@@ -2,7 +2,9 @@ import { type ReactNode } from "react"
 
 import { ArrowLeft } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
+import { F0Avatar } from "@/components/avatars/F0Avatar"
 import { ButtonInternal } from "@/components/F0Button/internal"
+import { cn, focusRing } from "@/lib/utils"
 
 import { useF0Chat } from "../providers/F0ChatProvider"
 import { type F0ChatMessage } from "../types"
@@ -27,8 +29,8 @@ const InfoRow = ({
 
 /**
  * Message-info panel shown in place of the actions menu (a back arrow returns to
- * it). Deliberately minimal for v1: delivered + read times for DMs, and just the
- * "Read by N" count for groups (no per-person reader list).
+ * it). Shows delivered + read times for DMs and the reader identities for group
+ * messages when the host provides them.
  */
 export const ChatMessageInfoView = ({
   message,
@@ -46,6 +48,11 @@ export const ChatMessageInfoView = ({
   const now = new Date()
 
   const isGroup = channel.type === "group"
+  const readByCount = message.readBy?.length ?? message.readByCount ?? 0
+  const readByLabel = i18n.t(
+    readByCount === 1 ? "chat.readBy.one" : "chat.readBy.other",
+    { count: readByCount }
+  )
 
   return (
     <div className="flex flex-col">
@@ -64,16 +71,46 @@ export const ChatMessageInfoView = ({
       </div>
 
       <div className="flex flex-col gap-4 px-3 py-3">
+        <InfoRow
+          label={i18n.chat.delivered}
+          value={formatSeparator(new Date(message.createdAt), now, labels)}
+        />
         {message.isMine &&
           (isGroup ? (
-            <InfoRow
-              label={i18n.t(
-                (message.readByCount ?? 0) === 1
-                  ? "chat.readBy.one"
-                  : "chat.readBy.other",
-                { count: message.readByCount ?? 0 }
+            <div className="flex flex-col gap-2">
+              <InfoRow label={readByLabel} />
+              {message.readBy && message.readBy.length > 0 && (
+                <ul
+                  aria-label={readByLabel}
+                  className={cn(
+                    "m-0 flex max-h-64 list-none flex-col gap-1 overflow-y-auto rounded p-0",
+                    focusRing("focus-visible:ring-inset")
+                  )}
+                  tabIndex={0}
+                >
+                  {message.readBy.map((user) => (
+                    <li
+                      key={user.id}
+                      className="flex items-center gap-2 rounded-md px-0 py-1.5"
+                    >
+                      <F0Avatar
+                        size="sm"
+                        avatar={
+                          user.avatar ?? {
+                            type: "person",
+                            firstName: user.name,
+                            lastName: "",
+                          }
+                        }
+                      />
+                      <span className="text-base font-normal text-f1-foreground">
+                        {user.name}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
               )}
-            />
+            </div>
           ) : (
             message.readAt && (
               <InfoRow
@@ -82,10 +119,6 @@ export const ChatMessageInfoView = ({
               />
             )
           ))}
-        <InfoRow
-          label={i18n.chat.delivered}
-          value={formatSeparator(new Date(message.createdAt), now, labels)}
-        />
       </div>
     </div>
   )

--- a/packages/react/src/sds/chat/F0Chat/components/ChatMessageReactions.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatMessageReactions.tsx
@@ -30,7 +30,7 @@ export const ChatMessageReactions = ({
 }): ReactNode => {
   const i18n = useI18n()
   const reducedMotion = useReducedMotion()
-  const { toggleReaction, capabilities } = useF0ChatStable()
+  const { toggleReaction, loadReactionUsers, capabilities } = useF0ChatStable()
   // Existing pills stay VISIBLE without the capability (the data is real) —
   // only adding/toggling is disabled.
   const canReact = capabilities?.canReact !== false
@@ -72,6 +72,17 @@ export const ChatMessageReactions = ({
               initialCount={reaction.count}
               hasReacted={reaction.reactedByMe}
               users={reaction.users}
+              loadUsers={
+                loadReactionUsers &&
+                (reaction.users?.length ?? 0) < reaction.count
+                  ? () =>
+                      loadReactionUsers(
+                        message.id,
+                        reaction.emoji,
+                        reaction.count
+                      )
+                  : undefined
+              }
               onInteraction={
                 canReact
                   ? (emoji) => void toggleReaction(message.id, emoji)

--- a/packages/react/src/sds/chat/F0Chat/components/ChatSystemMessage.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatSystemMessage.tsx
@@ -69,8 +69,8 @@ export const ChatSystemMessage = ({
   const payload = message.system
 
   const line = (content: ReactNode) => (
-    <div className="flex justify-center px-4 py-6">
-      <span className="text-center text-sm text-f1-foreground-tertiary">
+    <div className="flex justify-center px-4 py-5">
+      <span className="text-center text-sm text-f1-foreground-tertiary max-w-96">
         {content}
       </span>
     </div>

--- a/packages/react/src/sds/chat/F0Chat/components/ChatTextareaField.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatTextareaField.tsx
@@ -12,6 +12,7 @@ type ChatTextareaFieldProps = {
   placeholder: string
   onChange: (value: string, cursorPos: number) => void
   onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void
+  onPaste: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void
   onCursorUpdate: () => void
   onScroll: () => void
   highlightSegments: HighlightSegment[]
@@ -37,6 +38,7 @@ export const ChatTextareaField = ({
   placeholder,
   onChange,
   onKeyDown,
+  onPaste,
   onCursorUpdate,
   onScroll,
   highlightSegments,
@@ -103,6 +105,7 @@ export const ChatTextareaField = ({
         placeholder={placeholder}
         onChange={(e) => onChange(e.target.value, e.target.selectionStart ?? 0)}
         onKeyDown={onKeyDown}
+        onPaste={onPaste}
         onKeyUp={onCursorUpdate}
         onClick={onCursorUpdate}
         onSelect={onCursorUpdate}

--- a/packages/react/src/sds/chat/F0Chat/components/ChatTextareaField.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatTextareaField.tsx
@@ -10,12 +10,17 @@ type ChatTextareaFieldProps = {
   highlightRef: RefObject<HTMLDivElement>
   value: string
   placeholder: string
+  accessibleLabel: string
   onChange: (value: string, cursorPos: number) => void
   onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void
   onPaste: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void
+  onBlur?: (event: React.FocusEvent<HTMLTextAreaElement>) => void
   onCursorUpdate: () => void
   onScroll: () => void
   highlightSegments: HighlightSegment[]
+  isAutocompleteOpen: boolean
+  autocompleteListboxId?: string
+  activeAutocompleteOptionId?: string
   /** When true, a typed `@mention` / ghost completion is shown via the overlay
    * and the textarea text is hidden (caret stays visible). */
   hasOverlay: boolean
@@ -36,12 +41,17 @@ export const ChatTextareaField = ({
   highlightRef,
   value,
   placeholder,
+  accessibleLabel,
   onChange,
   onKeyDown,
   onPaste,
+  onBlur,
   onCursorUpdate,
   onScroll,
   highlightSegments,
+  isAutocompleteOpen,
+  autocompleteListboxId,
+  activeAutocompleteOptionId,
   hasOverlay,
 }: ChatTextareaFieldProps) => {
   return (
@@ -103,13 +113,20 @@ export const ChatTextareaField = ({
         rows={1}
         value={value}
         placeholder={placeholder}
+        aria-label={accessibleLabel}
         onChange={(e) => onChange(e.target.value, e.target.selectionStart ?? 0)}
         onKeyDown={onKeyDown}
         onPaste={onPaste}
+        onBlur={onBlur}
         onKeyUp={onCursorUpdate}
         onClick={onCursorUpdate}
         onSelect={onCursorUpdate}
         onScroll={onScroll}
+        role="combobox"
+        aria-autocomplete="list"
+        aria-expanded={isAutocompleteOpen}
+        aria-controls={autocompleteListboxId}
+        aria-activedescendant={activeAutocompleteOptionId}
         className={cn(
           "col-start-1 row-start-1",
           "w-full resize-none bg-transparent outline-none",

--- a/packages/react/src/sds/chat/F0Chat/components/ChatVideoAttachment.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatVideoAttachment.tsx
@@ -1,0 +1,109 @@
+import { lazy, Suspense, type ReactNode, useState } from "react"
+
+import { ButtonInternal } from "@/components/F0Button/internal"
+import { F0FileItem } from "@/components/F0FileItem"
+import { type IconType } from "@/components/F0Icon"
+import { Download } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
+import { cn } from "@/lib/utils"
+import { Skeleton } from "@/ui/skeleton"
+
+import { type F0ChatFileAttachment } from "../types"
+import { triggerDownload } from "../utils/download"
+
+const LazyVideoPlayer = lazy(() =>
+  import("@/components/F0VideoPlayer").then((module) => ({
+    default: module.F0VideoPlayer,
+  }))
+)
+
+/**
+ * An inline chat video powered by F0VideoPlayer. The player owns playback,
+ * keyboard shortcuts, speed, volume, captions and fullscreen; chat only adds
+ * message sizing/corners and preserves the attachment download action.
+ */
+export const ChatVideoAttachment = ({
+  file,
+  cornerClass,
+  className,
+  action,
+}: {
+  file: F0ChatFileAttachment
+  cornerClass: string
+  /** Optional sizing override for compact surfaces such as the composer. */
+  className?: string
+  /** Override the default download action, e.g. Remove inside the composer. */
+  action?: {
+    label: string
+    icon: IconType
+    onClick: () => void
+  }
+}): ReactNode => {
+  const i18n = useI18n()
+  const [failed, setFailed] = useState(false)
+  const attachmentAction = action ?? {
+    label: i18n.t("chat.downloadNamedFile", { name: file.name }),
+    icon: Download,
+    onClick: () => triggerDownload(file.url, file.name),
+  }
+
+  if (failed) {
+    return (
+      <F0FileItem
+        size="md"
+        file={{ name: file.name, type: file.mimeType ?? "" }}
+        actions={[attachmentAction]}
+      />
+    )
+  }
+
+  return (
+    <figure
+      aria-label={file.name}
+      className={cn(
+        "group/video relative m-0 aspect-video w-full max-w-xl overflow-hidden",
+        cornerClass,
+        className
+      )}
+      onErrorCapture={(event) => {
+        if (event.target instanceof HTMLVideoElement) {
+          setFailed(true)
+        }
+      }}
+      data-testid="chat-video-attachment"
+    >
+      <Suspense
+        fallback={
+          <div
+            role="status"
+            aria-label={i18n.t("chat.loadingVideo", { name: file.name })}
+            className="h-full w-full"
+          >
+            <Skeleton className="h-full w-full" />
+          </div>
+        }
+      >
+        <LazyVideoPlayer
+          src={file.url}
+          ariaLabel={i18n.t("chat.videoPlayerLabel", { name: file.name })}
+          poster={file.thumbnailUrl}
+          content={file.videoContent}
+          defaultLanguage={file.videoDefaultLanguage}
+          silent={file.videoSilent}
+          data-testid="chat-video-player"
+        />
+      </Suspense>
+
+      <span className="shadow-sm absolute right-2 top-2 z-10 flex rounded bg-f1-background">
+        <ButtonInternal
+          variant="outline"
+          hideLabel
+          icon={attachmentAction.icon}
+          label={attachmentAction.label}
+          onClick={attachmentAction.onClick}
+        />
+      </span>
+      <figcaption className="sr-only">{file.name}</figcaption>
+    </figure>
+  )
+}

--- a/packages/react/src/sds/chat/F0Chat/components/ChatVideoAttachment.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatVideoAttachment.tsx
@@ -1,8 +1,6 @@
 import { lazy, Suspense, type ReactNode, useState } from "react"
 
-import { ButtonInternal } from "@/components/F0Button/internal"
 import { F0FileItem } from "@/components/F0FileItem"
-import { type IconType } from "@/components/F0Icon"
 import { Download } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
@@ -19,29 +17,22 @@ const LazyVideoPlayer = lazy(() =>
 
 /**
  * An inline chat video powered by F0VideoPlayer. The player owns playback,
- * keyboard shortcuts, speed, volume, captions and fullscreen; chat only adds
- * message sizing/corners and preserves the attachment download action.
+ * keyboard shortcuts, speed, volume, captions, download and fullscreen; chat
+ * adds the file-specific download action, message sizing and chained corners.
  */
 export const ChatVideoAttachment = ({
   file,
   cornerClass,
   className,
-  action,
 }: {
   file: F0ChatFileAttachment
   cornerClass: string
   /** Optional sizing override for compact surfaces such as the composer. */
   className?: string
-  /** Override the default download action, e.g. Remove inside the composer. */
-  action?: {
-    label: string
-    icon: IconType
-    onClick: () => void
-  }
 }): ReactNode => {
   const i18n = useI18n()
   const [failed, setFailed] = useState(false)
-  const attachmentAction = action ?? {
+  const downloadAction = {
     label: i18n.t("chat.downloadNamedFile", { name: file.name }),
     icon: Download,
     onClick: () => triggerDownload(file.url, file.name),
@@ -52,7 +43,7 @@ export const ChatVideoAttachment = ({
       <F0FileItem
         size="md"
         file={{ name: file.name, type: file.mimeType ?? "" }}
-        actions={[attachmentAction]}
+        actions={[downloadAction]}
       />
     )
   }
@@ -90,19 +81,14 @@ export const ChatVideoAttachment = ({
           content={file.videoContent}
           defaultLanguage={file.videoDefaultLanguage}
           silent={file.videoSilent}
+          download={{
+            label: downloadAction.label,
+            onClick: downloadAction.onClick,
+          }}
           data-testid="chat-video-player"
         />
       </Suspense>
 
-      <span className="shadow-sm absolute right-2 top-2 z-10 flex rounded bg-f1-background">
-        <ButtonInternal
-          variant="outline"
-          hideLabel
-          icon={attachmentAction.icon}
-          label={attachmentAction.label}
-          onClick={attachmentAction.onClick}
-        />
-      </span>
       <figcaption className="sr-only">{file.name}</figcaption>
     </figure>
   )

--- a/packages/react/src/sds/chat/F0Chat/components/ChatVoiceAttachment.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/ChatVoiceAttachment.tsx
@@ -4,7 +4,7 @@ import { useAudioPlayer } from "@/components/F0AudioPlayer"
 import { ButtonInternal } from "@/components/F0Button/internal"
 import { SolidPause, SolidPlay } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
-import { cn } from "@/lib/utils"
+import { cn, focusRing } from "@/lib/utils"
 
 import { type F0ChatVoiceAttachment } from "../types"
 
@@ -141,14 +141,45 @@ export const ChatVoiceAttachment = ({
     [player, duration]
   )
 
+  const handleSeekKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (duration <= 0) return
+      const step = Math.max(1, duration / BAR_COUNT)
+      let nextTime: number
+
+      switch (event.key) {
+        case "ArrowLeft":
+        case "ArrowDown":
+          nextTime = player.currentTime - step
+          break
+        case "ArrowRight":
+        case "ArrowUp":
+          nextTime = player.currentTime + step
+          break
+        case "Home":
+          nextTime = 0
+          break
+        case "End":
+          nextTime = duration
+          break
+        default:
+          return
+      }
+
+      event.preventDefault()
+      player.seek(Math.min(duration, Math.max(0, nextTime)))
+    },
+    [duration, player]
+  )
+
   return (
     <div
       className={cn("flex w-full flex-col gap-1 bg-f1-background", cornerClass)}
     >
       <div
         className={cn(
-          // 320px by default, shrinking with the column when it doesn't fit
-          // (floor ≈ 254px: button + minimum bars + time slot + paddings).
+          // 320px by default, shrinking with the column when it doesn't fit.
+          // The waveform below owns any remaining overflow at very small sizes.
           "group/voice flex w-80 min-w-0 max-w-full items-center gap-2 border border-solid border-f1-border-secondary p-3",
           isMine ? "bg-f1-background-tertiary" : "bg-f1-background",
           cornerClass,
@@ -175,10 +206,15 @@ export const ChatVoiceAttachment = ({
         <div
           ref={barsRef}
           onClick={handleSeek}
+          onKeyDown={handleSeekKeyDown}
           // justify-between spreads the fixed set of bars across whatever width
           // the card gets, so the waveform stays proportioned at any size.
-          className="flex h-8 min-w-0 flex-1 cursor-pointer items-center justify-between gap-0.5"
+          className={cn(
+            "flex h-8 min-w-0 flex-1 cursor-pointer items-center justify-between gap-0.5 overflow-hidden rounded-sm",
+            focusRing("focus-visible:ring-inset")
+          )}
           role="slider"
+          tabIndex={0}
           aria-label={i18n.audioPlayer.seek}
           aria-valuemin={0}
           aria-valuemax={Math.round(duration)}
@@ -189,7 +225,7 @@ export const ChatVoiceAttachment = ({
             <span
               key={i}
               className={cn(
-                "w-0.5 min-w-0.5 shrink rounded-full transition-colors",
+                "w-0.5 min-w-px shrink rounded-full transition-colors",
                 // Played part reads darker, WhatsApp-style.
                 i / levels.length <= progress && progress > 0
                   ? "bg-f1-foreground"
@@ -204,26 +240,31 @@ export const ChatVoiceAttachment = ({
           card (or tabbing into it) swaps the time for the speed control. Both
           have the same FIXED width so neither the ticking time ("0:04" → "0:12")
           nor the cycling rate ("1x" → "1.5x") resizes the waveform. */}
-        <span
-          className="inline-block w-12 shrink-0 text-end text-base font-medium pr-2 tabular-nums text-f1-foreground-secondary group-hover/voice:hidden"
-          data-testid="chat-voice-time"
+        <div
+          className="relative w-12 shrink-0"
+          data-testid="chat-voice-trailing"
         >
-          {formatTime(
-            player.isPlaying || player.currentTime > 0
-              ? player.currentTime
-              : duration
-          )}
-        </span>
+          <span
+            className="inline-block w-full pr-2 text-end text-base font-medium tabular-nums text-f1-foreground-secondary group-focus-within/voice:invisible group-hover/voice:invisible"
+            data-testid="chat-voice-time"
+          >
+            {formatTime(
+              player.isPlaying || player.currentTime > 0
+                ? player.currentTime
+                : duration
+            )}
+          </span>
 
-        <div className="hidden w-12 shrink-0 justify-end group-hover/voice:flex">
-          <ButtonInternal
-            variant="ghost"
-            size="sm"
-            label={`${PLAYBACK_RATES[rateIndex]}x`}
-            aria-label={i18n.audioPlayer.playbackSpeed}
-            onClick={handleCycleRate}
-            data-testid="chat-voice-rate"
-          />
+          <div className="pointer-events-none absolute inset-0 flex justify-end opacity-0 transition-opacity group-focus-within/voice:pointer-events-auto group-focus-within/voice:opacity-100 group-hover/voice:pointer-events-auto group-hover/voice:opacity-100 motion-reduce:transition-none">
+            <ButtonInternal
+              variant="ghost"
+              size="sm"
+              label={`${PLAYBACK_RATES[rateIndex]}x`}
+              aria-label={`${i18n.audioPlayer.playbackSpeed}: ${PLAYBACK_RATES[rateIndex]}x`}
+              onClick={handleCycleRate}
+              data-testid="chat-voice-rate"
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/packages/react/src/sds/chat/F0Chat/components/MessageStatus.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/MessageStatus.tsx
@@ -6,16 +6,15 @@ import { useReducedMotion } from "@/lib/a11y"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
 
+import { useF0Chat } from "../providers/F0ChatProvider"
 import { type F0ChatMessage } from "../types"
 import { formatStatusTime } from "../utils/natural-time"
 
 /**
- * Footer under the conversation's last message: its time, plus — when the
- * message is mine and READ — the read state ("Read hh:mm", or "Read by N" in
- * groups). iMessage-style: only the latest message carries this line.
- * Optimistic on purpose (WhatsApp): sending/sent/delivered all show the bare
- * time — success isn't announced, a slow send is the SendingClock's job
- * (500ms) and a failure is the loud one ("Not sent" + retry alert).
+ * Footer under the conversation's last message. My settled messages show
+ * "Sent · hh:mm" until the read state is reached; group messages only advance
+ * to "Read · hh:mm" once every other channel member appears in the receipt
+ * count. Reader identities and counts remain available in the Info panel.
  */
 export const MessageStatus = ({
   message,
@@ -26,6 +25,7 @@ export const MessageStatus = ({
 }): ReactNode => {
   const i18n = useI18n()
   const reducedMotion = useReducedMotion()
+  const { channel } = useF0Chat()
 
   const time = formatStatusTime(new Date(message.createdAt), new Date(), {
     today: i18n.date.groups.today,
@@ -35,21 +35,31 @@ export const MessageStatus = ({
   let label = time
   if (message.isMine) {
     const readByCount = message.readBy?.length ?? message.readByCount
-    // sending/sent/delivered fall through to the bare time: the label never
-    // changes when the ack lands (same string, same key below) — zero flicker.
+    const expectedGroupReaders =
+      isGroup && channel.memberCount != null
+        ? Math.max(0, channel.memberCount - 1)
+        : undefined
+    const hasCompleteGroupReceipts =
+      expectedGroupReaders == null ||
+      expectedGroupReaders === 0 ||
+      (readByCount != null && readByCount >= expectedGroupReaders)
+    const isRead =
+      message.status === "read" && (!isGroup || hasCompleteGroupReceipts)
+    const isSettled =
+      message.status === "sent" ||
+      message.status === "delivered" ||
+      message.status === "read"
+
     if (message.status === "failed") label = `${i18n.chat.notSent} · ${time}`
-    else if (message.status === "read")
-      label =
-        isGroup && readByCount != null
-          ? i18n.t(
-              readByCount === 1 ? "chat.readBy.one" : "chat.readBy.other",
-              { count: readByCount }
-            )
-          : `${i18n.chat.read} ${time}`
+    else if (isSettled)
+      label = `${isRead ? i18n.chat.read : i18n.chat.sent} · ${time}`
   }
 
   return (
     <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
       className={cn(
         "px-1 pt-1 text-sm text-f1-foreground-secondary",
         message.isMine ? "text-right" : "text-left"

--- a/packages/react/src/sds/chat/F0Chat/components/MessageStatus.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/MessageStatus.tsx
@@ -34,17 +34,16 @@ export const MessageStatus = ({
 
   let label = time
   if (message.isMine) {
+    const readByCount = message.readBy?.length ?? message.readByCount
     // sending/sent/delivered fall through to the bare time: the label never
     // changes when the ack lands (same string, same key below) — zero flicker.
     if (message.status === "failed") label = `${i18n.chat.notSent} · ${time}`
     else if (message.status === "read")
       label =
-        isGroup && message.readByCount
+        isGroup && readByCount != null
           ? i18n.t(
-              message.readByCount === 1
-                ? "chat.readBy.one"
-                : "chat.readBy.other",
-              { count: message.readByCount }
+              readByCount === 1 ? "chat.readBy.one" : "chat.readBy.other",
+              { count: readByCount }
             )
           : `${i18n.chat.read} ${time}`
   }

--- a/packages/react/src/sds/chat/F0Chat/components/__tests__/ChatTextareaField.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/components/__tests__/ChatTextareaField.test.tsx
@@ -10,13 +10,36 @@ const baseProps = () => ({
   textareaRef: createRef<HTMLTextAreaElement>(),
   highlightRef: createRef<HTMLDivElement>(),
   placeholder: "Message",
+  accessibleLabel: "Write a message",
   onChange: vi.fn(),
   onKeyDown: vi.fn(),
+  onPaste: vi.fn(),
   onCursorUpdate: vi.fn(),
   onScroll: vi.fn(),
+  isAutocompleteOpen: false,
 })
 
 describe("ChatTextareaField emoji overlay", () => {
+  it("exposes the emoji list as an accessible combobox", () => {
+    zeroRender(
+      <ChatTextareaField
+        {...baseProps()}
+        value=":sm"
+        highlightSegments={[{ type: "text", text: ":sm" }]}
+        hasOverlay={false}
+        isAutocompleteOpen
+        autocompleteListboxId="emoji-list"
+        activeAutocompleteOptionId="emoji-smile"
+      />
+    )
+
+    const composer = document.querySelector('[role="combobox"]')
+    expect(composer).toHaveAccessibleName("Write a message")
+    expect(composer).toHaveAttribute("aria-expanded", "true")
+    expect(composer).toHaveAttribute("aria-controls", "emoji-list")
+    expect(composer).toHaveAttribute("aria-activedescendant", "emoji-smile")
+  })
+
   it("paints emoji as twemoji in the overlay when active", () => {
     const segments: HighlightSegment[] = [{ type: "text", text: "hi 😀" }]
     const { container } = zeroRender(

--- a/packages/react/src/sds/chat/F0Chat/hooks/__tests__/useChatVirtuoso.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/__tests__/useChatVirtuoso.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { act, zeroRenderHook as renderHook } from "@/testing/test-utils"
+
+import { useChatVirtuoso } from "../useChatVirtuoso"
+
+let frameCallbacks: FrameRequestCallback[]
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  frameCallbacks = []
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    frameCallbacks.push(callback)
+    return frameCallbacks.length
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+})
+
+const renderVirtuoso = () =>
+  renderHook(() =>
+    useChatVirtuoso({
+      rows: [],
+      indexById: new Map<string, number>(),
+      itemCount: 1,
+      messages: [{ id: "message-1" }],
+      hasMoreOlder: false,
+      loadingOlder: false,
+      loadOlder: vi.fn(),
+      hasMoreNewer: false,
+      loadingNewer: false,
+      conversationKey: "conversation-1",
+      reducedMotion: false,
+    })
+  )
+
+const hookOptions = (messages: { id: string; isMine?: boolean }[]) => ({
+  rows: [],
+  indexById: new Map<string, number>(),
+  itemCount: messages.length,
+  messages,
+  hasMoreOlder: false,
+  loadingOlder: false,
+  loadOlder: vi.fn(),
+  hasMoreNewer: false,
+  loadingNewer: false,
+  conversationKey: "conversation-1",
+  reducedMotion: false,
+})
+
+const attachScroller = (
+  handleScrollerRef: (element: HTMLElement | Window | null) => void
+) => {
+  const scroller = document.createElement("div")
+  let scrollHeight = 1000
+  let scrollTop = 500
+  const clientHeight = 500
+
+  Object.defineProperties(scroller, {
+    clientHeight: { configurable: true, get: () => clientHeight },
+    scrollHeight: { configurable: true, get: () => scrollHeight },
+    scrollTop: {
+      configurable: true,
+      get: () => scrollTop,
+      set: (value: number) => {
+        scrollTop = Math.min(
+          Math.max(0, value),
+          Math.max(0, scrollHeight - clientHeight)
+        )
+      },
+    },
+  })
+
+  act(() => handleScrollerRef(scroller))
+
+  return {
+    scroller,
+    getScrollTop: () => scrollTop,
+    setScrollTop: (value: number) => {
+      scroller.scrollTop = value
+    },
+    setScrollHeight: (height: number) => {
+      scrollHeight = height
+    },
+  }
+}
+
+describe("useChatVirtuoso wheel takeover", () => {
+  it("keeps following paused after the first small upward scroll", () => {
+    const { result } = renderVirtuoso()
+    const viewport = attachScroller(result.current.handleScrollerRef)
+
+    act(() => result.current.handleTotalListHeightChanged(1000))
+    expect(result.current.followOutput).not.toBe(false)
+
+    act(() => {
+      viewport.scroller.dispatchEvent(new WheelEvent("wheel", { deltaY: -120 }))
+    })
+    expect(result.current.followOutput).toBe(false)
+
+    viewport.setScrollTop(470)
+    act(() => viewport.scroller.dispatchEvent(new Event("scroll")))
+    expect(viewport.getScrollTop()).toBe(470)
+
+    viewport.setScrollHeight(1100)
+    act(() => result.current.handleTotalListHeightChanged(1100))
+    expect(viewport.getScrollTop()).toBe(470)
+
+    act(() => vi.advanceTimersByTime(200))
+    viewport.setScrollHeight(1200)
+    act(() => result.current.handleTotalListHeightChanged(1200))
+    expect(viewport.getScrollTop()).toBe(470)
+
+    viewport.setScrollTop(700)
+    act(() => viewport.scroller.dispatchEvent(new Event("scroll")))
+    expect(result.current.followOutput).not.toBe(false)
+
+    viewport.setScrollHeight(1300)
+    act(() => result.current.handleTotalListHeightChanged(1300))
+    expect(viewport.getScrollTop()).toBe(800)
+    act(() => result.current.handleScrollerRef(null))
+  })
+
+  it("restores following when an upward wheel cannot leave the bottom", () => {
+    const { result } = renderVirtuoso()
+    const viewport = attachScroller(result.current.handleScrollerRef)
+
+    act(() => result.current.handleTotalListHeightChanged(1000))
+    act(() => {
+      viewport.scroller.dispatchEvent(new WheelEvent("wheel", { deltaY: -120 }))
+    })
+    expect(result.current.followOutput).toBe(false)
+
+    act(() => vi.advanceTimersByTime(200))
+    expect(result.current.followOutput).not.toBe(false)
+
+    viewport.setScrollHeight(1100)
+    act(() => result.current.handleTotalListHeightChanged(1100))
+    expect(viewport.getScrollTop()).toBe(600)
+    act(() => result.current.handleScrollerRef(null))
+  })
+
+  it("does not trust the broad at-bottom callback until the true edge", () => {
+    const { result } = renderVirtuoso()
+    const viewport = attachScroller(result.current.handleScrollerRef)
+
+    act(() => result.current.handleTotalListHeightChanged(1000))
+    act(() => {
+      viewport.scroller.dispatchEvent(new WheelEvent("wheel", { deltaY: -120 }))
+      viewport.setScrollTop(470)
+      viewport.scroller.dispatchEvent(new Event("scroll"))
+      result.current.handleAtBottomChange(true)
+    })
+    expect(result.current.followOutput).toBe(false)
+
+    act(() => {
+      viewport.setScrollTop(500)
+      result.current.handleAtBottomChange(true)
+    })
+    expect(result.current.followOutput).not.toBe(false)
+    act(() => result.current.handleScrollerRef(null))
+  })
+
+  it("keeps touch takeover paused until touchend reaches the true bottom", () => {
+    const { result } = renderVirtuoso()
+    const viewport = attachScroller(result.current.handleScrollerRef)
+
+    act(() => result.current.handleTotalListHeightChanged(1000))
+    act(() => viewport.scroller.dispatchEvent(new TouchEvent("touchmove")))
+    expect(result.current.followOutput).toBe(false)
+
+    act(() => {
+      viewport.setScrollTop(470)
+      viewport.scroller.dispatchEvent(new TouchEvent("touchend"))
+    })
+    expect(result.current.followOutput).toBe(false)
+
+    act(() => {
+      viewport.setScrollTop(500)
+      viewport.scroller.dispatchEvent(new TouchEvent("touchend"))
+    })
+    expect(result.current.followOutput).not.toBe(false)
+    act(() => result.current.handleScrollerRef(null))
+  })
+
+  it("resumes following for an explicit jump to bottom", () => {
+    const { result } = renderVirtuoso()
+    const viewport = attachScroller(result.current.handleScrollerRef)
+
+    act(() => result.current.handleTotalListHeightChanged(1000))
+    act(() => {
+      viewport.scroller.dispatchEvent(new WheelEvent("wheel", { deltaY: -120 }))
+      result.current.scrollToBottom()
+    })
+
+    expect(result.current.followOutput).not.toBe(false)
+    act(() => result.current.handleScrollerRef(null))
+  })
+
+  it("resumes and glides home when my message arrives inside the broad bottom band", () => {
+    const initialMessages = [{ id: "message-1" }]
+    const { result, rerender } = renderHook(
+      ({ messages }) => useChatVirtuoso(hookOptions(messages)),
+      { initialProps: { messages: initialMessages } }
+    )
+    const viewport = attachScroller(result.current.handleScrollerRef)
+    const scrollToIndex = vi.fn()
+    result.current.virtuosoRef.current = { scrollToIndex } as never
+
+    act(() => {
+      result.current.handleTotalListHeightChanged(1000)
+      viewport.scroller.dispatchEvent(new WheelEvent("wheel", { deltaY: -120 }))
+      viewport.setScrollTop(470)
+      viewport.scroller.dispatchEvent(new Event("scroll"))
+    })
+    expect(result.current.followOutput).toBe(false)
+
+    rerender({
+      messages: [...initialMessages, { id: "message-2", isMine: true }],
+    })
+
+    expect(result.current.followOutput).not.toBe(false)
+    expect(scrollToIndex).toHaveBeenCalledWith({
+      index: "LAST",
+      align: "end",
+      behavior: "smooth",
+    })
+    act(() => result.current.handleScrollerRef(null))
+  })
+
+  it("does not resume through a missing scroller and rechecks its replacement", () => {
+    const { result } = renderVirtuoso()
+    const firstViewport = attachScroller(result.current.handleScrollerRef)
+
+    act(() => {
+      result.current.handleTotalListHeightChanged(1000)
+      firstViewport.scroller.dispatchEvent(
+        new WheelEvent("wheel", { deltaY: -120 })
+      )
+      firstViewport.setScrollTop(470)
+      firstViewport.scroller.dispatchEvent(new Event("scroll"))
+      result.current.handleScrollerRef(null)
+      result.current.handleAtBottomChange(true)
+    })
+    expect(result.current.followOutput).toBe(false)
+
+    attachScroller(result.current.handleScrollerRef)
+    expect(result.current.followOutput).not.toBe(false)
+    expect(vi.getTimerCount()).toBe(0)
+    act(() => result.current.handleScrollerRef(null))
+  })
+
+  it.each([0, 120])(
+    "does not pause following for a %i downward/empty wheel delta",
+    (deltaY) => {
+      const { result } = renderVirtuoso()
+      const viewport = attachScroller(result.current.handleScrollerRef)
+
+      act(() => result.current.handleTotalListHeightChanged(1000))
+      act(() => {
+        viewport.scroller.dispatchEvent(new WheelEvent("wheel", { deltaY }))
+      })
+
+      expect(result.current.followOutput).not.toBe(false)
+      viewport.setScrollHeight(1100)
+      act(() => result.current.handleTotalListHeightChanged(1100))
+      expect(viewport.getScrollTop()).toBe(600)
+      expect(frameCallbacks).toHaveLength(0)
+      act(() => result.current.handleScrollerRef(null))
+    }
+  )
+})

--- a/packages/react/src/sds/chat/F0Chat/hooks/__tests__/useEmojiAutocomplete.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/__tests__/useEmojiAutocomplete.test.ts
@@ -1,0 +1,228 @@
+import { type KeyboardEvent } from "react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  act,
+  waitFor,
+  zeroRenderHook as renderHook,
+} from "@/testing/test-utils"
+
+import {
+  findEmojiTrigger,
+  getEmojiAutocompleteOptionId,
+  replaceClosedEmojiShortcode,
+  searchEmojiCandidates,
+  useEmojiAutocomplete,
+} from "../useEmojiAutocomplete"
+
+beforeEach(() => {
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    callback(0)
+    return 0
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  document.body.replaceChildren()
+})
+
+type Props = Parameters<typeof useEmojiAutocomplete>[0]
+
+const makeProps = (overrides: Partial<Props> = {}): Props => {
+  const textarea = document.createElement("textarea")
+  document.body.appendChild(textarea)
+  return {
+    inputValue: "",
+    setInputValue: () => {},
+    cursorPosition: 0,
+    setCursorPosition: () => {},
+    textareaRef: { current: textarea },
+    ...overrides,
+  }
+}
+
+const keyboardEvent = (
+  key: string,
+  overrides: Record<string, unknown> = {}
+): KeyboardEvent<HTMLTextAreaElement> =>
+  ({
+    key,
+    preventDefault: vi.fn(),
+    ...overrides,
+  }) as unknown as KeyboardEvent<HTMLTextAreaElement>
+
+describe("emoji autocomplete search", () => {
+  it("only finds colon triggers at the start of a token", () => {
+    expect(findEmojiTrigger(":", 1)).toEqual({
+      colonIndex: 0,
+      query: "",
+    })
+    expect(findEmojiTrigger("Say :smil", 9)).toEqual({
+      colonIndex: 4,
+      query: "smil",
+    })
+    expect(findEmojiTrigger("hello:", 6)).toBeNull()
+    expect(findEmojiTrigger("Meet at 12:30", 13)).toBeNull()
+    expect(findEmojiTrigger("https://factorialhr.com", 8)).toBeNull()
+  })
+
+  it("ranks shortcode and alias matches before broader keywords", () => {
+    expect(searchEmojiCandidates("smile")[0]).toMatchObject({
+      id: "smile",
+      native: "😄",
+    })
+    expect(searchEmojiCandidates("smil")[0]?.id).toBe("smile")
+    expect(searchEmojiCandidates("thumbsup")[0]).toMatchObject({
+      id: "+1",
+      native: "👍",
+    })
+    expect(searchEmojiCandidates("definitely-not-an-emoji")).toEqual([])
+  })
+
+  it("replaces complete Slack-style shortcodes and aliases", () => {
+    expect(replaceClosedEmojiShortcode(":smile:", 7)).toEqual({
+      value: "😄",
+      cursorPosition: 2,
+    })
+    expect(replaceClosedEmojiShortcode("Great :thumbsup: work", 16)).toEqual({
+      value: "Great 👍 work",
+      cursorPosition: 8,
+    })
+    expect(replaceClosedEmojiShortcode("https://example.com", 8)).toBeNull()
+    expect(replaceClosedEmojiShortcode(":unknown:", 9)).toBeNull()
+  })
+
+  it("generates collision-free option IDs for signed shortcodes", () => {
+    const listboxId = "emoji-results"
+
+    expect(getEmojiAutocompleteOptionId(listboxId, "+1")).not.toBe(
+      getEmojiAutocompleteOptionId(listboxId, "-1")
+    )
+  })
+})
+
+describe("useEmojiAutocomplete", () => {
+  it("opens on colon and exposes the active option to the textarea", () => {
+    const { result } = renderHook(() =>
+      useEmojiAutocomplete(
+        makeProps({
+          inputValue: ":",
+          cursorPosition: 1,
+        })
+      )
+    )
+
+    expect(result.current.isOpen).toBe(true)
+    expect(result.current.results).toHaveLength(8)
+    expect(result.current.activeDescendantId).toBe(
+      getEmojiAutocompleteOptionId(
+        result.current.listboxId,
+        result.current.results[0]?.id ?? ""
+      )
+    )
+  })
+
+  it("replaces the active query and preserves surrounding text", () => {
+    const setInputValue = vi.fn()
+    const setCursorPosition = vi.fn()
+    const textarea = document.createElement("textarea")
+    textarea.value = "Hello :smil world"
+    document.body.appendChild(textarea)
+    const { result } = renderHook(() =>
+      useEmojiAutocomplete({
+        inputValue: "Hello :smil world",
+        setInputValue,
+        cursorPosition: 11,
+        setCursorPosition,
+        textareaRef: { current: textarea },
+      })
+    )
+
+    const enter = keyboardEvent("Enter")
+    act(() => expect(result.current.handleKeyDown(enter)).toBe(true))
+
+    expect(enter.preventDefault).toHaveBeenCalledOnce()
+    expect(setInputValue).toHaveBeenCalledWith("Hello 😄 world")
+    expect(setCursorPosition).toHaveBeenCalledWith(9)
+    expect(textarea).toHaveFocus()
+    expect(textarea.selectionStart).toBe(9)
+  })
+
+  it("navigates with arrows and selects with Tab", async () => {
+    const setInputValue = vi.fn()
+    const setCursorPosition = vi.fn()
+    const textarea = document.createElement("textarea")
+    textarea.value = ":sm"
+    document.body.appendChild(textarea)
+    const { result } = renderHook(() =>
+      useEmojiAutocomplete({
+        inputValue: ":sm",
+        setInputValue,
+        cursorPosition: 3,
+        setCursorPosition,
+        textareaRef: { current: textarea },
+      })
+    )
+
+    const firstId = result.current.results[0]?.id
+    act(() => result.current.handleKeyDown(keyboardEvent("ArrowDown")))
+    await waitFor(() => expect(result.current.selectedIndex).toBe(1))
+    const second = result.current.results[1]
+    expect(second?.id).not.toBe(firstId)
+
+    act(() => result.current.handleKeyDown(keyboardEvent("Tab")))
+    expect(setInputValue).toHaveBeenCalledWith(`${second?.native} `)
+    expect(setCursorPosition).toHaveBeenCalledWith(3)
+    expect(textarea).toHaveFocus()
+    expect(textarea.selectionStart).toBe(3)
+  })
+
+  it("dismisses the current trigger with Escape", () => {
+    const props = makeProps({
+      inputValue: ":fire",
+      cursorPosition: 5,
+    })
+    const { result, rerender } = renderHook(
+      (nextProps: Props) => useEmojiAutocomplete(nextProps),
+      { initialProps: props }
+    )
+
+    const escape = keyboardEvent("Escape")
+    act(() => expect(result.current.handleKeyDown(escape)).toBe(true))
+
+    expect(escape.preventDefault).toHaveBeenCalledOnce()
+    expect(result.current.isOpen).toBe(false)
+    expect(result.current.activeDescendantId).toBeUndefined()
+    expect(props.textareaRef.current).toHaveFocus()
+
+    rerender({ ...props, inputValue: ":firex", cursorPosition: 6 })
+    expect(result.current.isOpen).toBe(false)
+
+    rerender({ ...props, inputValue: ":fire :joy", cursorPosition: 10 })
+    expect(result.current.isOpen).toBe(true)
+  })
+
+  it("preserves backward focus navigation and IME composition", () => {
+    const setInputValue = vi.fn()
+    const { result } = renderHook(() =>
+      useEmojiAutocomplete(
+        makeProps({
+          inputValue: ":smile",
+          cursorPosition: 6,
+          setInputValue,
+        })
+      )
+    )
+    const shiftTab = keyboardEvent("Tab", { shiftKey: true })
+    const composingEnter = keyboardEvent("Enter", {
+      nativeEvent: { isComposing: true },
+    })
+
+    expect(result.current.handleKeyDown(shiftTab)).toBe(false)
+    expect(result.current.handleKeyDown(composingEnter)).toBe(false)
+    expect(shiftTab.preventDefault).not.toHaveBeenCalled()
+    expect(composingEnter.preventDefault).not.toHaveBeenCalled()
+    expect(setInputValue).not.toHaveBeenCalled()
+  })
+})

--- a/packages/react/src/sds/chat/F0Chat/hooks/__tests__/useMentions.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/__tests__/useMentions.test.ts
@@ -78,6 +78,35 @@ describe("useMentions", () => {
     })
   })
 
+  it("keeps an empty DM trigger searchable after no initial results", async () => {
+    const searchMembers = vi.fn((query: string) =>
+      Promise.resolve(query === "Ana" ? [MEMBERS[0]!] : [])
+    )
+    const props = makeProps({
+      everyoneLabel: undefined,
+      searchMembers,
+    })
+    const { result, rerender } = renderHook(
+      (nextProps: Props) => useMentions(nextProps),
+      {
+        initialProps: props,
+      }
+    )
+
+    rerender({ ...props, inputValue: "@", cursorPosition: 1 })
+    await waitFor(() => expect(searchMembers).toHaveBeenCalledWith(""))
+    expect(result.current.isOpen).toBe(true)
+
+    rerender({ ...props, inputValue: "@Ana", cursorPosition: 4 })
+    await waitFor(() => expect(searchMembers).toHaveBeenCalledWith("Ana"))
+    await waitFor(() =>
+      expect(result.current.results[0]).toMatchObject({
+        kind: "user",
+        user: { id: "ana-g" },
+      })
+    )
+  })
+
   it("reports everyone + selected members in getMentions()", async () => {
     let value = ""
     let cursor = 0

--- a/packages/react/src/sds/chat/F0Chat/hooks/__tests__/useTransientError.test.tsx
+++ b/packages/react/src/sds/chat/F0Chat/hooks/__tests__/useTransientError.test.tsx
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { act, zeroRenderHook as renderHook } from "@/testing/test-utils"
+
+import { useTransientError } from "../useTransientError"
+
+describe("useTransientError", () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("clears transient errors after the timeout", () => {
+    vi.useFakeTimers()
+    const { result } = renderHook(() => useTransientError())
+
+    act(() => result.current.show("Upload failed"))
+    expect(result.current.error).toBe("Upload failed")
+
+    act(() => vi.advanceTimersByTime(4_000))
+    expect(result.current.error).toBeNull()
+  })
+
+  it("keeps persistent errors until they are explicitly cleared", () => {
+    vi.useFakeTimers()
+    const { result } = renderHook(() => useTransientError())
+
+    act(() => result.current.show("File too large", { persistent: true }))
+    act(() => vi.advanceTimersByTime(4_000))
+    expect(result.current.error).toBe("File too large")
+
+    act(() => result.current.clear())
+    expect(result.current.error).toBeNull()
+  })
+})

--- a/packages/react/src/sds/chat/F0Chat/hooks/useChatVirtuoso.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/useChatVirtuoso.ts
@@ -6,7 +6,6 @@ import {
   useRef,
   useState,
 } from "react"
-
 import { type ListItem, type VirtuosoHandle } from "react-virtuoso"
 
 import { type ChatRow } from "../utils/grouping"
@@ -85,6 +84,10 @@ type UseChatVirtuosoReturn = {
 export const AT_BOTTOM_THRESHOLD_PX = 80
 /** Scrolled up = more than half a viewport away from the bottom. */
 const SCROLLED_UP_VIEWPORTS = 0.5
+/** A genuine bottom edge, stricter than Virtuoso's 80px at-bottom band. */
+const BOTTOM_EDGE_EPSILON_PX = 1
+/** Let a wheel gesture settle before treating a no-scroll boundary as bottom. */
+const WHEEL_BOUNDARY_SETTLE_MS = 160
 /** Farther than this (in viewports), teleport near the bottom and glide only
  * the last stretch (Telegram) instead of easing across the whole distance. */
 const FAR_TELEPORT_VIEWPORTS = 1.5
@@ -192,6 +195,7 @@ export function useChatVirtuoso({
   const [atBottom, setAtBottom] = useState(entersAtBottom)
   const [atTop, setAtTop] = useState(true)
   const [scrolledUp, setScrolledUp] = useState(false)
+  const [followPaused, setFollowPaused] = useState(false)
   const [revealed, setRevealed] = useState(false)
   const [stickyIndex, setStickyIndex] = useState<number | null>(null)
   const atBottomRef = useRef(entersAtBottom)
@@ -203,6 +207,8 @@ export function useChatVirtuoso({
   const distanceFromBottomRef = useRef(
     entersAtBottom ? 0 : Number.POSITIVE_INFINITY
   )
+  const followPausedRef = useRef(false)
+  const wheelBoundaryTimerRef = useRef<number | null>(null)
   const keyRef = useRef(listKey)
   if (keyRef.current !== listKey) {
     keyRef.current = listKey
@@ -211,17 +217,42 @@ export function useChatVirtuoso({
     distanceFromBottomRef.current = entersAtBottom
       ? 0
       : Number.POSITIVE_INFINITY
+    followPausedRef.current = false
     setAtBottom(entersAtBottom)
     setAtTop(true)
     setScrolledUp(false)
+    setFollowPaused(false)
     setRevealed(false)
     setStickyIndex(null)
   }
 
-  const handleAtBottomChange = useCallback((isAtBottom: boolean) => {
-    atBottomRef.current = isAtBottom
-    setAtBottom(isAtBottom)
+  const pauseFollowing = useCallback(() => {
+    followPausedRef.current = true
+    setFollowPaused(true)
   }, [])
+
+  const resumeFollowing = useCallback(() => {
+    followPausedRef.current = false
+    setFollowPaused(false)
+  }, [])
+
+  const handleAtBottomChange = useCallback(
+    (isAtBottom: boolean) => {
+      atBottomRef.current = isAtBottom
+      setAtBottom(isAtBottom)
+      if (!isAtBottom) return
+
+      const el = scrollerElRef.current
+      if (
+        el &&
+        el.scrollHeight - el.scrollTop - el.clientHeight <=
+          BOTTOM_EDGE_EPSILON_PX
+      ) {
+        resumeFollowing()
+      }
+    },
+    [resumeFollowing]
+  )
 
   const handleAtTopChange = useCallback((isAtTop: boolean) => {
     setAtTop(isAtTop)
@@ -232,7 +263,8 @@ export function useChatVirtuoso({
     (isAtBottom: boolean) => followDecision(isAtBottom, reducedMotion),
     [reducedMotion]
   )
-  const followOutput = atBottom && !hasMoreNewer ? follow : false
+  const followOutput =
+    atBottom && !followPaused && !hasMoreNewer ? follow : false
 
   // ---- pagination edges ----
   const handleStartReached = useCallback(() => {
@@ -254,8 +286,10 @@ export function useChatVirtuoso({
     // pre-scroll distance and yanks an escaping reader back to the bottom.
     const sync = scrollerElRef.current
     if (sync) {
-      distanceFromBottomRef.current =
+      const distanceFromBottom =
         sync.scrollHeight - sync.scrollTop - sync.clientHeight
+      distanceFromBottomRef.current = distanceFromBottom
+      if (distanceFromBottom <= BOTTOM_EDGE_EPSILON_PX) resumeFollowing()
     }
     if (measureRafRef.current != null) return
     measureRafRef.current = requestAnimationFrame(() => {
@@ -283,7 +317,7 @@ export function useChatVirtuoso({
       }
       setStickyIndex(topIndex)
     })
-  }, [])
+  }, [resumeFollowing])
 
   // DIRECT bottom pin. NOT `autoscrollToBottom()`: that method only arms a
   // 100ms trap that fires when Virtuoso's atBottom state flips off with cause
@@ -295,6 +329,7 @@ export function useChatVirtuoso({
   const pinToBottom = useCallback(() => {
     const el = scrollerElRef.current
     if (!el) return
+    if (followPausedRef.current) return
     // Gate on the pre-growth distance (see distanceFromBottomRef), NOT on
     // Virtuoso's atBottom state — a big growth flips that state off before
     // this runs and the pin would wrongly skip.
@@ -328,7 +363,9 @@ export function useChatVirtuoso({
           prevCount: prev.count,
           count,
           // Pre-growth distance, same reasoning as pinToBottom's own gate.
-          atBottom: distanceFromBottomRef.current <= AT_BOTTOM_THRESHOLD_PX,
+          atBottom:
+            !followPausedRef.current &&
+            distanceFromBottomRef.current <= AT_BOTTOM_THRESHOLD_PX,
         })
       ) {
         pinToBottom()
@@ -362,24 +399,42 @@ export function useChatVirtuoso({
   )
 
   // The user taking over beats every re-pin (WhatsApp cancels the follow).
-  // An upward wheel tick / touch drag disables the pins IMMEDIATELY — input
-  // events land before their scroll event, so a growth re-pin arriving in
-  // that gap would read the stale ~0 distance, yank the reader back to the
-  // bottom and eat their wheel deltas: with rows re-measuring continuously
-  // (PDF thumbnails rendering in), scrolling away became impossible. The next
-  // scroll event (or touchend) re-measures the real distance and gluing
-  // resumes only if they're genuinely still at the bottom.
-  const handleWheel = useCallback((event: WheelEvent) => {
-    if (event.deltaY < 0) {
-      distanceFromBottomRef.current = Number.POSITIVE_INFINITY
-    }
-  }, [])
+  // An upward wheel intent pauses following BEFORE the native scroll lands and
+  // keeps it paused while the reader is even slightly away from the true
+  // bottom. This is deliberately separate from Virtuoso's broad 80px
+  // `atBottom` band: async document/image growth must not pull a reader back
+  // during the first few wheel ticks. A short settle only restores following
+  // when the gesture could not move because it was already at the boundary.
+  const handleWheel = useCallback(
+    (event: WheelEvent) => {
+      if (event.deltaY >= 0) return
+      pauseFollowing()
+
+      if (wheelBoundaryTimerRef.current != null) {
+        window.clearTimeout(wheelBoundaryTimerRef.current)
+      }
+      const target = scrollerElRef.current
+      wheelBoundaryTimerRef.current = window.setTimeout(() => {
+        wheelBoundaryTimerRef.current = null
+        if (!target || scrollerElRef.current !== target) return
+        const distanceFromBottom =
+          target.scrollHeight - target.scrollTop - target.clientHeight
+        distanceFromBottomRef.current = distanceFromBottom
+        if (distanceFromBottom <= BOTTOM_EDGE_EPSILON_PX) resumeFollowing()
+      }, WHEEL_BOUNDARY_SETTLE_MS)
+    },
+    [pauseFollowing, resumeFollowing]
+  )
   const handleTouchMove = useCallback(() => {
-    distanceFromBottomRef.current = Number.POSITIVE_INFINITY
-  }, [])
+    pauseFollowing()
+  }, [pauseFollowing])
 
   const handleScrollerRef = useCallback(
     (el: HTMLElement | Window | null) => {
+      if (wheelBoundaryTimerRef.current != null) {
+        window.clearTimeout(wheelBoundaryTimerRef.current)
+        wheelBoundaryTimerRef.current = null
+      }
       const prev = scrollerElRef.current
       if (prev) {
         prev.removeEventListener("scroll", measureScrollState)
@@ -392,6 +447,11 @@ export function useChatVirtuoso({
       const next = scrollerElRef.current
       observeViewportResize(next)
       if (next) {
+        const distanceFromBottom =
+          next.scrollHeight - next.scrollTop - next.clientHeight
+        distanceFromBottomRef.current = distanceFromBottom
+        if (distanceFromBottom <= BOTTOM_EDGE_EPSILON_PX) resumeFollowing()
+
         // QA hook (the Storm story HUD traces scrollTop/scrollHeight per frame).
         next.setAttribute("data-chat-viewport", "")
         next.addEventListener("scroll", measureScrollState, { passive: true })
@@ -412,11 +472,13 @@ export function useChatVirtuoso({
       handleWheel,
       measureScrollState,
       observeViewportResize,
+      resumeFollowing,
     ]
   )
 
   // ---- imperative scrolls ----
   const scrollToBottom = useCallback(() => {
+    resumeFollowing()
     const el = scrollerElRef.current
     if (
       el &&
@@ -431,7 +493,7 @@ export function useChatVirtuoso({
       align: "end",
       behavior: reducedMotion ? "auto" : "smooth",
     })
-  }, [reducedMotion])
+  }, [reducedMotion, resumeFollowing])
 
   const indexByIdRef = useRef(indexById)
   indexByIdRef.current = indexById
@@ -468,7 +530,7 @@ export function useChatVirtuoso({
   useLayoutEffect(() => {
     if (!ownGlideRef.current) return
     ownGlideRef.current = false
-    if (atBottomRef.current) return
+    if (atBottomRef.current && !followPausedRef.current) return
     scrollToBottom()
   })
 
@@ -512,6 +574,8 @@ export function useChatVirtuoso({
         cancelAnimationFrame(measureRafRef.current)
       if (revealRafRef.current != null)
         cancelAnimationFrame(revealRafRef.current)
+      if (wheelBoundaryTimerRef.current != null)
+        window.clearTimeout(wheelBoundaryTimerRef.current)
       viewportResizeObserverRef.current?.disconnect()
     },
     []

--- a/packages/react/src/sds/chat/F0Chat/hooks/useEmojiAutocomplete.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/useEmojiAutocomplete.ts
@@ -1,0 +1,357 @@
+import data from "@emoji-mart/data/sets/15/twitter.json"
+import { useCallback, useEffect, useId, useMemo, useState } from "react"
+
+import {
+  getTextareaCaretCoordinates,
+  type PopoverPosition,
+} from "./useMentions"
+
+const MAX_RESULTS = 8
+const DEFAULT_EMOJI_IDS = [
+  "+1",
+  "heart",
+  "joy",
+  "tada",
+  "smile",
+  "fire",
+  "eyes",
+  "white_check_mark",
+] as const
+
+type EmojiMartEmoji = {
+  id: string
+  name: string
+  keywords?: string[]
+  emoticons?: string[]
+  skins: { native: string }[]
+}
+
+export type EmojiAutocompleteCandidate = {
+  id: string
+  name: string
+  native: string
+}
+
+type IndexedEmoji = EmojiAutocompleteCandidate & {
+  aliases: string[]
+  keywords: string[]
+  normalizedName: string
+  normalizedShortcodes: string[]
+  normalizedKeywords: string[]
+  order: number
+}
+
+type EmojiTrigger = {
+  colonIndex: number
+  query: string
+}
+
+export type UseEmojiAutocompleteOptions = {
+  inputValue: string
+  setInputValue: (value: string) => void
+  cursorPosition: number
+  setCursorPosition: (position: number) => void
+  textareaRef: React.RefObject<HTMLTextAreaElement | null>
+}
+
+export type UseEmojiAutocompleteReturn = {
+  isOpen: boolean
+  query: string
+  results: EmojiAutocompleteCandidate[]
+  selectedIndex: number
+  popoverPosition: PopoverPosition
+  listboxId: string
+  activeDescendantId: string | undefined
+  handleKeyDown: (event: React.KeyboardEvent<HTMLElement>) => boolean
+  selectCandidate: (candidate: EmojiAutocompleteCandidate) => void
+  setSelectedIndex: (index: number) => void
+  close: () => void
+}
+
+const normalize = (value: string): string =>
+  value.toLowerCase().replace(/[_-]+/g, " ").trim()
+
+const aliasesByEmoji = new Map<string, string[]>()
+for (const [alias, emojiId] of Object.entries(
+  data.aliases as Record<string, string>
+)) {
+  const aliases = aliasesByEmoji.get(emojiId) ?? []
+  aliases.push(alias)
+  aliasesByEmoji.set(emojiId, aliases)
+}
+
+const EMOJI_INDEX: IndexedEmoji[] = (
+  Object.values(data.emojis) as EmojiMartEmoji[]
+).flatMap((emoji, order) => {
+  const native = emoji.skins[0]?.native
+  if (!native) return []
+  const aliases = aliasesByEmoji.get(emoji.id) ?? []
+  const keywords = emoji.keywords ?? []
+  return [
+    {
+      id: emoji.id,
+      name: emoji.name,
+      native,
+      aliases,
+      keywords,
+      normalizedName: normalize(emoji.name),
+      normalizedShortcodes: [emoji.id, ...aliases].map(normalize),
+      normalizedKeywords: keywords.map(normalize),
+      order,
+    },
+  ]
+})
+
+const EMOJI_BY_ID = new Map(EMOJI_INDEX.map((emoji) => [emoji.id, emoji]))
+const EMOJI_BY_SHORTCODE = new Map<string, IndexedEmoji>()
+for (const emoji of EMOJI_INDEX) {
+  EMOJI_BY_SHORTCODE.set(emoji.id.toLowerCase(), emoji)
+  for (const alias of emoji.aliases) {
+    EMOJI_BY_SHORTCODE.set(alias.toLowerCase(), emoji)
+  }
+}
+
+const defaultResults = DEFAULT_EMOJI_IDS.flatMap((id) => {
+  const emoji = EMOJI_BY_ID.get(id)
+  return emoji ? [emoji] : []
+})
+
+const scoreCandidate = (emoji: IndexedEmoji, query: string): number | null => {
+  if (emoji.normalizedShortcodes.some((term) => term === query)) return 0
+  if (emoji.normalizedShortcodes.some((term) => term.startsWith(query)))
+    return 10
+  if (emoji.normalizedKeywords.some((term) => term === query)) return 20
+  if (emoji.normalizedKeywords.some((term) => term.startsWith(query))) return 30
+  if (emoji.normalizedName.startsWith(query)) return 40
+  if (
+    emoji.normalizedShortcodes.some((term) => term.includes(query)) ||
+    emoji.normalizedKeywords.some((term) => term.includes(query)) ||
+    emoji.normalizedName.includes(query)
+  ) {
+    return 50
+  }
+  return null
+}
+
+export const searchEmojiCandidates = (
+  rawQuery: string
+): EmojiAutocompleteCandidate[] => {
+  const query = normalize(rawQuery)
+  if (!query) return defaultResults.slice(0, MAX_RESULTS)
+
+  return EMOJI_INDEX.flatMap((emoji) => {
+    const score = scoreCandidate(emoji, query)
+    return score === null ? [] : [{ emoji, score }]
+  })
+    .sort(
+      (a, b) =>
+        a.score - b.score ||
+        a.emoji.id.length - b.emoji.id.length ||
+        a.emoji.order - b.emoji.order
+    )
+    .slice(0, MAX_RESULTS)
+    .map(({ emoji }) => emoji)
+}
+
+export const findEmojiTrigger = (
+  text: string,
+  cursorPosition: number
+): EmojiTrigger | null => {
+  const textBeforeCursor = text.slice(0, cursorPosition)
+  const colonIndex = textBeforeCursor.lastIndexOf(":")
+  if (colonIndex === -1) return null
+
+  if (colonIndex > 0 && !/\s/.test(text[colonIndex - 1] ?? "")) return null
+
+  const query = textBeforeCursor.slice(colonIndex + 1)
+  if (!/^[a-zA-Z0-9_+-]*$/.test(query)) return null
+
+  return { colonIndex, query }
+}
+
+export const replaceClosedEmojiShortcode = (
+  text: string,
+  cursorPosition: number
+): { value: string; cursorPosition: number } | null => {
+  const textBeforeCursor = text.slice(0, cursorPosition)
+  const match = textBeforeCursor.match(/(^|\s):([a-zA-Z0-9_+-]+):$/)
+  if (!match) return null
+
+  const emoji = EMOJI_BY_SHORTCODE.get(match[2]?.toLowerCase() ?? "")
+  if (!emoji) return null
+
+  const boundaryLength = match[1]?.length ?? 0
+  const shortcodeStart = cursorPosition - match[0].length + boundaryLength
+  const value =
+    text.slice(0, shortcodeStart) + emoji.native + text.slice(cursorPosition)
+
+  return {
+    value,
+    cursorPosition: shortcodeStart + emoji.native.length,
+  }
+}
+
+export const getEmojiAutocompleteOptionId = (
+  listboxId: string,
+  id: string
+): string => {
+  const encodedId = Array.from(id, (character) =>
+    character.codePointAt(0)!.toString(16)
+  ).join("-")
+  return `${listboxId}-option-${encodedId}`
+}
+
+export function useEmojiAutocomplete({
+  inputValue,
+  setInputValue,
+  cursorPosition,
+  setCursorPosition,
+  textareaRef,
+}: UseEmojiAutocompleteOptions): UseEmojiAutocompleteReturn {
+  const reactId = useId()
+  const listboxId = `chat-emoji-autocomplete-${reactId.replace(/:/g, "")}`
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const [dismissedTrigger, setDismissedTrigger] = useState<number | null>(null)
+
+  const trigger = useMemo(
+    () => findEmojiTrigger(inputValue, cursorPosition),
+    [inputValue, cursorPosition]
+  )
+  const results = useMemo(
+    () => (trigger ? searchEmojiCandidates(trigger.query) : []),
+    [trigger]
+  )
+  const isOpen =
+    trigger !== null &&
+    trigger.colonIndex !== dismissedTrigger &&
+    results.length > 0
+  const effectiveSelectedIndex = results[selectedIndex] ? selectedIndex : 0
+
+  useEffect(() => {
+    setSelectedIndex(0)
+    if (!trigger) setDismissedTrigger(null)
+  }, [trigger?.colonIndex, trigger?.query])
+
+  const close = useCallback(() => {
+    setDismissedTrigger(trigger?.colonIndex ?? null)
+    setSelectedIndex(0)
+  }, [trigger?.colonIndex])
+
+  const selectCandidate = useCallback(
+    (candidate: EmojiAutocompleteCandidate) => {
+      if (!trigger) return
+
+      const before = inputValue.slice(0, trigger.colonIndex)
+      const after = inputValue.slice(cursorPosition)
+      const hasExistingSeparator = /^\s/.test(after)
+      const nextValue =
+        before + candidate.native + (hasExistingSeparator ? "" : " ") + after
+      const nextCursorPosition = before.length + candidate.native.length + 1
+
+      setInputValue(nextValue)
+      setCursorPosition(nextCursorPosition)
+      close()
+
+      requestAnimationFrame(() => {
+        const textarea = textareaRef.current
+        if (!textarea) return
+        textarea.focus()
+        textarea.setSelectionRange(nextCursorPosition, nextCursorPosition)
+      })
+    },
+    [
+      trigger,
+      inputValue,
+      cursorPosition,
+      setInputValue,
+      setCursorPosition,
+      close,
+      textareaRef,
+    ]
+  )
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLElement>): boolean => {
+      if (!isOpen) return false
+      if (event.nativeEvent?.isComposing) return false
+
+      if (event.key === "Escape") {
+        event.preventDefault()
+        close()
+        requestAnimationFrame(() => textareaRef.current?.focus())
+        return true
+      }
+
+      if (results.length === 0) return false
+
+      switch (event.key) {
+        case "ArrowDown":
+          event.preventDefault()
+          setSelectedIndex((index) => (index + 1) % results.length)
+          return true
+        case "ArrowUp":
+          event.preventDefault()
+          setSelectedIndex(
+            (index) => (index + results.length - 1) % results.length
+          )
+          return true
+        case "Enter":
+        case "Tab": {
+          if (event.key === "Tab" && event.shiftKey) return false
+          const candidate = results[effectiveSelectedIndex] ?? results[0]
+          if (!candidate) return false
+          event.preventDefault()
+          selectCandidate(candidate)
+          return true
+        }
+        default:
+          return false
+      }
+    },
+    [
+      isOpen,
+      results,
+      effectiveSelectedIndex,
+      selectCandidate,
+      close,
+      textareaRef,
+    ]
+  )
+
+  const popoverPosition: PopoverPosition = useMemo(() => {
+    if (!isOpen || !trigger) return null
+    const textarea = textareaRef.current
+    if (!textarea) return null
+
+    const coordinates = getTextareaCaretCoordinates(
+      textarea,
+      trigger.colonIndex
+    )
+    const left = textarea.offsetLeft + coordinates.left
+    const formHeight = textarea.offsetParent
+      ? (textarea.offsetParent as HTMLElement).offsetHeight
+      : 0
+    const bottom = formHeight - (textarea.offsetTop + coordinates.top)
+
+    return { left, bottom }
+  }, [isOpen, trigger, inputValue, cursorPosition, textareaRef])
+
+  const selectedCandidate = results[effectiveSelectedIndex] ?? results[0]
+
+  return {
+    isOpen,
+    query: trigger?.query ?? "",
+    results,
+    selectedIndex: effectiveSelectedIndex,
+    popoverPosition,
+    listboxId,
+    activeDescendantId:
+      isOpen && selectedCandidate
+        ? getEmojiAutocompleteOptionId(listboxId, selectedCandidate.id)
+        : undefined,
+    handleKeyDown,
+    selectCandidate,
+    setSelectedIndex,
+    close,
+  }
+}

--- a/packages/react/src/sds/chat/F0Chat/hooks/useMentions.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/useMentions.ts
@@ -79,6 +79,8 @@ export type UseMentionsReturn = {
   seedMentions: (entries: MentionEntry[]) => void
   /** Close the popover. */
   close: () => void
+  /** Dismiss the current `@` trigger until the caret leaves it. */
+  dismissCurrentTrigger: () => void
 }
 
 /**
@@ -162,7 +164,7 @@ const MIRROR_PROPERTIES = [
 ] as const
 
 /** Pixel position of the character at `index`, relative to the textarea. */
-function getCaretCoordinates(
+export function getTextareaCaretCoordinates(
   textarea: HTMLTextAreaElement,
   index: number
 ): { left: number; top: number } {
@@ -296,7 +298,10 @@ export function useMentions({
           }
         })
         .catch(() => {
-          if (currentSearchId === searchIdRef.current) setMemberResults([])
+          if (currentSearchId === searchIdRef.current) {
+            setMemberResults([])
+            setIsOpen(false)
+          }
         })
         .finally(() => {
           if (currentSearchId === searchIdRef.current) setIsLoading(false)
@@ -322,6 +327,11 @@ export function useMentions({
     setSelectedIndex(0)
     atIndexRef.current = -1
   }, [])
+
+  const dismissCurrentTrigger = useCallback(() => {
+    dismissedAtIndexRef.current = atIndexRef.current
+    close()
+  }, [close])
 
   const selectCandidate = useCallback(
     (candidate: MentionCandidate) => {
@@ -447,7 +457,7 @@ export function useMentions({
     const textarea = textareaRef.current
     if (!textarea) return null
 
-    const coords = getCaretCoordinates(textarea, atIndexRef.current)
+    const coords = getTextareaCaretCoordinates(textarea, atIndexRef.current)
     const left = textarea.offsetLeft + coords.left
     const formHeight = textarea.offsetParent
       ? (textarea.offsetParent as HTMLElement).offsetHeight
@@ -483,5 +493,6 @@ export function useMentions({
     getMentions,
     seedMentions,
     close,
+    dismissCurrentTrigger,
   }
 }

--- a/packages/react/src/sds/chat/F0Chat/hooks/useTransientError.ts
+++ b/packages/react/src/sds/chat/F0Chat/hooks/useTransientError.ts
@@ -4,21 +4,32 @@ import { useCallback, useEffect, useRef, useState } from "react"
 const TRANSIENT_ERROR_MS = 4000
 
 /**
- * A short-lived error message: `show(msg)` flashes it, and it auto-clears after
- * `timeoutMs`. Used by the composer for "too many files" / upload / voice
- * failures (same pattern as the AI chat).
+ * Composer error state. `show(msg)` clears after `timeoutMs` by default;
+ * validation errors can opt into persistence until the next corrective action
+ * calls `clear()`.
  */
 export function useTransientError(timeoutMs: number = TRANSIENT_ERROR_MS): {
   error: string | null
-  show: (message: string) => void
+  show: (message: string, options?: { persistent?: boolean }) => void
+  clear: () => void
 } {
   const [error, setError] = useState<string | null>(null)
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
+  const clear = useCallback(() => {
+    if (timeoutRef.current) clearTimeout(timeoutRef.current)
+    timeoutRef.current = null
+    setError(null)
+  }, [])
+
   const show = useCallback(
-    (message: string) => {
+    (message: string, options?: { persistent?: boolean }) => {
       if (timeoutRef.current) clearTimeout(timeoutRef.current)
       setError(message)
+      if (options?.persistent) {
+        timeoutRef.current = null
+        return
+      }
       timeoutRef.current = setTimeout(() => {
         setError(null)
         timeoutRef.current = null
@@ -34,5 +45,5 @@ export function useTransientError(timeoutMs: number = TRANSIENT_ERROR_MS): {
     []
   )
 
-  return { error, show }
+  return { error, show, clear }
 }

--- a/packages/react/src/sds/chat/F0Chat/mocks/MockChatApp.tsx
+++ b/packages/react/src/sds/chat/F0Chat/mocks/MockChatApp.tsx
@@ -30,6 +30,7 @@ import {
   useMockChatApp,
   useMockChatStore,
 } from "./useMockChatApp"
+import { MOCK_MAX_FILE_SIZE_BYTES } from "./constants"
 
 export const MockChatAppProvider = ({
   children,
@@ -233,6 +234,8 @@ export const useConversationRuntime = (convId: string): F0ChatRuntime => {
     uploadFiles,
     // Demoes the "too many files" transient error (mirrors the AI chat).
     maxFiles: 5,
+    // ApplicationFrame demonstrates a 100 MB per-file upload limit.
+    maxFileSizeBytes: MOCK_MAX_FILE_SIZE_BYTES,
     transcribe: mockTranscribe,
     markRead,
     searchMessages,

--- a/packages/react/src/sds/chat/F0Chat/mocks/MockChatApp.tsx
+++ b/packages/react/src/sds/chat/F0Chat/mocks/MockChatApp.tsx
@@ -10,6 +10,7 @@ import {
   isUserMessage,
   type F0ChatAttachment,
   type F0ChatEditInput,
+  type F0ChatItem,
   type F0ChatRuntime,
   type F0ChatSearchResult,
   type F0ChatSendInput,
@@ -43,6 +44,24 @@ export const MockChatAppProvider = ({
   )
 }
 
+export const resolveMockReactionUsers = (
+  seed: Seed | undefined,
+  messages: F0ChatItem[],
+  messageId: string,
+  emoji: string
+): F0ChatUser[] => {
+  const message = messages.find(
+    (item) => isUserMessage(item) && item.id === messageId
+  )
+  if (!seed || !message || !isUserMessage(message)) return []
+
+  const reaction = message.reactions?.find((item) => item.emoji === emoji)
+  if (!reaction) return []
+  if (reaction.users?.length === reaction.count) return reaction.users
+
+  return seed.participants.slice(0, reaction.count)
+}
+
 /** F0ChatRuntime for one conversation, backed by the shared store. */
 export const useConversationRuntime = (convId: string): F0ChatRuntime => {
   const app = useMockChatApp()
@@ -69,6 +88,16 @@ export const useConversationRuntime = (convId: string): F0ChatRuntime => {
     (messageId: string, emoji: string) =>
       app.toggleReaction(convId, messageId, emoji),
     [app, convId]
+  )
+  const loadReactionUsers = useCallback(
+    async (messageId: string, emoji: string): Promise<F0ChatUser[]> =>
+      resolveMockReactionUsers(
+        seed,
+        app.states[convId]?.messages ?? [],
+        messageId,
+        emoji
+      ),
+    [app.states, convId, seed]
   )
   const deleteMessage = useCallback(
     (messageId: string) => app.deleteMessage(convId, messageId),
@@ -191,6 +220,7 @@ export const useConversationRuntime = (convId: string): F0ChatRuntime => {
     retryMessage,
     loadOlder,
     toggleReaction,
+    loadReactionUsers,
     deleteMessage,
     deleteFailedMessage,
     editMessage,

--- a/packages/react/src/sds/chat/F0Chat/mocks/MockChatApp.tsx
+++ b/packages/react/src/sds/chat/F0Chat/mocks/MockChatApp.tsx
@@ -2,8 +2,8 @@
 
 import { useCallback, useMemo, type ReactNode } from "react"
 
-import { mockTranscribe } from "@/lib/storybook-utils/ai-mocks"
 import { MicrophoneNegative, PalmTree } from "@/icons/app"
+import { mockTranscribe } from "@/lib/storybook-utils/ai-mocks"
 import { type SidebarChatGroup } from "@/patterns/Navigation/Sidebar/Chats/types"
 
 import {
@@ -16,6 +16,7 @@ import {
   type F0ChatSendInput,
   type F0ChatUser,
 } from "../types"
+import { MOCK_MAX_FILE_SIZE_BYTES } from "./constants"
 import {
   type Seed,
   ME,
@@ -30,7 +31,6 @@ import {
   useMockChatApp,
   useMockChatStore,
 } from "./useMockChatApp"
-import { MOCK_MAX_FILE_SIZE_BYTES } from "./constants"
 
 export const MockChatAppProvider = ({
   children,
@@ -127,6 +127,9 @@ export const useConversationRuntime = (convId: string): F0ChatRuntime => {
                       name: file.name,
                       size: file.size,
                       mimeType: file.type,
+                      thumbnailUrl: file.type.startsWith("video/")
+                        ? "/video-poster.webp"
+                        : undefined,
                     }
               })
             ),
@@ -233,7 +236,7 @@ export const useConversationRuntime = (convId: string): F0ChatRuntime => {
     stopTyping: () => {},
     uploadFiles,
     // Demoes the "too many files" transient error (mirrors the AI chat).
-    maxFiles: 5,
+    maxFiles: 8,
     // ApplicationFrame demonstrates a 100 MB per-file upload limit.
     maxFileSizeBytes: MOCK_MAX_FILE_SIZE_BYTES,
     transcribe: mockTranscribe,

--- a/packages/react/src/sds/chat/F0Chat/mocks/constants.ts
+++ b/packages/react/src/sds/chat/F0Chat/mocks/constants.ts
@@ -1,0 +1,1 @@
+export const MOCK_MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024

--- a/packages/react/src/sds/chat/F0Chat/mocks/constants.ts
+++ b/packages/react/src/sds/chat/F0Chat/mocks/constants.ts
@@ -1,1 +1,23 @@
 export const MOCK_MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024
+
+/** Captions keep the public video fixture accessible in chat examples. */
+export const MOCK_VIDEO_CAPTIONS = [
+  "WEBVTT",
+  "",
+  "00:00:00.000 --> 00:00:05.000",
+  "[Music]",
+  "",
+  "00:00:05.000 --> 00:00:10.000",
+  "Big Buck Bunny looks across the meadow.",
+].join("\n")
+
+/** Visual descriptions for the public video fixture's accessible demo. */
+export const MOCK_VIDEO_DESCRIPTIONS = [
+  "WEBVTT",
+  "",
+  "00:00:00.000 --> 00:00:05.000",
+  "A large white rabbit steps into a sunny green meadow.",
+  "",
+  "00:00:05.000 --> 00:00:10.000",
+  "The rabbit looks around and smiles beneath a tree.",
+].join("\n")

--- a/packages/react/src/sds/chat/F0Chat/mocks/createMockChatRuntime.ts
+++ b/packages/react/src/sds/chat/F0Chat/mocks/createMockChatRuntime.ts
@@ -14,6 +14,7 @@ import {
   type F0ChatSystemEvent,
   type F0ChatUser,
 } from "../types"
+import { MOCK_MAX_FILE_SIZE_BYTES } from "./constants"
 
 /** Seed describing a fake conversation the mock runtime should simulate. */
 export type MockChatSeed = {
@@ -604,6 +605,8 @@ export function useMockChatRuntime(seed: MockChatSeed): F0ChatRuntime & {
     uploadFiles,
     // Demoes the "too many files" transient error (mirrors the AI chat).
     maxFiles: 5,
+    // F0Chat stories use the same 100 MB per-file limit as ApplicationFrame.
+    maxFileSizeBytes: MOCK_MAX_FILE_SIZE_BYTES,
     // Same streaming dictation mock the AI chat / RichText stories use.
     transcribe: mockTranscribe,
     markRead,

--- a/packages/react/src/sds/chat/F0Chat/mocks/createMockChatRuntime.ts
+++ b/packages/react/src/sds/chat/F0Chat/mocks/createMockChatRuntime.ts
@@ -509,6 +509,9 @@ export function useMockChatRuntime(seed: MockChatSeed): F0ChatRuntime & {
                 name: file.name,
                 size: file.size,
                 mimeType: file.type,
+                thumbnailUrl: file.type.startsWith("video/")
+                  ? "/video-poster.webp"
+                  : undefined,
               }
         })
       ),
@@ -604,7 +607,7 @@ export function useMockChatRuntime(seed: MockChatSeed): F0ChatRuntime & {
     stopTyping: () => {},
     uploadFiles,
     // Demoes the "too many files" transient error (mirrors the AI chat).
-    maxFiles: 5,
+    maxFiles: 8,
     // F0Chat stories use the same 100 MB per-file limit as ApplicationFrame.
     maxFileSizeBytes: MOCK_MAX_FILE_SIZE_BYTES,
     // Same streaming dictation mock the AI chat / RichText stories use.

--- a/packages/react/src/sds/chat/F0Chat/mocks/mockSeeds.ts
+++ b/packages/react/src/sds/chat/F0Chat/mocks/mockSeeds.ts
@@ -101,6 +101,19 @@ const ISLA = person("u_isla", "Isla", "Romano", "Content Strategist", {
 // No photo — initials + colour avatar.
 const VIKTOR = person("u_viktor", "Viktor", "Hale", "Staff Engineer")
 
+/** Extra members for the large read-receipt demo. Together with the named
+ * participants, they make every Quarterly Reporting message expose 45 readers
+ * so the message-info list has a realistic overflow state. */
+const RECEIPT_DEMO_READERS = Array.from({ length: 42 }, (_, index) => {
+  const number = String(index + 1).padStart(2, "0")
+  return person(
+    `u_receipt_demo_${number}`,
+    "Demo",
+    `Reader ${number}`,
+    "Quarterly Reporting member"
+  )
+})
+
 // ---------------------------------------------------------------------------
 // Seeds — every conversation is deliberately different (empty, short, long,
 // DMs and multi-person groups with topical messages).
@@ -587,7 +600,7 @@ export const SEEDS: Seed[] = [
     type: "group",
     title: "Quarterly Reporting",
     avatar: groupAvatar("Quarterly Reporting", "📊"),
-    participants: [GRACE, MARCUS, SAM],
+    participants: [GRACE, MARCUS, SAM, ...RECEIPT_DEMO_READERS],
     lines: [
       {
         from: GRACE,
@@ -659,7 +672,6 @@ export const SEEDS: Seed[] = [
         from: ME,
         body: "And the kickoff deck — no client-side preview for ppt, stays a chip",
         min: 10 * MIN,
-        readBy: [GRACE, MARCUS, SAM],
         reactions: [
           {
             emoji: "🎉",
@@ -974,6 +986,23 @@ export type ConvState = {
 let seq = 0
 export const nextId = (): string => `m-${seq++}`
 
+/** Reader identities for a group message in the ApplicationFrame mock. */
+export const groupReadersFor = (
+  seed: Seed | undefined,
+  authorId: string
+): F0ChatUser[] | undefined => {
+  if (seed?.type !== "group") return undefined
+
+  const uniqueParticipants = new Map(
+    [...seed.participants, ME].map((participant) => [
+      participant.id,
+      participant,
+    ])
+  )
+  uniqueParticipants.delete(authorId)
+  return [...uniqueParticipants.values()]
+}
+
 const buildSeedMessages = (seed: Seed): F0ChatItem[] => {
   const built = seed.lines.map((line): F0ChatItem => {
     const sentMs = Date.now() - line.min * 60_000
@@ -986,12 +1015,6 @@ const buildSeedMessages = (seed: Seed): F0ChatItem[] => {
       }
     }
     const isMine = line.from.id === ME.id
-    const groupReaders =
-      seed.type === "group"
-        ? [...seed.participants, ME].filter(
-            (participant) => participant.id !== line.from.id
-          )
-        : undefined
     return {
       id: nextId(),
       author: line.from,
@@ -1005,7 +1028,7 @@ const buildSeedMessages = (seed: Seed): F0ChatItem[] => {
       mentionedEveryone: line.mentionedEveryone,
       linkPreviews: line.linkPreviews,
       attachments: line.attachments,
-      readBy: line.readBy ?? groupReaders,
+      readBy: line.readBy ?? groupReadersFor(seed, line.from.id),
       reactions: line.reactions,
     }
   })

--- a/packages/react/src/sds/chat/F0Chat/mocks/mockSeeds.ts
+++ b/packages/react/src/sds/chat/F0Chat/mocks/mockSeeds.ts
@@ -7,6 +7,7 @@ import {
   type F0ChatItem,
   type F0ChatLinkPreview,
   type F0ChatMention,
+  type F0ChatReaction,
   type F0ChatSystemEvent,
   type F0ChatUser,
 } from "../types"
@@ -119,6 +120,10 @@ type MessageLine = {
   linkPreviews?: F0ChatLinkPreview[]
   /** Attachments (images, files, shared locations) for the media demos. */
   attachments?: F0ChatAttachment[]
+  /** Group members who read this message. */
+  readBy?: F0ChatUser[]
+  /** Reactions shown under the message. */
+  reactions?: F0ChatReaction[]
 }
 
 /** A membership event in the transcript — becomes a centered system row. */
@@ -654,6 +659,15 @@ export const SEEDS: Seed[] = [
         from: ME,
         body: "And the kickoff deck — no client-side preview for ppt, stays a chip",
         min: 10 * MIN,
+        readBy: [GRACE, MARCUS, SAM],
+        reactions: [
+          {
+            emoji: "🎉",
+            count: 3,
+            reactedByMe: false,
+            users: [GRACE, MARCUS, SAM],
+          },
+        ],
         attachments: [
           {
             kind: "file",
@@ -972,6 +986,12 @@ const buildSeedMessages = (seed: Seed): F0ChatItem[] => {
       }
     }
     const isMine = line.from.id === ME.id
+    const groupReaders =
+      seed.type === "group"
+        ? [...seed.participants, ME].filter(
+            (participant) => participant.id !== line.from.id
+          )
+        : undefined
     return {
       id: nextId(),
       author: line.from,
@@ -985,6 +1005,8 @@ const buildSeedMessages = (seed: Seed): F0ChatItem[] => {
       mentionedEveryone: line.mentionedEveryone,
       linkPreviews: line.linkPreviews,
       attachments: line.attachments,
+      readBy: line.readBy ?? groupReaders,
+      reactions: line.reactions,
     }
   })
   // Second pass: resolve reply references now that every message has an id.

--- a/packages/react/src/sds/chat/F0Chat/mocks/mockSeeds.ts
+++ b/packages/react/src/sds/chat/F0Chat/mocks/mockSeeds.ts
@@ -598,7 +598,7 @@ export const SEEDS: Seed[] = [
     id: "grp-reporting",
     type: "group",
     title: "Quarterly Reporting",
-    avatar: groupAvatar("Quarterly Reporting", "📊"),
+    avatar: groupAvatar("Quarterly Reporting"),
     participants: [GRACE, MARCUS, SAM, ...RECEIPT_DEMO_READERS],
     lines: [
       {
@@ -893,7 +893,7 @@ export const SEEDS: Seed[] = [
     id: "grp-release",
     type: "group",
     title: "Release War Room",
-    avatar: groupAvatar("Release War Room", "🔥"),
+    avatar: groupAvatar("Release War Room"),
     participants: [MARCUS, GRACE],
     multiTyping: true,
     lines: [

--- a/packages/react/src/sds/chat/F0Chat/mocks/mockSeeds.ts
+++ b/packages/react/src/sds/chat/F0Chat/mocks/mockSeeds.ts
@@ -11,6 +11,7 @@ import {
   type F0ChatSystemEvent,
   type F0ChatUser,
 } from "../types"
+import { MOCK_VIDEO_CAPTIONS, MOCK_VIDEO_DESCRIPTIONS } from "./constants"
 
 // ---------------------------------------------------------------------------
 // People
@@ -592,9 +593,8 @@ export const SEEDS: Seed[] = [
     ],
   },
   // GROUP — document attachments of every previewable kind (pdf, xlsx, csv,
-  // docx, md, txt) plus a non-previewable deck that stays a plain chip. The
-  // sample files live in `public/`, same as the F0Chat "Document attachments"
-  // story.
+  // docx, md, txt), two inline videos in one message, and a non-previewable deck
+  // that stays a plain chip. The sample files live in `public/`.
   {
     id: "grp-reporting",
     type: "group",
@@ -670,7 +670,7 @@ export const SEEDS: Seed[] = [
       },
       {
         from: ME,
-        body: "And the kickoff deck — no client-side preview for ppt, stays a chip",
+        body: "And the kickoff deck — plus two walkthrough videos",
         min: 10 * MIN,
         reactions: [
           {
@@ -681,6 +681,28 @@ export const SEEDS: Seed[] = [
           },
         ],
         attachments: [
+          {
+            kind: "file",
+            url: "/Big_Buck_Bunny_alt.webm",
+            name: "quarterly-walkthrough.webm",
+            mimeType: "video/webm",
+            thumbnailUrl: "/video-poster.webp",
+            videoContent: {
+              captions: MOCK_VIDEO_CAPTIONS,
+              descriptions: MOCK_VIDEO_DESCRIPTIONS,
+            },
+          },
+          {
+            kind: "file",
+            url: "/Big_Buck_Bunny_alt.webm",
+            name: "chart-deep-dive.webm",
+            mimeType: "video/webm",
+            thumbnailUrl: "/video-poster.webp",
+            videoContent: {
+              captions: MOCK_VIDEO_CAPTIONS,
+              descriptions: MOCK_VIDEO_DESCRIPTIONS,
+            },
+          },
           {
             kind: "file",
             url: "#",

--- a/packages/react/src/sds/chat/F0Chat/mocks/mockSeeds.ts
+++ b/packages/react/src/sds/chat/F0Chat/mocks/mockSeeds.ts
@@ -182,9 +182,8 @@ export type Seed = {
   myRole?: "admin" | "member" | "guest"
 }
 
-/** Group avatar: the emoji when one is given, otherwise the company avatar
- * built from the group's name (its initials). A company avatar is never passed
- * by hand — it's always this name-derived fallback. */
+/** Group avatar data: an explicit emoji when one is given; otherwise a
+ * name-derived company avatar that chat surfaces replace with the ＃ fallback. */
 const groupAvatar = (name: string, emoji?: string): AvatarVariant =>
   emoji ? { type: "emoji", emoji } : { type: "company", name }
 

--- a/packages/react/src/sds/chat/F0Chat/mocks/useMockChatApp.ts
+++ b/packages/react/src/sds/chat/F0Chat/mocks/useMockChatApp.ts
@@ -23,6 +23,7 @@ import {
   REPLIES,
   SEED_BY_ID,
   SEEDS,
+  groupReadersFor,
   initialConvState,
   nextId,
   pickRandomTypers,
@@ -242,7 +243,11 @@ export const useMockChatStore = (): MockChatAppValue => {
                 isUserMessage(m) &&
                 m.isMine &&
                 (m.status === "sent" || m.status === "delivered")
-                  ? { ...m, status: "read" }
+                  ? {
+                      ...m,
+                      status: "read",
+                      readBy: groupReadersFor(replySeed, m.author.id),
+                    }
                   : m
             ),
             ...typers.map(
@@ -252,6 +257,7 @@ export const useMockChatStore = (): MockChatAppValue => {
                 body: REPLIES[(s.messages.length + i) % REPLIES.length],
                 createdAt: new Date(Date.now() + i).toISOString(),
                 isMine: false,
+                readBy: groupReadersFor(replySeed, responder.id),
               })
             ),
           ],
@@ -386,6 +392,7 @@ export const useMockChatStore = (): MockChatAppValue => {
             ? new Date(oldest.createdAt).getTime()
             : Date.now()
           const responder = SEED_BY_ID.get(convId)?.participants[0] ?? ME
+          const seed = SEED_BY_ID.get(convId)
           const page: F0ChatMessage[] = Array.from({ length: 12 }, (_, i) => {
             const author = i % 2 === 0 ? responder : ME
             const isMine = author.id === ME.id
@@ -396,6 +403,7 @@ export const useMockChatStore = (): MockChatAppValue => {
               createdAt: new Date(base - (12 - i) * 5 * 60_000).toISOString(),
               isMine,
               status: isMine ? "read" : undefined,
+              readBy: groupReadersFor(seed, author.id),
             }
           })
           return { ...s, messages: [...page, ...s.messages] }

--- a/packages/react/src/sds/chat/F0Chat/providers/F0ChatProvider.tsx
+++ b/packages/react/src/sds/chat/F0Chat/providers/F0ChatProvider.tsx
@@ -12,6 +12,7 @@ import {
   type F0ChatCapabilities,
   type F0ChatEditInput,
   type F0ChatRuntime,
+  type F0ChatUser,
 } from "../types"
 
 const F0ChatContext = createContext<F0ChatRuntime | null>(null)
@@ -31,6 +32,11 @@ export type F0ChatStable = {
   capabilities?: F0ChatCapabilities
   editWindowMs?: number
   toggleReaction: (messageId: string, emoji: string) => void
+  loadReactionUsers?: (
+    messageId: string,
+    emoji: string,
+    count: number
+  ) => Promise<F0ChatUser[]>
   retryMessage: (id: string) => void
   deleteMessage: (id: string) => void
   deleteFailedMessage?: (id: string) => void
@@ -72,6 +78,13 @@ export const F0ChatProvider = ({
 }): ReactNode => {
   const runtimeRef = useRef(runtime)
   runtimeRef.current = runtime
+  const reactionUsersCacheRef = useRef(new Map<string, Promise<F0ChatUser[]>>())
+  const reactionUsersCacheChannelRef = useRef(runtime.channel.id)
+
+  if (reactionUsersCacheChannelRef.current !== runtime.channel.id) {
+    reactionUsersCacheRef.current.clear()
+    reactionUsersCacheChannelRef.current = runtime.channel.id
+  }
 
   // Identity-stable delegates: always call into the LATEST runtime, so hosts
   // that rebuild their callbacks per render don't churn the stable context.
@@ -79,6 +92,34 @@ export const F0ChatProvider = ({
     () => ({
       toggleReaction: (messageId: string, emoji: string) =>
         void runtimeRef.current.toggleReaction(messageId, emoji),
+      loadReactionUsers: (
+        messageId: string,
+        emoji: string,
+        count: number
+      ): Promise<F0ChatUser[]> => {
+        const currentRuntime = runtimeRef.current
+        if (!currentRuntime.loadReactionUsers) return Promise.resolve([])
+
+        const keyPrefix = `${currentRuntime.channel.id}\u0000${messageId}\u0000${emoji}\u0000`
+        const key = `${keyPrefix}${count}`
+        const cached = reactionUsersCacheRef.current.get(key)
+        if (cached) return cached
+
+        for (const cachedKey of reactionUsersCacheRef.current.keys()) {
+          if (cachedKey.startsWith(keyPrefix)) {
+            reactionUsersCacheRef.current.delete(cachedKey)
+          }
+        }
+
+        const request = currentRuntime.loadReactionUsers(messageId, emoji)
+        reactionUsersCacheRef.current.set(key, request)
+        void request.catch(() => {
+          if (reactionUsersCacheRef.current.get(key) === request) {
+            reactionUsersCacheRef.current.delete(key)
+          }
+        })
+        return request
+      },
       retryMessage: (id: string) => void runtimeRef.current.retryMessage(id),
       deleteMessage: (id: string) => void runtimeRef.current.deleteMessage(id),
       deleteFailedMessage: (id: string) =>
@@ -94,6 +135,7 @@ export const F0ChatProvider = ({
   // identity, in the memo.
   const hasEditMessage = !!runtime.editMessage
   const hasDeleteFailedMessage = !!runtime.deleteFailedMessage
+  const hasLoadReactionUsers = !!runtime.loadReactionUsers
 
   const stable = useMemo<F0ChatStable>(
     () => ({
@@ -101,6 +143,9 @@ export const F0ChatProvider = ({
       capabilities,
       editWindowMs: runtime.editWindowMs,
       toggleReaction: delegates.toggleReaction,
+      loadReactionUsers: hasLoadReactionUsers
+        ? delegates.loadReactionUsers
+        : undefined,
       retryMessage: delegates.retryMessage,
       deleteMessage: delegates.deleteMessage,
       deleteFailedMessage: hasDeleteFailedMessage
@@ -114,6 +159,7 @@ export const F0ChatProvider = ({
       runtime.editWindowMs,
       hasEditMessage,
       hasDeleteFailedMessage,
+      hasLoadReactionUsers,
       delegates,
     ]
   )

--- a/packages/react/src/sds/chat/F0Chat/types.ts
+++ b/packages/react/src/sds/chat/F0Chat/types.ts
@@ -519,6 +519,13 @@ export type F0ChatRuntime = {
    */
   maxFiles?: number
   /**
+   * Maximum size in bytes for each file selected, dropped, or pasted into the
+   * composer. When any file exceeds the limit, the composer rejects the whole
+   * batch before calling `uploadFiles` and keeps the validation error visible
+   * until the next attachment attempt. Omit for no size limit.
+   */
+  maxFileSizeBytes?: number
+  /**
    * Optional voice dictation — same signature as the AI chat (streams partials).
    * Not part of the Stream transport; a host wires it to its own speech service
    * (the Stream adapter omits it, so the mic button stays hidden there).

--- a/packages/react/src/sds/chat/F0Chat/types.ts
+++ b/packages/react/src/sds/chat/F0Chat/types.ts
@@ -1,5 +1,6 @@
 import { type AvatarVariant } from "@/components/avatars/F0Avatar"
 import { type IconType } from "@/components/F0Icon"
+import { type VideoPlayerContent } from "@/components/F0VideoPlayer"
 import { type TranscribeFn } from "@/kits/ai/F0AiChat/types"
 
 /** A participant in a conversation. */
@@ -86,6 +87,17 @@ export type F0ChatFileAttachment = {
   name: string
   size?: number
   mimeType?: string
+  /** Poster used when a video file renders through the inline F0VideoPlayer. */
+  thumbnailUrl?: string
+  /**
+   * Optional captions/audio-description sources for video files. Passed
+   * directly to F0VideoPlayer; ignored for non-video files.
+   */
+  videoContent?: VideoPlayerContent
+  /** Initial locale for localized video audio and accessibility content. */
+  videoDefaultLanguage?: string
+  /** Declare that a video file has no audio, so captions are not required. */
+  videoSilent?: boolean
   /** 0–100 while uploading; undefined once done. */
   progress?: number
 }

--- a/packages/react/src/sds/chat/F0Chat/types.ts
+++ b/packages/react/src/sds/chat/F0Chat/types.ts
@@ -60,7 +60,11 @@ export type F0ChatChannel = {
    * factorial sources these from its own data (e.g. HR vacation status).
    */
   statuses?: F0ChatChannelStatus[]
-  /** Group only. */
+  /**
+   * Group only. Total channel members, including the current user. F0 compares
+   * `memberCount - 1` with the unique other members in `readBy` (or its count
+   * fallback) before showing the all-read footer state.
+   */
   memberCount?: number
   /** DM only — the counterpart, used for the header identity hover card. */
   user?: F0ChatUser
@@ -151,7 +155,10 @@ export type F0ChatReaction = {
  * shows a tappable critical alert whose menu is reduced to Retry / Delete.
  * `delivered` (reached the counterpart's device, not read yet) is for backends
  * that distinguish it — Stream doesn't, so the factorial adapter never emits it
- * and those messages go straight from `sent` to `read`.
+ * and those messages go straight from `sent` to `read`. In groups, `read`
+ * should only be emitted when all other channel members have read the message;
+ * F0 also guards that transition with `channel.memberCount` and the available
+ * `readBy` / `readByCount`.
  */
 export type F0ChatMessageStatus =
   | "sending"

--- a/packages/react/src/sds/chat/F0Chat/types.ts
+++ b/packages/react/src/sds/chat/F0Chat/types.ts
@@ -137,6 +137,10 @@ export type F0ChatReaction = {
   emoji: string
   count: number
   reactedByMe: boolean
+  /**
+   * People who reacted with this emoji. Hosts may omit this initial list and
+   * provide {@link F0ChatRuntime.loadReactionUsers} to resolve it lazily.
+   */
   users?: F0ChatUser[]
 }
 
@@ -211,9 +215,14 @@ export type F0ChatMessage = {
    */
   mentionedEveryone?: boolean
   /**
-   * Group read receipts — how many other members have read this message.
-   * Approximated by counting members whose last-read pointer is at/after this
-   * message (Stream exposes no per-message reader list).
+   * Group read receipts — the other members who have read this message.
+   * Hosts derive this from their transport's per-member read pointers.
+   */
+  readBy?: F0ChatUser[]
+  /**
+   * Group read-receipt count for hosts that cannot provide reader identities.
+   * Prefer `readBy` when identities are available; F0 derives its count from
+   * `readBy.length`.
    */
   readByCount?: number
   /**
@@ -445,6 +454,16 @@ export type F0ChatRuntime = {
   retryMessage: (id: string) => void | Promise<void>
   loadOlder: () => void
   toggleReaction: (messageId: string, emoji: string) => void | Promise<void>
+  /**
+   * Resolve the complete user list for one reaction on demand. F0 calls this
+   * when the reaction receives pointer hover or keyboard focus and caches the
+   * result while its count is unchanged. Omit when every reaction already
+   * carries its complete {@link F0ChatReaction.users} list.
+   */
+  loadReactionUsers?: (
+    messageId: string,
+    emoji: string
+  ) => Promise<F0ChatUser[]>
   /**
    * Delete a message that exists server-side (soft delete → tombstone, or hard
    * delete → removed from `messages`).

--- a/packages/react/src/sds/chat/F0Chat/utils/__tests__/attachments.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/__tests__/attachments.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest"
 
 import { type F0ChatFileAttachment } from "../../types"
-import { documentPreviewKind, withinPreviewSizeLimit } from "../attachments"
+import {
+  documentPreviewKind,
+  formatFileSize,
+  withinPreviewSizeLimit,
+} from "../attachments"
 
 const file = (
   overrides: Partial<F0ChatFileAttachment>
@@ -10,6 +14,18 @@ const file = (
   url: "https://cdn.example.com/doc",
   name: "document",
   ...overrides,
+})
+
+describe("formatFileSize", () => {
+  it("formats byte, kilobyte, megabyte, and gigabyte limits compactly", () => {
+    expect(formatFileSize(512)).toBe("512 B")
+    expect(formatFileSize(1024)).toBe("1 KB")
+    expect(formatFileSize(1536)).toBe("1.5 KB")
+    expect(formatFileSize(100 * 1024 * 1024)).toBe("100 MB")
+    expect(formatFileSize(1.5 * 1024 * 1024)).toBe("1.5 MB")
+    expect(formatFileSize(2 * 1024 * 1024 * 1024)).toBe("2 GB")
+    expect(formatFileSize(1.5 * 1024 * 1024 * 1024)).toBe("1.5 GB")
+  })
 })
 
 describe("documentPreviewKind", () => {

--- a/packages/react/src/sds/chat/F0Chat/utils/__tests__/attachments.test.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/__tests__/attachments.test.ts
@@ -4,6 +4,7 @@ import { type F0ChatFileAttachment } from "../../types"
 import {
   documentPreviewKind,
   formatFileSize,
+  isVideoFileAttachment,
   withinPreviewSizeLimit,
 } from "../attachments"
 
@@ -25,6 +26,31 @@ describe("formatFileSize", () => {
     expect(formatFileSize(1.5 * 1024 * 1024)).toBe("1.5 MB")
     expect(formatFileSize(2 * 1024 * 1024 * 1024)).toBe("2 GB")
     expect(formatFileSize(1.5 * 1024 * 1024 * 1024)).toBe("1.5 GB")
+  })
+})
+
+describe("isVideoFileAttachment", () => {
+  it("recognizes video MIME types and browser-supported file extensions", () => {
+    expect(
+      isVideoFileAttachment(file({ name: "recording", mimeType: "video/mp4" }))
+    ).toBe(true)
+    expect(
+      isVideoFileAttachment(
+        file({
+          name: "walkthrough.webm",
+          mimeType: "application/octet-stream",
+        })
+      )
+    ).toBe(true)
+    expect(
+      isVideoFileAttachment(
+        file({
+          name: "download",
+          url: "https://cdn.example.com/walkthrough.mov?token=123",
+        })
+      )
+    ).toBe(true)
+    expect(isVideoFileAttachment(file({ name: "report.pdf" }))).toBe(false)
   })
 })
 

--- a/packages/react/src/sds/chat/F0Chat/utils/attachments.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/attachments.ts
@@ -2,6 +2,21 @@ import { type F0DocumentKind } from "@/components/F0PdfViewer"
 
 import { type F0ChatFileAttachment } from "../types"
 
+/** Compact binary size used in composer validation messages. */
+export const formatFileSize = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) {
+    const kilobytes = bytes / 1024
+    return `${Number.isInteger(kilobytes) ? kilobytes : kilobytes.toFixed(1)} KB`
+  }
+  if (bytes < 1024 * 1024 * 1024) {
+    const megabytes = bytes / (1024 * 1024)
+    return `${Number.isInteger(megabytes) ? megabytes : megabytes.toFixed(1)} MB`
+  }
+  const gigabytes = bytes / (1024 * 1024 * 1024)
+  return `${Number.isInteger(gigabytes) ? gigabytes : gigabytes.toFixed(1)} GB`
+}
+
 /**
  * Document families with an in-chat preview (Slack-style snapshot card + the
  * fullscreen F0PdfViewer, which routes by this same kind). Anything else —

--- a/packages/react/src/sds/chat/F0Chat/utils/attachments.ts
+++ b/packages/react/src/sds/chat/F0Chat/utils/attachments.ts
@@ -2,6 +2,8 @@ import { type F0DocumentKind } from "@/components/F0PdfViewer"
 
 import { type F0ChatFileAttachment } from "../types"
 
+const VIDEO_EXTENSIONS = new Set(["m4v", "mov", "mp4", "ogv", "webm"])
+
 /** Compact binary size used in composer validation messages. */
 export const formatFileSize = (bytes: number): string => {
   if (bytes < 1024) return `${bytes} B`
@@ -15,6 +17,17 @@ export const formatFileSize = (bytes: number): string => {
   }
   const gigabytes = bytes / (1024 * 1024 * 1024)
   return `${Number.isInteger(gigabytes) ? gigabytes : gigabytes.toFixed(1)} GB`
+}
+
+/** Whether a generic file attachment can render in the native F0 video player. */
+export const isVideoFileAttachment = (file: F0ChatFileAttachment): boolean => {
+  if (file.mimeType?.toLowerCase().startsWith("video/")) return true
+
+  return [file.name, file.url].some((candidate) => {
+    const cleanCandidate = candidate.split(/[?#]/, 1)[0] ?? ""
+    const extension = cleanCandidate.split(".").at(-1)?.toLowerCase()
+    return extension !== undefined && VIDEO_EXTENSIONS.has(extension)
+  })
 }
 
 /**

--- a/packages/react/src/sds/social/Reactions/index.mdx
+++ b/packages/react/src/sds/social/Reactions/index.mdx
@@ -1,0 +1,197 @@
+import { Canvas, Meta, Controls, Unstyled } from "@storybook/addon-docs/blocks"
+import * as Stories from "./index.stories"
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
+
+<Meta of={Stories} />
+
+# Reactions
+
+Reactions displays emoji response totals and reveals the people behind each response. Use it for lightweight feedback attached to shared content.
+
+## Anatomy
+
+<Canvas of={Stories.Default} />
+
+<Controls of={Stories.Default} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Prop</th>
+        <th className="text-left">Type</th>
+        <th className="text-left">Default</th>
+        <th className="text-left">Required</th>
+        <th className="text-left">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>items</code>
+        </td>
+        <td>
+          <code>ReactionProps[]</code>
+        </td>
+        <td>—</td>
+        <td>Yes</td>
+        <td>
+          Emoji reactions, their counts, current-member state, and optional user
+          identities.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>items[].loadUsers</code>
+        </td>
+        <td>
+          <code>() =&gt; Promise&lt;User[]&gt;</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>
+          Loads the complete identity list when the reaction receives hover or
+          keyboard focus.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>onInteraction</code>
+        </td>
+        <td>
+          <code>(emoji: string) =&gt; void</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>Handles adding or removing the current member's reaction.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>locale</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>Locale used by the emoji picker.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>action</code>
+        </td>
+        <td>
+          <code>{"{ label, icon, onClick }"}</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>Optional action displayed beside the emoji picker.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+## Guidelines
+
+### Design best practices
+
+**When to use**
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Situation</th>
+        <th className="text-left">Use Reactions when</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Shared content</td>
+        <td>
+          People need a lightweight response without starting another
+          conversation.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+**When not to use**
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Situation</th>
+        <th className="text-left">Use instead</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>A response needs explanation</td>
+        <td>A comment or chat reply.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+**Do's and don'ts**
+
+<DoDonts
+  do={{
+    description:
+      "Provide complete reaction identities, eagerly or through loadUsers.",
+  }}
+  dont={{
+    description:
+      "Show a count that cannot be reconciled with the identity list.",
+  }}
+/>
+
+### Behavior
+
+- WHEN `users` already contains at least `initialCount` entries → THEN the tooltip uses those names without calling `loadUsers`.
+- WHEN the identity list is incomplete and the reaction receives hover or keyboard focus → THEN `loadUsers` runs once and replaces the fallback tooltip with the resolved names.
+- WHEN the emoji or count changes → THEN stale identity responses are ignored.
+
+### Usage examples
+
+**Load identities on demand**
+
+Use deferred loading when the host transport omits full reaction membership from the initial payload.
+
+<Canvas of={Stories.LazyUsers} />
+
+## Accessibility
+
+### Keyboard interaction
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Key</th>
+        <th className="text-left">Action</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <kbd>Tab</kbd>
+        </td>
+        <td>Moves focus to a reaction and reveals its identity tooltip.</td>
+      </tr>
+      <tr>
+        <td>
+          <kbd>Enter</kbd> / <kbd>Space</kbd>
+        </td>
+        <td>Toggles the focused reaction.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+### Screen reader behavior
+
+Each reaction is a pressed-state button whose accessible name includes the emoji label and current count.

--- a/packages/react/src/sds/social/Reactions/index.stories.tsx
+++ b/packages/react/src/sds/social/Reactions/index.stories.tsx
@@ -1,19 +1,24 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
+import { expect, within } from "storybook/test"
+
+import { getEmojiLabel } from "@/lib/emojis"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
+
 import { Reactions } from "./index"
 
-const meta: Meta<typeof Reactions> = {
+const meta = {
   component: Reactions,
   title: "Reactions",
-  tags: ["autodocs", "experimental"],
+  tags: ["!autodocs", "experimental"],
   parameters: {
     layout: "centered",
   },
-}
+} satisfies Meta<typeof Reactions>
 
 export default meta
 
-type Story = StoryObj<typeof Reactions>
+type Story = StoryObj<typeof meta>
 
 export const Default: Story = {
   args: {
@@ -78,6 +83,49 @@ export const Default: Story = {
         ],
       },
     ],
+  },
+}
+
+export const Snapshot: Story = {
+  args: Default.args,
+  parameters: withSnapshot({}),
+}
+
+export const LazyUsers: Story = {
+  tags: ["f0chat-receipts"],
+  args: {
+    items: [
+      {
+        emoji: "🎉",
+        initialCount: 3,
+        loadUsers: async () => [
+          { name: "Grace Liang" },
+          { name: "Marcus Bennett" },
+          { name: "Sam Okafor" },
+        ],
+      },
+    ],
+  },
+  play: async ({ canvasElement }) => {
+    const page = within(canvasElement.closest("body")!)
+    const reaction = within(canvasElement).getByRole("button", {
+      name: `${getEmojiLabel("🎉")}: 3`,
+    })
+
+    reaction.focus()
+
+    const tooltips = await page.findAllByText(
+      "Grace Liang, Marcus Bennett, Sam Okafor"
+    )
+    const tooltipId = reaction.getAttribute("aria-describedby")
+    const visibleTooltip = tooltipId
+      ? canvasElement.ownerDocument.getElementById(tooltipId)
+      : null
+    await expect(tooltips.length).toBeGreaterThan(0)
+    await expect(tooltipId).toBeTruthy()
+    await expect(visibleTooltip).toHaveTextContent(
+      "Grace Liang, Marcus Bennett, Sam Okafor"
+    )
   },
 }
 

--- a/packages/react/src/sds/social/Reactions/index.test.tsx
+++ b/packages/react/src/sds/social/Reactions/index.test.tsx
@@ -1,0 +1,40 @@
+import { expect, it, vi } from "vitest"
+
+import {
+  zeroRender as render,
+  screen,
+  userEvent,
+  waitFor,
+} from "@/testing/test-utils"
+import { getEmojiLabel } from "@/lib/emojis"
+
+import { Reactions } from "./index"
+
+it("forwards the lazy user loader and shows the resolved identities", async () => {
+  const loadUsers = vi
+    .fn()
+    .mockResolvedValue([{ name: "Grace Liang" }, { name: "Marcus Bennett" }])
+
+  render(
+    <Reactions
+      items={[
+        {
+          emoji: "🎉",
+          initialCount: 2,
+          loadUsers,
+        },
+      ]}
+    />
+  )
+
+  await userEvent.hover(
+    screen.getByRole("button", {
+      name: `${getEmojiLabel("🎉")}: 2`,
+    })
+  )
+
+  await waitFor(() => expect(loadUsers).toHaveBeenCalledTimes(1))
+  expect(
+    await screen.findAllByText("Grace Liang, Marcus Bennett")
+  ).not.toHaveLength(0)
+})

--- a/packages/react/src/sds/social/Reactions/index.tsx
+++ b/packages/react/src/sds/social/Reactions/index.tsx
@@ -36,6 +36,7 @@ function _Reactions({ items, onInteraction, locale, action }: ReactionsProps) {
           initialCount={item.initialCount}
           hasReacted={item.hasReacted}
           users={item.users}
+          loadUsers={item.loadUsers}
           onInteraction={onInteraction}
         />
       ))}

--- a/packages/react/src/sds/social/Reactions/reaction.tsx
+++ b/packages/react/src/sds/social/Reactions/reaction.tsx
@@ -1,7 +1,7 @@
 import NumberFlow from "@number-flow/react"
-import { useRef, useState } from "react"
+import { useEffect, useRef, useState } from "react"
 
-import { Tooltip } from "@/experimental/Overlays/Tooltip"
+import { TooltipInternal } from "@/experimental/Overlays/Tooltip"
 import { EmojiImage, getEmojiLabel, useEmojiConfetti } from "@/lib/emojis"
 import { cn } from "@/lib/utils"
 import { Action } from "@/ui/Action"
@@ -15,6 +15,8 @@ export interface ReactionProps {
   initialCount: number
   hasReacted?: boolean
   users?: User[]
+  /** Resolve the complete user list on first hover or keyboard focus. */
+  loadUsers?: () => Promise<User[]>
   onInteraction?: (emoji: string) => void
   size?: "sm" | "md" | "lg"
 }
@@ -24,13 +26,49 @@ export function Reaction({
   initialCount,
   hasReacted = false,
   users,
+  loadUsers,
   onInteraction,
   size = "md",
 }: ReactionProps) {
   const [isActive, setIsActive] = useState(hasReacted)
   const [count, setCount] = useState(initialCount)
+  const [resolvedUsers, setResolvedUsers] = useState(users)
   const buttonRef = useRef<HTMLButtonElement>(null)
+  const usersRequestRef = useRef<Promise<User[]> | null>(null)
+  const usersRequestGenerationRef = useRef(0)
   const { fireEmojiConfetti } = useEmojiConfetti()
+
+  useEffect(() => {
+    usersRequestGenerationRef.current += 1
+    setResolvedUsers(users)
+    usersRequestRef.current = null
+  }, [emoji, initialCount, users])
+
+  const loadFullUsers = () => {
+    if (
+      !loadUsers ||
+      usersRequestRef.current ||
+      (resolvedUsers?.length ?? 0) >= initialCount
+    ) {
+      return
+    }
+
+    const request = loadUsers()
+    const requestGeneration = usersRequestGenerationRef.current
+    usersRequestRef.current = request
+    void request
+      .then((nextUsers) => {
+        if (usersRequestGenerationRef.current === requestGeneration) {
+          setResolvedUsers(nextUsers)
+        }
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (usersRequestRef.current === request) {
+          usersRequestRef.current = null
+        }
+      })
+  }
 
   const handleClick = (
     event: React.MouseEvent<HTMLButtonElement>,
@@ -46,7 +84,8 @@ export function Reaction({
     }
   }
 
-  const tooltipContent = users?.map((user) => user.name).join(", ") || ""
+  const tooltipContent =
+    resolvedUsers?.map((user) => user.name).join(", ") || ""
 
   const button = (
     <Action
@@ -62,7 +101,8 @@ export function Reaction({
         isActive &&
           "border-f1-border-selected bg-f1-background-selected hover:border-f1-border-selected-bold"
       )}
-      aria-label={getEmojiLabel(emoji)}
+      aria-label={`${getEmojiLabel(emoji)}: ${count}`}
+      aria-pressed={isActive}
       prepend={<EmojiImage emoji={emoji} size={size} />}
     >
       <NumberFlow
@@ -79,8 +119,13 @@ export function Reaction({
     </Action>
   )
 
-  return tooltipContent ? (
-    <Tooltip label={tooltipContent}>{button}</Tooltip>
+  return tooltipContent || loadUsers ? (
+    <TooltipInternal
+      label={tooltipContent || getEmojiLabel(emoji)}
+      onOpen={loadFullUsers}
+    >
+      {button}
+    </TooltipInternal>
   ) : (
     button
   )


### PR DESCRIPTION
## Description

Expands the headless `F0Chat` contract and UI so group conversations can expose exactly who read a message and who used each reaction. It also completes the surrounding chat experience requested during review: accurate group receipt status, richer attachment previews, paste uploads and file-size limits, inline video, compact voice playback, Slack-style emoji autocomplete, resilient scroll following, and group-avatar fallbacks.

This is a stacked PR:

1. [#4911 — F0VideoPlayer controlled download action](https://github.com/factorialco/f0/pull/4911)
2. **#4881 — F0Chat contract, integration, mocks, and chat-specific UI**

[#4910 — F0EmojiPicker](https://github.com/factorialco/f0/pull/4910) is an independent experimental component extracted from this branch and can be reviewed or merged separately.

## Type of change

- [ ] New component
- [ ] New pattern
- [ ] New pattern variant
- [x] Component enhancement/variant
- [x] Pattern enhancement/variant
- [x] Bug fix
- [ ] Refactor/internal change

## Lifecycle phase (if applicable)

- Phase: Validate
- Status: Experimental
- `F0Chat` remains experimental while its new runtime contracts are validated in the frontend Stream adapter.
- This PR provides the headless API, complete mock runtime, documentation, interaction stories, ApplicationFrame scenarios, unit coverage, and accessibility behavior needed for that integration.

## Screenshots (if applicable)

The review states are available in Storybook:

- `ApplicationFrame / Communications — partial readers (sent)`
- `ApplicationFrame / Communications — 40+ readers and reaction users`
- `ApplicationFrame / Communications — 100 MB file limit`
- `ApplicationFrame / Communications — composer attachment previews`
- `ApplicationFrame / Communications — inline video attachments`
- `ApplicationFrame / Communications — group avatar fallback`
- `F0Chat / Snapshot` for autocomplete, compact voice, document previews, and multiple inline videos

## Implementation details

### Reader and reaction identities

- Adds `F0ChatMessage.readBy?: F0ChatUser[]` while preserving `readByCount` as a compatibility fallback.
- Adds `F0ChatRuntime.loadReactionUsers(messageId, emoji)` for transports that omit complete reaction membership from their initial payload.
- Caches lazy reaction-user requests by channel, message, emoji, and count; stale counts and channel changes invalidate the cache, while failed requests remain retryable.
- Extends `Reactions` with eager or lazy user identities, count-aware accessible names, pressed state, and pointer/focus tooltips listing the people behind a reaction.
- Replaces the group message-info count-only row with a scrollable reader list containing avatars and names.
- Renders every reader as a static avatar-and-name row without profile links or hover cards.
- Moves delivery before readers in the information panel and focuses the Back action when the panel opens.

### Sent/read footer semantics

- Own settled messages show `Sent · time` until they are genuinely read.
- DMs switch to `Read · time` when their read timestamp arrives.
- Groups switch to `Read · time` only when `memberCount - 1` readers are represented by `readBy` or `readByCount`.
- Reader counts stay in the information panel instead of the final bubble footer.
- The footer is an atomic polite live region so status transitions are announced without duplicating message content.

### Composer uploads and previews

- Adds `maxFileSizeBytes` to the runtime. Oversized selected, dropped, or pasted batches are rejected before `uploadFiles`; the Storybook/ApplicationFrame example uses 100 MB.
- Adds clipboard file ingestion through `Cmd/Ctrl + V`, alongside drag-and-drop and the file button.
- Keeps pasted plain text behavior unchanged when no file is present.
- Replaces generic composer chips with compact previews for images, horizontal video thumbnails, previewable documents, voice notes, locations, and unknown files.
- Preserves upload progress, ordering, keyboard-accessible removal, focus restoration, and local object-URL cleanup.

### Sent attachments

- Renders completed video files as wide inline `F0VideoPlayer` instances and stacks multiple videos vertically so each keeps the available message width.
- Passes poster, captions, localized content, audio descriptions, locale, and silent-video metadata through the chat attachment contract.
- Uses the controlled player action from #4911 for video downloads.
- Removes redundant bubble-level download buttons from PDF, Word, spreadsheet, text, and video attachments that already have a preview; download remains in the fullscreen document viewer or video controls.
- Keeps non-previewable files and failed previews downloadable.
- Makes voice attachments compress safely in narrow chat panels, with a keyboard-operable seek slider, stable time/speed slot, and announced playback-rate state.

### Emoji autocomplete and mentions

- Adds Slack-style `:` search by shortcode, alias, and emoji name inside the composer.
- Supports Arrow navigation, Enter/Tab selection, Escape dismissal, complete alias conversion, caret-aware replacement, pointer selection, IME safety, and focus retention.
- Exposes listbox, option, selected state, controls, expanded state, and active-descendant semantics.
- Coordinates with `@` mentions: the active token owns the popover, an emoji query can supersede a pending mention, and an empty DM mention remains searchable after receiving no initial results.

### Scroll behavior

- Pauses follow-to-bottom immediately on upward wheel or touch movement so arriving messages and attachment reflows do not pull the reader back down.
- Resumes only at the real bottom, through the explicit jump action, or after the current user sends a message.
- Handles scroll-container replacement, repeated input, timers, touch cleanup, and conversation changes.

### Group fallbacks and mocked examples

- Uses a `#` avatar fallback in the group header and sidebar whenever a channel has no emoji/avatar.
- Adds several group fallback examples rather than a single Leadership channel.
- Gives every mocked group message reader identities.
- Adds partial-receipt and completed-receipt conversations.
- Adds a 45-reader message to verify that the whole information panel scrolls naturally without nested scrolling.
- Adds complete reaction-user examples, 100 MB validation, paste/upload previews, multiple videos, and previewable/non-previewable document combinations to ApplicationFrame.

## Verification

- 40 relevant unit-test files pass with 358 tests across F0Chat, Reactions, Tooltip, and F0VideoPlayer.
- The extracted F0EmojiPicker branch separately passes 21 tests; the F0VideoPlayer branch passes 45 tests.
- TypeScript, formatting, lint hooks, circular-dependency checks, ownership checks, and `git diff --check` pass.
- Targeted Storybook runs passed before consolidation: F0Chat 15/15, F0VideoPlayer 12/12, and F0EmojiPicker 7/7.
- The final consolidated F0Chat snapshot was re-rendered on a clean Storybook server and verified with the autocomplete open, compact voice controls contained at 360 px, previewable document cards, two loaded video players, and downloads only in the expected surfaces.

---
> Factorial is conducting an analysis on the impact of the used skills. This was autogenerated, please don't delete:
> - factorial-ci
> - factorial-f0
> - factorial-pr
> - factorial-skill-tracking
> - factorial-skills
