### PR TITLE
fix(react): stop flagging widened unions as breaking API changes

### DIFF
--- a/packages/react/.scripts/__tests__/check-api-surface.test.ts
+++ b/packages/react/.scripts/__tests__/check-api-surface.test.ts
@@ -324,6 +324,58 @@ describe("check-api-surface — unions and intersections", () => {
     expect(changed?.reasons?.some((r) => /union variants/i.test(r))).toBe(true)
   })
 
+  it("treats a widened string-literal union (variants added) as safe", () => {
+    // The country-code case: `CountryCode` is `keyof translations.countries`,
+    // so adding countries grows every union that accepts a country code. A
+    // consumer passing an existing value is unaffected.
+    const diff = f0(
+      `
+      export declare type Flag = "es" | "us" | "fr";
+      export declare const Avatar: (props: { flag: Flag }) => unknown;
+      `,
+      `
+      export declare type Flag = "es" | "us" | "fr" | "de" | "it" | "pt";
+      export declare const Avatar: (props: { flag: Flag }) => unknown;
+      `
+    )
+    expect(diff.breaking).toHaveLength(0)
+  })
+
+  it("treats a new field-type variant added to a union as safe", () => {
+    // The F0FieldType case: a new `"phone"` variant added to the union.
+    const diff = f0(
+      `export declare type FieldType = "text" | "number" | "date";`,
+      `export declare type FieldType = "text" | "number" | "date" | "phone";`
+    )
+    expect(diff.breaking).toHaveLength(0)
+  })
+
+  it("flags a removed variant from a string-literal union (narrowing)", () => {
+    const diff = f0(
+      `export declare type Flag = "es" | "us" | "fr";`,
+      `export declare type Flag = "es" | "fr";`
+    )
+    const changed = diff.breaking.find((b) => b.name === "Flag")
+    expect(changed?.reasons?.some((r) => /union variants/i.test(r))).toBe(true)
+  })
+
+  it("treats a variant added to a union-of-object variants as safe", () => {
+    const diff = f0(
+      `
+      export declare type Shape =
+        | { kind: "a"; value: string }
+        | { kind: "b"; value: number };
+      `,
+      `
+      export declare type Shape =
+        | { kind: "a"; value: string }
+        | { kind: "b"; value: number }
+        | { kind: "c"; value: boolean };
+      `
+    )
+    expect(diff.breaking).toHaveLength(0)
+  })
+
   it("treats an optional prop added to a plain intersection as safe", () => {
     const diff = f0(
       `

--- a/packages/react/.scripts/check-api-surface.ts
+++ b/packages/react/.scripts/check-api-surface.ts
@@ -29,10 +29,18 @@
  * rollup noise (the `F0TextInputProps_2` suffixes / dangling `./types` imports)
  * instead of diffing raw `.d.ts` text.
  *
- * Unions are compared variant-by-variant (pairwise) and intersections of
+ * Unions are compared as *sets* of structural variants, and intersections of
  * object shapes are flattened into one merged member set — so an optional
  * prop added to a base type that feeds a union of prop variants (the
  * `F0SelectProps` shape) classifies as additive, not as "the union changed".
+ *
+ * A union that only *gains* variants is a widening and is treated as safe:
+ * accepting more values (e.g. a `CountryCode` union that grows when countries
+ * are added, or a new `"phone"` field type) does not break a consumer passing
+ * one of the existing values, the same way a new optional prop is safe. Only a
+ * *removed* variant (narrowing) is breaking. When every variant is reshaped by
+ * a change to a shared base, the reshaped variants are aligned and compared
+ * structurally so a real breaking prop change is still caught.
  *
  * The shared translations dictionary (`TranslationsType` / `TranslationShape`
  * / `TranslationKey`, plus the inlined `defaultTranslations` object) is
@@ -47,7 +55,12 @@
  * unions/intersections) are compared by their normalized string, so a
  * *widening* of a leaf type (e.g. a prop `string` → `string | number`, which
  * is safe for an input) is reported as breaking. Object/parameter shape
- * changes — the common case — are classified precisely.
+ * changes — the common case — are classified precisely. Variance is not
+ * tracked, so a widened union is assumed to sit in an input position (a prop
+ * value the consumer passes in), where widening is safe; a union that only
+ * grows in a covariant output position (a value the consumer reads back and
+ * exhaustively switches over) is under-reported rather than flagged. This
+ * matches how the check already treats a new optional prop as safe.
  *
  * Usage:
  *   tsx .scripts/check-api-surface.ts --base <dir> --head <dir> [--json]
@@ -803,6 +816,44 @@ function translationsToObjectItem(keys: string[]): ApiItem {
 }
 
 /**
+ * A canonical, order-independent string signature of an {@link ApiItem}, used
+ * to match union variants across the two sides as a set. Two variants with the
+ * same signature are structurally identical; object members are sorted by name
+ * and union members by their own signatures so member/variant ordering does not
+ * affect the result.
+ */
+export function itemSignature(item: ApiItem): string {
+  switch (item.k) {
+    case "opaque":
+      return `O:${item.text}`
+    case "translations":
+      // keys are already sorted at construction time
+      return `T:${item.keys.join(",")}`
+    case "union":
+      return `U:[${item.members.map(itemSignature).sort().join("|")}]`
+    case "callable":
+      return `C:[${item.sigs
+        .map(
+          (s) =>
+            `(${s.params
+              .map((p) => `${p.optional ? "?" : ""}${itemSignature(p.type)}`)
+              .join(",")})=>${itemSignature(s.ret)}`
+        )
+        .join(";")}]`
+    case "object": {
+      const members = Object.keys(item.members)
+        .sort()
+        .map((name) => {
+          const m = item.members[name]
+          return `${name}${m.optional ? "?" : ""}${m.readonly ? "R" : ""}:${itemSignature(m.type)}`
+        })
+        .join(";")
+      return `{${members}}${item.index ? `[${item.index}]` : ""}`
+    }
+  }
+}
+
+/**
  * Structural breaking-change comparison. Variance is modelled the way a
  * consumer experiences component props: adding an optional member or relaxing
  * a required member to optional is safe; removing a member, retyping it, adding
@@ -850,19 +901,72 @@ function classifyItem(
   }
 
   if (before.k === "union" && after.k === "union") {
-    if (before.members.length !== after.members.length) {
+    // Match variants across the two sides as a multiset of structural
+    // signatures. Variants present on both sides are unchanged; what is left
+    // over is the actual delta.
+    const remainingHead = new Map<string, number>()
+    for (const m of after.members) {
+      const s = itemSignature(m)
+      remainingHead.set(s, (remainingHead.get(s) ?? 0) + 1)
+    }
+    const unmatchedBase: ApiItem[] = []
+    for (const m of before.members) {
+      const s = itemSignature(m)
+      const n = remainingHead.get(s) ?? 0
+      if (n > 0) remainingHead.set(s, n - 1)
+      else unmatchedBase.push(m)
+    }
+    const remainingBase = new Map<string, number>()
+    for (const m of before.members) {
+      const s = itemSignature(m)
+      remainingBase.set(s, (remainingBase.get(s) ?? 0) + 1)
+    }
+    const unmatchedHead: ApiItem[] = []
+    for (const m of after.members) {
+      const s = itemSignature(m)
+      const n = remainingBase.get(s) ?? 0
+      if (n > 0) remainingBase.set(s, n - 1)
+      else unmatchedHead.push(m)
+    }
+
+    // Every base variant still has a twin on the head side: the union only
+    // gained variants (widening) or is unchanged. Safe, like a new optional
+    // prop — accepting more values doesn't break a consumer passing an
+    // existing one.
+    if (unmatchedBase.length === 0) return []
+
+    // Base variants disappeared and nothing reshaped took their place: a pure
+    // narrowing. Removing accepted values is breaking.
+    if (unmatchedHead.length === 0) {
       return [
-        `${path || "type"} union variants changed (${before.members.length} → ${after.members.length})`,
+        `${path || "type"} union variants removed (${before.members.length} → ${after.members.length})`,
       ]
     }
-    // Variants are compared at the same path so identical reasons coming
-    // from a change in a shared base dedupe into a single line.
+
+    // Both sides carry unmatched variants — the shape a shared base being
+    // changed produces (every variant is reshaped, so none matches exactly).
+    // Align the reshaped variants pairwise and compare them structurally, so a
+    // real breaking prop change is still caught while an additive one is not.
+    // Identical reasons from each variant dedupe into a single line.
     const reasons = new Set<string>()
-    before.members.forEach((b, i) => {
-      for (const reason of classifyItem(b, after.members[i], path, tx)) {
+    const paired = Math.min(unmatchedBase.length, unmatchedHead.length)
+    for (let i = 0; i < paired; i++) {
+      for (const reason of classifyItem(
+        unmatchedBase[i],
+        unmatchedHead[i],
+        path,
+        tx
+      )) {
         reasons.add(reason)
       }
-    })
+    }
+    // Leftover base variants with no head counterpart were removed (breaking);
+    // leftover head variants are additive and safe.
+    if (unmatchedBase.length > unmatchedHead.length) {
+      reasons.add(
+        `${path || "type"} union variants removed (${before.members.length} → ${after.members.length})`
+      )
+    }
     return [...reasons]
   }
 


### PR DESCRIPTION
## Description

The public API surface check (`.scripts/check-api-surface.ts`) treated any change in a union's member count as a breaking change. This produced dozens of false-positive "breaking" entries — as seen on [#4880](https://github.com/factorialco/f0/pull/4880#issuecomment-5109198446) — whenever a union was merely *widened*: adding countries to the translations dictionary grows every `CountryCode`-derived union (avatar flag props on `AvatarVariant`/`Chip`/`CardSelectableItem`/`DropdownItem`, …) and adding a field type grows `F0FieldType`, all of which are backward-compatible for consumers passing an existing value. Unions are now compared as sets of structural variants, so widening is treated as safe (like a new optional prop) while genuine narrowing is still flagged.

## Implementation details

- fix: compare union variants as a multiset of structural signatures instead of by count/position — a union that only gains variants is a safe widening and is no longer flagged

  <details>
  <summary>Why?</summary>

  `CountryCode = keyof TranslationsType["countries"]`, so the phone-input PR that added ~145 countries grew every union referencing a country code from ~60 to ~145 members, and `F0FieldType` from 19 to 20. Accepting more input values doesn't break a consumer passing one of the existing values, exactly like adding a new optional prop — which the check already treats as safe. Removed variants (narrowing) remain breaking, and when a shared base change reshapes every variant, the reshaped variants are still aligned and compared structurally so a real breaking prop change is caught. The old pairwise-by-position comparison also produced misleading "each value shifted by one position" noise, which this removes.
  </details>

- feat: add `itemSignature` helper for order-independent structural comparison of API items
- test: cover widened literal unions, a new field-type variant, union narrowing, and an added object-variant

This is a non-blocking advisory check; variance is not tracked, so a union that only grows in a covariant output position is under-reported rather than flagged — the same assumption the check already makes for new optional props (documented in the file header).