### PR TITLE
fix(Table): unmount flat rows on removal instead of animating them out

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__tests__/flatRowRemoval.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__tests__/flatRowRemoval.test.tsx
@@ -1,0 +1,120 @@
+import { act, fireEvent, screen, waitFor } from "@testing-library/react"
+import { MotionGlobalConfig } from "motion"
+import { useState } from "react"
+import { afterAll, beforeAll, describe, expect, test } from "vitest"
+
+import { defaultTranslations, I18nProvider } from "@/lib/providers/i18n"
+import { zeroRender as render } from "@/testing/test-utils"
+
+import type { OnSelectItemsCallback } from "@/hooks/datasource"
+import type { FiltersDefinition } from "@/patterns/OneFilterPicker/types"
+
+import { useDataCollectionSource } from "../hooks/useDataCollectionSource"
+import { OneDataCollection } from "../index"
+
+/**
+ * Rows that leave a flat table's dataset must unmount on the same commit that
+ * renders the new dataset. Wrapping them in `AnimatePresence` with an `exit`
+ * variant kept them in the DOM — and in the selection registry — for as long as
+ * the exit transition ran, so a deleted row still answered queries and still
+ * counted towards select-all.
+ */
+
+type Person = { id: string; name: string }
+
+const people: Person[] = [
+  { id: "1", name: "John Doe" },
+  { id: "2", name: "Jane Smith" },
+]
+
+const columns = [{ label: "Name", render: (item: Person) => item.name }]
+
+const Collection = ({
+  selectable,
+  onSelectItems,
+}: {
+  selectable?: boolean
+  onSelectItems?: OnSelectItemsCallback<Person, FiltersDefinition>
+}) => {
+  const [records, setRecords] = useState(people)
+
+  const source = useDataCollectionSource<Person>(
+    {
+      ...(selectable ? { selectable: (item: Person) => item.id } : {}),
+      dataAdapter: { fetchData: async () => ({ records }) },
+    },
+    [records]
+  )
+
+  return (
+    <I18nProvider translations={defaultTranslations}>
+      <button onClick={() => setRecords((r) => r.slice(1))}>Delete John</button>
+      <button
+        onClick={() =>
+          setRecords((r) => [...r, { id: "3", name: "Alice Brown" }])
+        }
+      >
+        Add Alice
+      </button>
+      <OneDataCollection
+        source={source}
+        visualizations={[{ type: "table", options: { columns } }]}
+        {...(onSelectItems ? { onSelectItems } : {})}
+      />
+    </I18nProvider>
+  )
+}
+
+/**
+ * Removes John from the dataset and flushes the refetch. Uses `fireEvent` and a
+ * bare microtask flush rather than `userEvent`/`waitFor`: both of those advance
+ * real time, which would let an exit transition finish and turn the assertions
+ * below into a tautology.
+ */
+const deleteJohn = async () => {
+  fireEvent.click(screen.getByRole("button", { name: "Delete John" }))
+  await act(async () => {})
+}
+
+describe("OneDataCollection flat table row removal", () => {
+  // `test-utils` sets `MotionGlobalConfig.skipAnimations = true` for the whole
+  // suite, which resolves every exit transition instantly and would hide the
+  // regression these tests guard. Consumers run with animations on, so this
+  // file opts back into real motion timing to match what they see.
+  beforeAll(() => {
+    MotionGlobalConfig.skipAnimations = false
+  })
+  afterAll(() => {
+    MotionGlobalConfig.skipAnimations = true
+  })
+
+  test("unmounts a row as soon as it leaves the dataset", async () => {
+    render(<Collection />)
+
+    await waitFor(() => {
+      expect(screen.getByText("John Doe")).toBeInTheDocument()
+      expect(screen.getByText("Jane Smith")).toBeInTheDocument()
+    })
+
+    await deleteJohn()
+
+    expect(screen.queryByText("John Doe")).not.toBeInTheDocument()
+    expect(screen.getAllByRole("row")).toHaveLength(2) // header + Jane
+  })
+
+  // Dropping the exit transition must not cost us the feature #4709 added:
+  // a genuinely-inserted row still plays the "flash on add" highlight.
+  test("still flashes a newly-inserted row", async () => {
+    render(<Collection />)
+
+    await waitFor(() => {
+      expect(screen.getByText("John Doe")).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByRole("button", { name: "Add Alice" }))
+    await act(async () => {})
+
+    const addedRow = screen.getByText("Alice Brown").closest("tr")
+    expect(addedRow).toHaveClass("animate-row-flash")
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/Table.tsx
@@ -241,14 +241,6 @@ export const TableCollection = <
         : undefined
   const addedRowKeys = useAddedRowKeys(flatRowKeys, paginationResetKey)
 
-  // Remount the flat row presence group on page-based page changes so the
-  // outgoing page doesn't animate out. Infinite scroll keeps a stable key: its
-  // rows are appended, not swapped, so they must not be torn down on load-more.
-  const flatPresenceKey =
-    paginationInfo?.type === "pages"
-      ? `flat-page-${paginationInfo.currentPage}`
-      : "flat"
-
   const selectionRegistry = useCreateSelectionRegistry<R>()
   const {
     selectedItems,
@@ -755,62 +747,61 @@ export const TableCollection = <
                     </Fragment>
                   )
                 })}
-              {data?.type === "flat" && (
-                // Keying the presence group by page makes a page change remount
-                // the whole group, so the outgoing page's rows are dropped
-                // instantly instead of playing their exit animation. Inserts and
-                // deletes within a page (same key) still animate.
-                <AnimatePresence initial={false} key={flatPresenceKey}>
-                  {data.records.map((item, index) => {
-                    const rowKey = `row-${getRowKey(item, index)}`
-                    const isNew = addedRowKeys.has(rowKey)
-                    const motionRow = (
-                      <MotionRow
-                        variants={getAnimationVariants()}
-                        // Only a genuinely-inserted row plays the enter
-                        // animation; rows arriving via pagination or the initial
-                        // load appear in place, without movement.
-                        initial={isNew ? "hidden" : false}
-                        animate="visible"
-                        exit="hidden"
-                        custom={index}
-                        key={rowKey}
-                        layout
-                        isNew={isNew}
-                        groupIndex={0}
-                        source={effectiveSource}
-                        item={item}
-                        index={index}
-                        onItemCheckedChange={handleSelectItemChange}
-                        onCheckedChange={(checked) =>
-                          handleSelectItemChange(item, checked)
-                        }
-                        selectedItems={selectedItems}
-                        columns={columns}
-                        frozenColumnsLeft={frozenColumnsLeft}
-                        checkColumnWidth={checkColumnWidth}
-                        tableWithChildren={tableWithChildren}
-                        referenceRowType={referenceRowType}
-                        rowWrapper={RowWrapper}
-                        cellRenderer={cellRenderer}
-                        fromVisualization={fromVisualization}
-                        headerGroups={headerGroups}
-                        registerSelectable={selectionRegistry.register}
-                        unregisterSelectable={selectionRegistry.unregister}
-                      />
+              {data?.type === "flat" &&
+                // Deliberately not wrapped in `AnimatePresence`: a row that
+                // leaves the dataset (deleted, filtered out, re-sorted away)
+                // must unmount on the same render. An exit transition keeps it
+                // mounted — still in the DOM, still in the selection registry —
+                // for as long as it runs, so a removed row goes on answering
+                // queries and shifting row/checkbox positions. Enter and flash
+                // don't need presence tracking; `initial`/`animate` cover them.
+                data.records.map((item, index) => {
+                  const rowKey = `row-${getRowKey(item, index)}`
+                  const isNew = addedRowKeys.has(rowKey)
+                  const motionRow = (
+                    <MotionRow
+                      variants={getAnimationVariants()}
+                      // Only a genuinely-inserted row plays the enter
+                      // animation; rows arriving via pagination or the initial
+                      // load appear in place, without movement.
+                      initial={isNew ? "hidden" : false}
+                      animate="visible"
+                      custom={index}
+                      key={rowKey}
+                      layout
+                      isNew={isNew}
+                      groupIndex={0}
+                      source={effectiveSource}
+                      item={item}
+                      index={index}
+                      onItemCheckedChange={handleSelectItemChange}
+                      onCheckedChange={(checked) =>
+                        handleSelectItemChange(item, checked)
+                      }
+                      selectedItems={selectedItems}
+                      columns={columns}
+                      frozenColumnsLeft={frozenColumnsLeft}
+                      checkColumnWidth={checkColumnWidth}
+                      tableWithChildren={tableWithChildren}
+                      referenceRowType={referenceRowType}
+                      rowWrapper={RowWrapper}
+                      cellRenderer={cellRenderer}
+                      fromVisualization={fromVisualization}
+                      headerGroups={headerGroups}
+                      registerSelectable={selectionRegistry.register}
+                      unregisterSelectable={selectionRegistry.unregister}
+                    />
+                  )
+                  if (RowWrapper) {
+                    return (
+                      <RowWrapper key={rowKey} item={item} index={index}>
+                        {motionRow}
+                      </RowWrapper>
                     )
-                    if (RowWrapper) {
-                      return (
-                        <RowWrapper key={rowKey} item={item} index={index}>
-                          {motionRow}
-                        </RowWrapper>
-                      )
-                    }
+                  }
 
-                    return motionRow
-                  })}
-                </AnimatePresence>
-              )}
+                  return motionRow
+                })}
               {paginationInfo?.type === "infinite-scroll" &&
                 isLoadingMore &&
                 Array.from({ length: 5 }).map((_, rowIndex) => (


### PR DESCRIPTION
## Description

Rows removed from a flat `OneDataCollection` table stayed mounted while their exit transition played. Fixes the `OneDataCollection` spec failures reported on the F0 upgrade in `factorial/main`.

## Type of change

- [x] Bug fix

## Implementation details

[#4709](https://github.com/factorialco/f0/pull/4709) (`4f632af8e`, "flash newly-added rows on insert") wrapped the **flat** branch of `Table.tsx` in `<AnimatePresence>` with `<MotionRow … exit="hidden">`. Before that it rendered a plain `<Row>`.

`exit="hidden"` keeps a row **mounted** for the length of its exit transition. So a row that leaves the dataset — deleted, filtered out, re-sorted away — is still in the DOM, still in the selection registry, and still shifting row/checkbox positions after the data says it's gone.

This PR drops the presence wrapper from the flat branch. Removals unmount on the same render, as they did before #4709.

- **Insert animation and flash-on-add are untouched.** They run off `initial`/`animate` on the motion component and need no presence tracking; the `useAddedRowKeys` + `paginationResetKey` logic from #4809 is unchanged.
- **`flatPresenceKey` is removed.** [#4809](https://github.com/factorialco/f0/pull/4809) added it to stop the outgoing page animating out on pagination. With no exit transition at all, there is nothing left for it to suppress.
- **Grouped rows are untouched.** Their `AnimatePresence` predates #4709, so it isn't part of this regression. Scoping the change keeps the blast radius to what actually broke.

## Impact on consumers

CI in `factorial/main` is red on these unchanged specs (reported by @victor-shcherbakov in [#f0-support](https://factorialteam.slack.com/archives/C082ZNKS403/p1785267443517249)):

- `ats/…/EvaluationForms` — the deleted "Technical skills" row stays in the DOM
- `compensations/…/EmployeeUpdatesDataCollectionPage` — the filtered-out "John Doe" row stays mounted and skews selection
- `job_catalog/…/JobCatalogTreeOneDataCollection` (×2) — the tree never converges to its filtered state, so the spec times out

Confirmed boundary: F0 `4.47.3` passes, `4.48.0` fails.

## Tests

New `packages/react/src/patterns/OneDataCollection/__tests__/flatRowRemoval.test.tsx`:

1. **`unmounts a row as soon as it leaves the dataset`** — removes a record, flushes the refetch, then asserts synchronously. Verified as a real guard: fails on `main`, passes here.
2. **`still flashes a newly-inserted row`** — an inserted row keeps the `animate-row-flash` class, so #4709's feature survives this change.

The file deliberately uses `fireEvent` + a bare microtask flush rather than `userEvent`/`waitFor`: both of the latter advance real time, which lets an exit transition finish and turns the assertion into a tautology.

### Why f0 CI didn't catch this

`src/testing/test-utils.tsx:27` sets `MotionGlobalConfig.skipAnimations = true` for the whole suite, so every exit transition resolves instantly and this class of bug is invisible to f0's own tests. Consumers run with animations on. The new test file opts back into real motion timing for its duration. Worth considering whether more of the animation-sensitive suite should do the same — out of scope here.

Full `packages/react` suite green: 4999 passed, 14 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)