### PR TITLE
fix(value-display): even vertical padding on avatar table cells

### DIFF
--- a/packages/react/src/ui/value-display/const.ts
+++ b/packages/react/src/ui/value-display/const.ts
@@ -1,9 +1,15 @@
 /**
  * This is a list of class names that are used to style the value display components in the table.
  * The base case is that the value display can not be centered manually as some value can use a lot of height (e.g. longText), and we want to center the texts, not wrapper.
+ *
+ * `text` gets a small top nudge so single-line text reads as optically centered
+ * within the top-aligned cell (glyphs sit high in their line box).
+ * Avatars are fixed-size boxes that the cell padding already centers, so they must
+ * NOT get that nudge — the extra top padding pushes them down and makes the top/bottom
+ * gaps uneven, which is especially visible on square (team) avatars.
  */
 export const tableDisplayClassNames = {
   text: "pt-0.5",
-  avatar: "pt-0.5",
-  avatarList: "pt-0.5",
+  avatar: "",
+  avatarList: "",
 }

--- a/packages/react/src/ui/value-display/const.ts
+++ b/packages/react/src/ui/value-display/const.ts
@@ -1,15 +1,17 @@
 /**
- * This is a list of class names that are used to style the value display components in the table.
- * The base case is that the value display can not be centered manually as some value can use a lot of height (e.g. longText), and we want to center the texts, not wrapper.
+ * Class names applied to value-display content when rendered inside a table cell.
  *
- * `text` gets a small top nudge so single-line text reads as optically centered
- * within the top-aligned cell (glyphs sit high in their line box).
- * Avatars are fixed-size boxes that the cell padding already centers, so they must
- * NOT get that nudge — the extra top padding pushes them down and makes the top/bottom
- * gaps uneven, which is especially visible on square (team) avatars.
+ * Table cells are `align-top` so that tall, multi-line values (e.g. longText) align
+ * to the top of the row instead of floating in its vertical center. Single-line
+ * values must NOT receive an extra top padding: a per-type nudge (previously
+ * `pt-0.5` on text) makes that cell taller than its avatar-only siblings, so the
+ * row grows and the shorter cells end up with uneven top/bottom gaps — most visible
+ * on square (team) avatars. Keeping every single-line type flush with the cell
+ * padding makes all of them the same height, so the row is symmetric while
+ * multi-line values still top-align.
  */
 export const tableDisplayClassNames = {
-  text: "pt-0.5",
+  text: "",
   avatar: "",
   avatarList: "",
 }


### PR DESCRIPTION
## Context

FCT-59074 — In the Teams hierarchy table, the vertical spacing around a team avatar is uneven (the gap above differs from the gap below). It looks fine on People. Reported against square team avatars, where any asymmetry is obvious; the round person avatars hide it.

Root of the whole thing: value-display table cells are `align-top`, and single-line cell types were given a `pt-0.5` optical nudge. That nudge interacts badly with fixed-size avatar boxes and with sibling cells in the same row. Fixed in two iterations, each verified by measuring the rendered DOM in Storybook.

## Iteration 1 — avatars shouldn't get the text nudge

`tableDisplayClassNames.avatar` / `.avatarList` were `pt-0.5`. That value is an optical nudge for **text** (glyphs sit high in their line box, so a 2px top padding centers them in the top-aligned cell). An avatar is a fixed-size box that the cell's `py-2` already centers, so the extra top padding just pushes it down.

Measured (short row, real f0 render):

| | top gap | bottom gap |
|---|---|---|
| team avatar, before | 10px | 8px |
| team avatar, after i1 | 8px | 8.5px |

→ set `avatar` / `avatarList` to `""`.

## Iteration 2 — the row grows because of the *other* cells

With avatars un-nudged but `text` still `pt-0.5`, a row that mixes an avatar cell (20px) with a text cell (20px + 2px nudge = 22px) grows to 22px content. The taller text cell drives the row height, and the shorter avatar cell — being `align-top` — ends up with the extra 2px **below** it. Same 2px asymmetry, now bottom-heavy:

| | top gap | bottom gap | row |
|---|---|---|---|
| team avatar, after i1 | 8px | 10px | 38px |
| team avatar, after i2 | 8px | 8px | 36px |

→ drop the nudge from **every** single-line display type (`text` too), so they all share one height and the row is symmetric.

## Why not just change the cell to `align-middle`

Considered and rejected. `align-middle` centers short content nicely in tight rows, but in rows with tall/multi-line content (e.g. a `longText` column) it also centers the avatar — so the avatar floats to the vertical middle of the row instead of aligning with the first line of the adjacent text. Keeping `align-top` + equal-height single-liners fixes the reported case without regressing mixed-height tables.

Verified: in a `longText` table the avatar top-aligns with the text's first line (both at 8px from the row top); in a tight table every cell is 8px / 8px.

## Change

`packages/react/src/ui/value-display/const.ts` — all single-line display types now render flush with the cell padding (no top nudge):

```ts
text: "",
avatar: "",
avatarList: "",
```

### Before
 
<img width="549" height="87" alt="image-20260713-134709" src="https://github.com/user-attachments/assets/cee8858e-1970-4eed-99ac-1212abe5d027" />

### After

<img width="445" height="83" alt="Screenshot 2026-07-29 at 12 37 02" src="https://github.com/user-attachments/assets/03d14da6-cd1b-49cc-b565-aca5b622a3e2" />

## Verification

- Measured before/after in Storybook (BasicTableView = tight rows, RendererTypes = mixed/`longText` rows).
- value-display unit tests: 76/76 pass.
- oxfmt + oxlint clean; lefthook green.
- ⚠️ Chromatic will show a 2px vertical shift on single-line cells (avatars now symmetric; text sits 2px higher / geometrically centered) across tables — expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)