### PR TITLE
feat(OneDataCollection): optional group-header selection in Kanban

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/grouping.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/grouping.mdx
@@ -202,3 +202,10 @@ options to hide the group-level checkbox while keeping per-card selection —
 useful when "select a whole group" isn't a meaningful action for the consumer.
 
 <Canvas of={KanbanStories.KanbanWithGrouping} />
+
+### Kanban grouping with the group checkbox hidden
+
+`selectableGroups={false}` on a grouped, selectable Kanban keeps per-card
+selection (and bulk actions) while hiding the per-group "Select all" checkbox.
+
+<Canvas of={KanbanStories.KanbanWithGroupingHiddenGroupSelect} />

--- a/packages/react/src/patterns/OneDataCollection/__stories__/grouping.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/grouping.mdx
@@ -195,4 +195,10 @@ group header shows its own item count.
 Note: pagination and infinite scroll apply per board, not per lane inside a
 group — grouped lanes render the records that have already been fetched.
 
+When the collection is selectable, each group header shows a checkbox that
+selects every item in that group (parity with the Card and List
+visualizations). Pass `selectableGroups={false}` in the Kanban visualization
+options to hide the group-level checkbox while keeping per-card selection —
+useful when "select a whole group" isn't a meaningful action for the consumer.
+
 <Canvas of={KanbanStories.KanbanWithGrouping} />

--- a/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/kanban.stories.tsx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/visualizations/kanban.stories.tsx
@@ -277,3 +277,78 @@ export const KanbanWithGrouping: Story = {
     })
   },
 }
+
+export const KanbanWithGroupingHiddenGroupSelect: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    docs: {
+      description: {
+        story:
+          "Grouped, selectable Kanban with `selectableGroups: false`. Cards stay " +
+          "selectable (per-card checkboxes + bulk actions) but the per-group-header " +
+          '"Select all" checkbox is hidden — for cases where selecting a whole group ' +
+          "isn't a meaningful action for the consumer.",
+      },
+    },
+  },
+  render: () => {
+    const [items] = useState<MockUser[]>(() => generateMockUsers(60))
+    const mockVisualizations = getMockVisualizations({})
+    const kanban = mockVisualizations.kanban
+    const kanbanNoGroupSelect =
+      kanban.type === "kanban"
+        ? { ...kanban, options: { ...kanban.options, selectableGroups: false } }
+        : kanban
+
+    const dataAdapter = useMemo(
+      () =>
+        createDataAdapter({
+          data: items,
+          paginationType: "infinite-scroll",
+          perPage: 20,
+        }),
+      [items]
+    )
+
+    return (
+      <ExampleComponent
+        visualizations={[kanbanNoGroupSelect]}
+        dataAdapter={dataAdapter}
+        selectable={(el) => el.id}
+        currentGrouping={{ field: "role", order: "asc" }}
+        grouping={{
+          collapsible: true,
+          defaultOpenGroups: true,
+          groupBy: {
+            role: {
+              name: "Role",
+              label: (groupId) => String(groupId),
+            },
+          },
+        }}
+        totalItemSummary={(total) => `Total items: ${total}`}
+        fullHeight
+        searchBar
+      />
+    )
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement)
+    await step(
+      "grouped board hides the group 'Select all' but keeps card selection",
+      async () => {
+        const groups = await canvas.findAllByTestId(/^kanban-group-/)
+        expect(groups.length).toBeGreaterThan(1)
+        const [firstGroupEl] = groups
+        if (!firstGroupEl) return
+        const firstGroup = within(firstGroupEl)
+        expect(
+          firstGroup.queryByRole("checkbox", { name: "Select all" })
+        ).not.toBeInTheDocument()
+        expect(
+          (await firstGroup.findAllByRole("checkbox")).length
+        ).toBeGreaterThan(0)
+      }
+    )
+  },
+}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
@@ -14,6 +14,7 @@ import {
 import { useGroups } from "@/hooks/datasource/useGroups"
 import { useReducedMotion } from "@/lib/a11y"
 import { useIsDev } from "@/lib/providers/user-platafform"
+import { cn } from "@/lib/utils"
 import { GroupHeader } from "@/ui/GroupHeader/GroupHeader"
 import { KanbanCard } from "@/ui/Kanban/components/KanbanCard"
 
@@ -55,7 +56,7 @@ export const KanbanCollection = <
   onLoadError,
   onLoadData,
   getLanesForGroup,
-  selectableGroups,
+  selectableGroups = true,
 }: KanbanCollectionProps<
   R,
   Filters,
@@ -467,7 +468,7 @@ export const KanbanCollection = <
               // the toggle out to each lane (same primitives Card/List use, just
               // summed across the board's columns).
               const groupSelectable =
-                selectableGroups !== false && source.selectable !== undefined
+                selectableGroups && source.selectable !== undefined
               let selectedCount = 0
               let unselectedCount = 0
               for (const lane of board.lanes) {
@@ -490,7 +491,11 @@ export const KanbanCollection = <
                   data-testid={`kanban-group-${board.key}`}
                 >
                   <GroupHeader
-                    className="cursor-pointer select-none rounded-md px-3.5 py-3 transition-colors hover:bg-f1-background-hover"
+                    className={cn(
+                      "rounded-md px-3.5 py-3",
+                      (collapsible || groupSelectable) &&
+                        "cursor-pointer select-none transition-colors hover:bg-f1-background-hover"
+                    )}
                     showOpenChange={collapsible}
                     label={board.label}
                     itemCount={board.itemCount}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
@@ -55,6 +55,7 @@ export const KanbanCollection = <
   onLoadError,
   onLoadData,
   getLanesForGroup,
+  selectableGroups,
 }: KanbanCollectionProps<
   R,
   Filters,
@@ -465,7 +466,8 @@ export const KanbanCollection = <
               // board's lanes' status for this group into one tri-state, and fan
               // the toggle out to each lane (same primitives Card/List use, just
               // summed across the board's columns).
-              const groupSelectable = source.selectable !== undefined
+              const groupSelectable =
+                selectableGroups !== false && source.selectable !== undefined
               let selectedCount = 0
               let unselectedCount = 0
               for (const lane of board.lanes) {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/index.spec.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/index.spec.tsx
@@ -563,6 +563,60 @@ describe("KanbanCollection - grouping", () => {
     expect(selectAllB()).toHaveAttribute("aria-checked", "false")
   })
 
+  it("hides the group-header checkbox when selectableGroups is false but keeps card selection", async () => {
+    const people: GroupPerson[] = [
+      { id: 1, name: "John", group: "A", lane: "todo" },
+      { id: 2, name: "Jane", group: "A", lane: "doing" },
+      { id: 3, name: "Bob", group: "B", lane: "doing" },
+    ]
+
+    const source = {
+      ...createGroupedSource(people),
+      selectable: (p: GroupPerson) => p.id,
+      lanes: [
+        { id: "todo", filters: { lane: ["todo"] } },
+        { id: "doing", filters: { lane: ["doing"] } },
+      ],
+    }
+
+    zeroRender(
+      <KanbanCollection<
+        GroupPerson,
+        TestFilters,
+        SortingsDefinition,
+        SummariesDefinition,
+        ItemActionsDefinition<GroupPerson>,
+        TestNavigationFilters,
+        GroupingDefinition<GroupPerson>
+      >
+        lanes={[
+          { id: "todo", title: "Todo" },
+          { id: "doing", title: "Doing" },
+        ]}
+        selectableGroups={false}
+        title={(p) => p.name}
+        description={(p) => p.name}
+        metadata={() => []}
+        source={source}
+        onSelectItems={vi.fn()}
+        onLoadData={vi.fn()}
+        onLoadError={vi.fn()}
+      />
+    )
+
+    const groupA = await screen.findByTestId("kanban-group-A")
+    await waitFor(() => {
+      expect(within(groupA).getAllByTestId("card")).toHaveLength(2)
+    })
+
+    // The group header has no "Select all" checkbox...
+    expect(
+      within(groupA).queryByRole("checkbox", { name: "Select all" })
+    ).not.toBeInTheDocument()
+    // ...but the cards are still selectable (their own checkboxes render).
+    expect(within(groupA).getAllByRole("checkbox").length).toBeGreaterThan(0)
+  })
+
   // Onboarding case: each version renders its own phases; a version with no
   // people is simply not shown (standard data-driven grouping).
   it("renders each shown version with its own columns and omits empty versions", async () => {

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/index.spec.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/index.spec.tsx
@@ -613,8 +613,10 @@ describe("KanbanCollection - grouping", () => {
     expect(
       within(groupA).queryByRole("checkbox", { name: "Select all" })
     ).not.toBeInTheDocument()
-    // ...but the cards are still selectable (their own checkboxes render).
-    expect(within(groupA).getAllByRole("checkbox").length).toBeGreaterThan(0)
+    // ...but the cards are still selectable: exactly one checkbox per card (2),
+    // so a regression that also hid card selection (0) or re-added the group
+    // checkbox (3) would fail here.
+    expect(within(groupA).getAllByRole("checkbox")).toHaveLength(2)
   })
 
   // Onboarding case: each version renders its own phases; a version with no

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/types.ts
@@ -32,6 +32,11 @@ export type KanbanVisualizationOptions<
    * `source.lanes`). Enables the onboarding case where each policy version has
    * its own phases. NOTE: API shape pending Foundations review. */
   getLanesForGroup?: (groupKey: string) => ReadonlyArray<KanbanLaneDefinition>
+  /** Whether each group header shows a selection checkbox when the collection is
+   * selectable. Defaults to `true` (parity with Card/List). Set to `false` to
+   * keep per-card selection while hiding the group-level checkbox — e.g. when
+   * "select a whole group" isn't a meaningful action for the consumer. */
+  selectableGroups?: boolean
   title?: (record: Record) => string
   description?: (record: Record) => string
   avatar?: (record: Record) => CardAvatarVariant

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/types.ts
@@ -35,7 +35,9 @@ export type KanbanVisualizationOptions<
   /** Whether each group header shows a selection checkbox when the collection is
    * selectable. Defaults to `true` (parity with Card/List). Set to `false` to
    * keep per-card selection while hiding the group-level checkbox — e.g. when
-   * "select a whole group" isn't a meaningful action for the consumer. */
+   * "select a whole group" isn't a meaningful action for the consumer. Note: a
+   * collapsed group unmounts its cards, so with `false` the group's items can
+   * only be selected once the group is expanded. */
   selectableGroups?: boolean
   title?: (record: Record) => string
   description?: (record: Record) => string


### PR DESCRIPTION
## Summary

Adds `selectableGroups?: boolean` (default `true`) to the Kanban visualization options. When `false`, a **grouped + selectable** Kanban keeps **per-card selection** (and bulk actions) but does **not** render the per-group-header checkbox.

Motivation: onboarding tracking groups the Kanban by policy version. "Select a whole version" isn't a meaningful action there, so product wants the group-header checkbox hidden while keeping onboardee (card) selection + bulk-remove. Today the group-header checkbox is gated only on `source.selectable`, same as Card/List, with no way to opt out.

## Changes
- `KanbanVisualizationOptions.selectableGroups?: boolean` (default `true`)
- Grouped Kanban gates the `GroupHeader` checkbox on `selectableGroups && source.selectable`
- The header's clickable styling (`cursor-pointer`/hover) now follows the same `collapsible || groupSelectable` condition as `GroupHeader`'s own `isInteractive`, so the header no longer looks interactive when it isn't
- Backwards compatible: default preserves current behaviour (parity with Card/List)
- Unit test: with `selectableGroups={false}` the group-header "Select all" checkbox is absent while exactly the per-card checkboxes still render
- Story `KanbanWithGroupingHiddenGroupSelect` demonstrates the opt-out (grouped + selectable, group checkbox hidden, cards still selectable) with a `play` assertion

## Testing
- `pnpm lint` 0/0 · `pnpm build:types` clean · Kanban unit suite 9/9
- New story is type-checked; its `play` mirrors the unit contract (no group "Select all", card checkboxes present)

## For Foundations
**Scope is intentionally Kanban-only.** The default is `true`, so out of the box all three visualizations behave identically (full parity) — the divergence only appears when a consumer deliberately opts out. The opt-out has a Kanban-specific rationale: a collapsed group unmounts its cards, so the group-header checkbox is otherwise the only way to bulk-select a collapsed group; onboarding (grouped by policy version) doesn't want "select a whole version" at all.

Scoped it to the **Kanban viz option** (smallest, additive, lives next to `getLanesForGroup`) rather than Card/List, which have no consumer need for it today. If you'd prefer a **grouping-level** flag (`GroupingDefinition.selectableGroups`) or a shared visualization-overrides option honoured consistently across Card/List/Kanban, happy to lift it there — flag your preference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)