### PR TITLE
fix(F0Form): keep staged uploads when applying an initialFiles pool

### DIFF
--- a/packages/react/src/patterns/F0Form/fields/file/FileFieldRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/fields/file/FileFieldRenderer.tsx
@@ -213,7 +213,9 @@ export function FileFieldRenderer({
         initialFilesPool,
         formField.value,
         isMultiple
-      ).filter((entry) => !runtimeValues.has(entry.value))
+      ).filter(
+        (entry) => entry.value == null || !runtimeValues.has(entry.value)
+      )
       return [...seededEntries, ...runtimeEntries]
     })
   }, [initialFilesPool, formField.value, isMultiple])

--- a/packages/react/src/patterns/F0Form/fields/file/FileFieldRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/fields/file/FileFieldRenderer.tsx
@@ -196,9 +196,26 @@ export function FileFieldRenderer({
     if (!hasFormValue) return
 
     initialFilesApplied.current = true
-    setEntries(
-      resolveInitialEntries(initialFilesPool, formField.value, isMultiple)
-    )
+    setEntries((prev) => {
+      // Preserve files the user added at runtime (those backed by a File). The
+      // one-time pool sync only seeds pre-existing files, so it must never drop
+      // an in-flight or just-uploaded entry whose value isn't part of the pool
+      // (a fresh upload's value never is). Without this, uploading the first
+      // file into a field whose pool is empty (or resolves after the value is
+      // populated) wiped that file from the list.
+      const runtimeEntries = prev.filter((entry) => entry.file)
+      const runtimeValues = new Set(
+        runtimeEntries
+          .map((entry) => entry.value)
+          .filter((value): value is string => value != null)
+      )
+      const seededEntries = resolveInitialEntries(
+        initialFilesPool,
+        formField.value,
+        isMultiple
+      ).filter((entry) => !runtimeValues.has(entry.value))
+      return [...seededEntries, ...runtimeEntries]
+    })
   }, [initialFilesPool, formField.value, isMultiple])
   const [validationError, setValidationError] = useState<string | null>(null)
 

--- a/packages/react/src/patterns/F0Form/fields/file/__tests__/FileFieldRenderer.test.tsx
+++ b/packages/react/src/patterns/F0Form/fields/file/__tests__/FileFieldRenderer.test.tsx
@@ -1012,4 +1012,34 @@ describe("FileFieldRenderer — async initialFiles", () => {
     // Server file NOT injected since user already added a file
     expect(screen.queryByText("server_file.pdf")).not.toBeInTheDocument()
   })
+
+  it("keeps a user-uploaded file when the initialFiles pool is empty (multiple)", async () => {
+    // Deterministic repro: an empty pool resolves before the user interacts, so
+    // the one-time sync runs when the first upload populates the form value. It
+    // must not drop that upload just because its value isn't in the (empty) pool.
+    const initialFiles = () =>
+      new Promise<InitialFile[]>((resolve) => setTimeout(() => resolve([]), 10))
+
+    render(
+      <AsyncInitialFilesForm
+        defaultValues={{ document: "", attachments: [] }}
+        initialFiles={initialFiles}
+      />
+    )
+
+    // Let the (empty) pool resolve so the sync's loading guard clears.
+    await vi.advanceTimersByTimeAsync(20)
+
+    // Upload into the multiple "attachments" field (second file input).
+    const inputs = document.querySelectorAll('input[type="file"]')
+    await userEvent.upload(
+      inputs[1] as HTMLInputElement,
+      createFile("added.pdf")
+    )
+
+    // Let the upload complete and the one-time initialFiles sync run.
+    await vi.advanceTimersByTimeAsync(20)
+
+    expect(screen.getByText("added.pdf")).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Problem

The `F0Form` file field runs a one-time effect that seeds entries from the `initialFiles` pool once the form value is populated (to handle the async `defaultValues` race). That effect **replaced** the whole entry list via `resolveInitialEntries`, which keeps only form values present in the pool.

A freshly uploaded file's value is never in `initialFiles`. So when the **first** upload populated the form value, this sync ran and wiped the just-uploaded file from the list. It reproduces deterministically when a field's pool is **empty** (or resolves after the form value is set): the file uploads successfully but disappears from the field.

This surfaced in Factorial task edit forms (FCT-58010): attaching a file to a task with no existing attachments showed nothing, even though the upload succeeded.

## Fix

When the one-time sync runs, preserve entries the user added at runtime (those backed by a `File`) and **merge** them with the seeded pre-existing entries instead of replacing the list. A fresh upload's value is never in the pool, so it can only ever be preserved via its runtime `File` entry.

## Test

Adds a regression test: an empty `initialFiles` pool resolves, the user uploads into a multiple-file field, and the uploaded file must remain. Verified it fails on `main` and passes with the fix. All 25 file-field tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)