### PR TITLE
fix(F0Form): block submit while a file upload is in flight

### DIFF
--- a/packages/react/src/patterns/F0Form/F0Form.tsx
+++ b/packages/react/src/patterns/F0Form/F0Form.tsx
@@ -694,6 +694,30 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
   const rootError = form.formState.errors.root
   const { isDirty, isSubmitting, errors } = form.formState
 
+  // Track file fields with in-flight uploads. Submission is blocked until the
+  // set empties so a form is never submitted with a file that hasn't finished
+  // uploading (its form value isn't set until the upload completes).
+  const [uploadingFieldIds, setUploadingFieldIds] = useState<Set<string>>(
+    () => new Set()
+  )
+  const registerUploadState = useCallback(
+    (id: string, isUploading: boolean) => {
+      setUploadingFieldIds((prev) => {
+        if (isUploading === prev.has(id)) return prev
+        const next = new Set(prev)
+        if (isUploading) next.add(id)
+        else next.delete(id)
+        return next
+      })
+    },
+    []
+  )
+  const hasPendingUploads = uploadingFieldIds.size > 0
+  // Mirror into a ref so the submit handler can guard against non-button
+  // submits (Enter key, autosubmit) without being re-created every render.
+  const hasPendingUploadsRef = useRef(hasPendingUploads)
+  hasPendingUploadsRef.current = hasPendingUploads
+
   const [actionBarStatus, setActionBarStatus] =
     useState<ActionBarStatus>("idle")
   const [successMessage, setSuccessMessage] = useState<string | undefined>()
@@ -738,6 +762,11 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
 
   // Handle form submission with status flow: idle -> loading -> success -> idle
   const handleSubmit = async (data: TValues) => {
+    // Block submission while any file field still has an upload in flight.
+    // Covers non-button submit paths (Enter key, autosubmit); the visible
+    // submit controls are also disabled via `hasPendingUploads`.
+    if (hasPendingUploadsRef.current) return
+
     if (successTimerRef.current) {
       clearTimeout(successTimerRef.current)
       successTimerRef.current = null
@@ -1071,6 +1100,7 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
       renderCustomField: props.renderCustomField,
       isLoading: isFormLoading,
       useUpload,
+      registerUploadState,
       submitConfig,
     }),
     [
@@ -1080,6 +1110,7 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
       props.renderCustomField,
       isFormLoading,
       useUpload,
+      registerUploadState,
       submitConfig,
     ]
   )
@@ -1185,7 +1216,7 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
             label={submitLabel}
             icon={submitIcon}
             loading={isSubmitting}
-            disabled={hasErrors || isFormLoading}
+            disabled={hasErrors || isFormLoading || hasPendingUploads}
           />
         </div>
       )}
@@ -1227,6 +1258,7 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
             isDirty={isDirty}
             actionBarStatus={actionBarStatus}
             hasErrors={hasErrors}
+            hasPendingUploads={hasPendingUploads}
             errorCount={errorCount}
             resolvedActionBarLabel={resolvedActionBarLabel}
             submitLabel={submitLabel}

--- a/packages/react/src/patterns/F0Form/components/ActionBar.test.tsx
+++ b/packages/react/src/patterns/F0Form/components/ActionBar.test.tsx
@@ -9,6 +9,7 @@ const defaultProps = {
   isDirty: true,
   actionBarStatus: "idle" as const,
   hasErrors: false,
+  hasPendingUploads: false,
   errorCount: 0,
   resolvedActionBarLabel: "You have changes pending to be saved",
   submitLabel: "Save",
@@ -129,6 +130,20 @@ describe("FormActionBar", () => {
       expect(
         screen.queryByRole("button", { name: "Go to previous error" })
       ).not.toBeInTheDocument()
+    })
+
+    it("disables the submit action while an upload is in flight", () => {
+      render(<FormActionBar {...defaultProps} hasPendingUploads={true} />)
+
+      const saveButtons = screen.getAllByRole("button", { name: /save/i })
+      saveButtons.forEach((btn) => expect(btn).toBeDisabled())
+    })
+
+    it("enables the submit action when no upload is in flight", () => {
+      render(<FormActionBar {...defaultProps} hasPendingUploads={false} />)
+
+      const saveButtons = screen.getAllByRole("button", { name: /save/i })
+      saveButtons.forEach((btn) => expect(btn).not.toBeDisabled())
     })
 
     it("calls goToPreviousError when clicking navigation", async () => {

--- a/packages/react/src/patterns/F0Form/components/ActionBar.tsx
+++ b/packages/react/src/patterns/F0Form/components/ActionBar.tsx
@@ -14,6 +14,8 @@ interface FormActionBarProps {
   isDirty: boolean
   actionBarStatus: ActionBarStatus
   hasErrors: boolean
+  /** Whether any file field still has an upload in flight */
+  hasPendingUploads: boolean
   errorCount: number
   resolvedActionBarLabel: string | undefined
   submitLabel: string
@@ -36,6 +38,7 @@ export const FormActionBar = forwardRef<F0ActionBarRef, FormActionBarProps>(
       isDirty,
       actionBarStatus,
       hasErrors,
+      hasPendingUploads,
       errorCount,
       resolvedActionBarLabel,
       submitLabel,
@@ -104,7 +107,7 @@ export const FormActionBar = forwardRef<F0ActionBarRef, FormActionBarProps>(
               label: submitLabel,
               icon: submitIcon,
               onClick: onSubmit,
-              disabled: hasErrors,
+              disabled: hasErrors || hasPendingUploads,
             },
           ]}
           secondaryActions={

--- a/packages/react/src/patterns/F0Form/context.ts
+++ b/packages/react/src/patterns/F0Form/context.ts
@@ -17,6 +17,12 @@ interface F0FormContextValue {
   /** Default upload hook shared across all file fields */
   useUpload?: UseFileUpload
   /**
+   * Registers whether a given file field currently has an upload in progress.
+   * The form aggregates these signals to block submission until every upload
+   * settles. `id` must be stable for the lifetime of the field.
+   */
+  registerUploadState?: (id: string, isUploading: boolean) => void
+  /**
    * Submit configuration for the form.
    */
   submitConfig?: F0FormSubmitConfig

--- a/packages/react/src/patterns/F0Form/fields/file/FileFieldRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/fields/file/FileFieldRenderer.tsx
@@ -206,6 +206,23 @@ export function FileFieldRenderer({
 
   const hasFiles = entries.length > 0
 
+  // An entry with a File but no resolved value (and no error) is still
+  // uploading. Only meaningful when an upload hook is present — without one
+  // the value can never resolve, so we must not block submission forever.
+  const hasPendingUploads =
+    !!resolvedUseUpload &&
+    entries.some((entry) => entry.file && !entry.value && !entry.error)
+
+  // Report this field's upload state up to the form so it can block
+  // submission until every upload settles.
+  const registerUploadState = context?.registerUploadState
+  useEffect(() => {
+    registerUploadState?.(inputId, hasPendingUploads)
+  }, [registerUploadState, inputId, hasPendingUploads])
+  useEffect(() => {
+    return () => registerUploadState?.(inputId, false)
+  }, [registerUploadState, inputId])
+
   // In single mode, hide dropzone once a file entry exists.
   // In multiple mode, hide dropzone if maxFiles limit is reached.
   const isAtLimit =

--- a/packages/react/src/patterns/F0Form/fields/file/FileFieldRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/fields/file/FileFieldRenderer.tsx
@@ -289,56 +289,69 @@ export function FileFieldRenderer({
         return
       }
 
-      // Multiple mode: use functional updater to always read latest entries count.
-      // Validation error is captured via a local variable and scheduled after.
-      let errorMsg: string | null = null
+      // Multiple mode. Validate and build the new entries synchronously, then
+      // apply the error and merge separately. Doing the validation inside the
+      // setEntries updater would rely on React invoking that updater
+      // synchronously (eager state computation) so the captured error could be
+      // read right after — but that is not guaranteed. When the entries update
+      // is batched, the updater runs during render, after the error read, so
+      // the validation error was silently dropped (single mode never hit this
+      // because it sets the error synchronously).
+      const remaining =
+        field.maxFiles != null ? field.maxFiles - entries.length : Infinity
 
-      setEntries((prev) => {
-        const remaining =
-          field.maxFiles != null ? field.maxFiles - prev.length : Infinity
-
-        if (remaining <= 0) {
-          errorMsg = translations.maxFilesReached.replace(
+      if (remaining <= 0) {
+        setValidationError(
+          translations.maxFilesReached.replace(
             "{{maxFiles}}",
             String(field.maxFiles)
           )
-          return prev
-        }
+        )
+        return
+      }
 
-        const filesToProcess = files.slice(0, remaining)
-        if (files.length > remaining) {
-          errorMsg = translations.maxFilesReached.replace(
-            "{{maxFiles}}",
-            String(field.maxFiles)
-          )
-        }
-
-        const newEntries: FileEntry[] = []
-        for (const file of filesToProcess) {
-          const validationMsg = validateFile(file)
-          if (validationMsg) {
-            errorMsg = validationMsg
-            continue
-          }
-          if (!resolvedUseUpload) {
-            console.warn(
-              "[F0Form] No useUpload hook provided. Pass useUpload to <F0Form> or to the file field config."
+      const filesToProcess = files.slice(0, remaining)
+      let errorMsg: string | null =
+        files.length > remaining
+          ? translations.maxFilesReached.replace(
+              "{{maxFiles}}",
+              String(field.maxFiles)
             )
-          }
-          newEntries.push({
-            key: `${file.name}-${file.size}-${Date.now()}-${Math.random()}`,
-            file,
-          })
-        }
-        return [...prev, ...newEntries]
-      })
+          : null
 
-      // Apply captured error after the state update batch
+      const newEntries: FileEntry[] = []
+      for (const file of filesToProcess) {
+        const validationMsg = validateFile(file)
+        if (validationMsg) {
+          errorMsg = validationMsg
+          continue
+        }
+        if (!resolvedUseUpload) {
+          console.warn(
+            "[F0Form] No useUpload hook provided. Pass useUpload to <F0Form> or to the file field config."
+          )
+        }
+        newEntries.push({
+          key: `${file.name}-${file.size}-${Date.now()}-${Math.random()}`,
+          file,
+        })
+      }
+
       if (errorMsg !== null) {
         setValidationError(errorMsg)
       }
+      if (newEntries.length > 0) {
+        setEntries((prev) => [...prev, ...newEntries])
+      }
     },
-    [isMultiple, field.maxFiles, validateFile, resolvedUseUpload, translations]
+    [
+      isMultiple,
+      field.maxFiles,
+      validateFile,
+      resolvedUseUpload,
+      translations,
+      entries.length,
+    ]
   )
 
   const handleDragOver = useCallback(

--- a/packages/react/src/patterns/F0Form/fields/file/FileFieldRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/fields/file/FileFieldRenderer.tsx
@@ -541,7 +541,7 @@ export function FileFieldRenderer({
       {validationError && (
         <div className="-mt-2 flex items-center gap-1">
           <F0Icon icon={AlertCircle} color="critical" />
-          <p className="text-sm font-medium text-f1-foreground-critical">
+          <p className="text-base font-medium text-f1-foreground-critical">
             {validationError}
           </p>
         </div>

--- a/packages/react/src/patterns/F0Form/fields/file/__tests__/FileFieldRenderer.test.tsx
+++ b/packages/react/src/patterns/F0Form/fields/file/__tests__/FileFieldRenderer.test.tsx
@@ -246,6 +246,89 @@ describe("FileFieldRenderer", () => {
     })
   })
 
+  it("disables submit while a file is uploading and re-enables it after", async () => {
+    const onSubmit = vi.fn(async () => ({ success: true }))
+
+    const schema = z.object({
+      file: f0FormField(z.string().min(1), {
+        label: "Document",
+        fieldType: "file",
+      }),
+    })
+
+    render(
+      <F0Form
+        name="test-upload-blocks-submit"
+        schema={schema}
+        defaultValues={{ file: "" }}
+        onSubmit={onSubmit}
+        useUpload={createMockUploadHook({ delay: 50 })}
+        submitConfig={{ label: "Save" }}
+      />
+    )
+
+    const submitButton = screen.getByRole("button", { name: "Save" })
+    // No upload in flight yet — submit is enabled.
+    expect(submitButton).not.toBeDisabled()
+
+    const input = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement
+    await userEvent.upload(input, createFile("test.pdf"))
+
+    // Upload in flight → submit blocked.
+    await waitFor(() => {
+      expect(submitButton).toBeDisabled()
+    })
+
+    // Upload settles → file value resolved and submit re-enabled.
+    await waitFor(() => {
+      expect(screen.getByText("test.pdf")).toBeInTheDocument()
+    })
+    await waitFor(() => {
+      expect(submitButton).not.toBeDisabled()
+    })
+
+    await userEvent.click(submitButton)
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({ file: "signed_test.pdf" })
+      )
+    })
+  })
+
+  it("does not block submit when no upload hook is provided", async () => {
+    const schema = z.object({
+      file: f0FormField(z.string().optional(), {
+        label: "Document",
+        fieldType: "file",
+      }),
+    })
+
+    render(
+      <F0Form
+        name="test-no-hook-submit"
+        schema={schema}
+        defaultValues={{ file: "" }}
+        onSubmit={async () => ({ success: true })}
+        submitConfig={{ label: "Save" }}
+      />
+    )
+
+    const input = document.querySelector(
+      'input[type="file"]'
+    ) as HTMLInputElement
+    await userEvent.upload(input, createFile("nohook.pdf"))
+
+    await waitFor(() => {
+      expect(screen.getByText("nohook.pdf")).toBeInTheDocument()
+    })
+
+    // Without an upload hook the value can never resolve, so submission must
+    // not be blocked indefinitely.
+    expect(screen.getByRole("button", { name: "Save" })).not.toBeDisabled()
+  })
+
   it("shows accepted file types in the dropzone", () => {
     const schema = z.object({
       file: f0FormField(z.string().optional(), {

--- a/packages/react/src/patterns/F0Form/fields/file/__tests__/FileFieldRenderer.test.tsx
+++ b/packages/react/src/patterns/F0Form/fields/file/__tests__/FileFieldRenderer.test.tsx
@@ -392,6 +392,61 @@ describe("FileFieldRenderer", () => {
     })
   })
 
+  it("shows a file-type validation error in multiple mode", async () => {
+    const schema = z.object({
+      files: f0FormField(z.array(z.string()).optional(), {
+        label: "Attachments",
+        fieldType: "file",
+        multiple: true,
+        accept: ["application/pdf", "image"],
+      }),
+    })
+
+    render(
+      <F0Form
+        name="test-multi-type-validation"
+        schema={schema}
+        defaultValues={{ files: [] }}
+        useUpload={createMockUploadHook()}
+        onSubmit={async () => ({ success: true })}
+      />
+    )
+
+    const dropzone = screen.getByRole("button", { name: /drag and drop/i })
+    const makeCsvTransfer = () => ({
+      files: [createFile("data.csv", 1024, "text/csv")],
+      types: ["Files"],
+    })
+
+    // First unsupported drop surfaces the error.
+    fireEvent.dragOver(dropzone, { dataTransfer: makeCsvTransfer() })
+    fireEvent.drop(dropzone, { dataTransfer: makeCsvTransfer() })
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "File type not accepted. Accepted formats: PDF, Images"
+        )
+      ).toBeInTheDocument()
+    })
+
+    // A second unsupported drop must keep surfacing the error. This is the
+    // regression: the message used to be set from inside the setEntries
+    // updater, so once a prior state update was pending the updater ran after
+    // the read and the error was silently dropped on the repeat attempt.
+    fireEvent.dragOver(dropzone, { dataTransfer: makeCsvTransfer() })
+    fireEvent.drop(dropzone, { dataTransfer: makeCsvTransfer() })
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "File type not accepted. Accepted formats: PDF, Images"
+        )
+      ).toBeInTheDocument()
+    })
+
+    // No CSV entry was ever added.
+    expect(screen.queryByText("data.csv")).not.toBeInTheDocument()
+  })
+
   it("shows file size validation error", async () => {
     const schema = z.object({
       file: f0FormField(z.string().optional(), {


### PR DESCRIPTION
## Description

Two related fixes to F0Form file fields. First, when a file field is uploading, the form could still be submitted with a file that hadn't finished uploading (the field's form value is only set once the upload completes); submission is now blocked until all uploads settle. Second, in multiple-file mode the "file type not accepted" validation error was surfaced unreliably — this makes it deterministic, matching single-file behavior.

## Implementation details

- fix: track in-flight uploads per file field via a new `registerUploadState` callback on `F0FormContext`; the form aggregates them into a single `hasPendingUploads` flag

  <details>
  <summary>Why plumb it through context?</summary>

  Upload state previously lived only inside the leaf `FileAttachment` component and never reached the form. A file field derives "pending" from its own entries (an entry with a `File` but no resolved value and no error), gated on an upload hook actually being present so a form configured without `useUpload` is never blocked indefinitely.
  </details>

- fix: disable the default submit button while an upload is in flight
- fix: disable the action-bar primary action while an upload is in flight
- fix: guard `handleSubmit` so non-button submit paths (Enter key, autosubmit) are also blocked

- fix: surface the file-type validation error reliably for multiple-file fields

  <details>
  <summary>Root cause</summary>

  In multiple mode the validation error was assigned inside the `setEntries` updater and read synchronously right after. That relied on React invoking the updater eagerly (eager state computation), which is skipped when the fiber already has a pending update (e.g. the `setValidationError(null)` at the top of `addFiles`, or any prior state change). In those cases the updater ran during render — after the read — so the error was silently dropped. Single-file mode set the error synchronously and was unaffected, which is why the cover-image field rejected an unsupported file but the attachments field did not. Fixed by validating and building entries synchronously and setting the error outside the updater; the updater now only performs the pure merge.
  </details>

- test: cover submit disabling/re-enabling during upload, the no-upload-hook case, the action-bar disabled state, and multiple-file type validation (including the repeat-attempt regression)