### PR TITLE
fix(F0Form): remove 2px horizontal inset on section headers

### DIFF
--- a/packages/react/src/patterns/F0Form/components/F0FormSection.tsx
+++ b/packages/react/src/patterns/F0Form/components/F0FormSection.tsx
@@ -289,7 +289,7 @@ export function F0FormSection<TSchema extends F0FormSchema>({
           <div
             className={cn(
               "flex items-start justify-between py-5",
-              "[&>div]:px-0.5 [&>div]:mx-0 [&>div]:border-0"
+              "[&>div]:px-0 [&>div]:mx-0 [&>div]:border-0"
             )}
           >
             <SectionHeader title={title} description={description ?? ""} />

--- a/packages/react/src/patterns/F0Form/components/SectionRenderer.tsx
+++ b/packages/react/src/patterns/F0Form/components/SectionRenderer.tsx
@@ -54,7 +54,7 @@ export function SectionRenderer({ section }: SectionRendererProps) {
         className={cn(
           "flex items-start justify-between py-5",
           withInset && "px-5",
-          "[&>div]:px-0.5 [&>div]:mx-0 [&>div]:border-0"
+          "[&>div]:px-0 [&>div]:mx-0 [&>div]:border-0"
         )}
       >
         <SectionHeader title={title} description={description ?? ""} />


### PR DESCRIPTION
## What

F0Form section headers (title + description) sit 2px inboard of the fields below them. This aligns them flush.

## Why

Both section renderers embed `SectionHeader` and cancel its standalone styling with an arbitrary-variant override:

```
"[&>div]:px-0.5 [&>div]:mx-0 [&>div]:border-0"
```

`mx-0` and `border-0` zero out cleanly, but `px-0.5` resolves to `0.125rem` (2px) rather than 0, so the header text ends up 2px to the right of the field column.

## How

`px-0.5` -> `px-0` in the two call sites:

- `packages/react/src/patterns/F0Form/components/SectionRenderer.tsx`
- `packages/react/src/patterns/F0Form/components/F0FormSection.tsx`

The class is kept rather than deleted on purpose: removing it would let `SectionHeader`'s own `px-6` apply, producing a 24px inset. `py-5`, the `withInset` wrapper `px-5`, and `SectionHeader` itself are untouched, so non-form consumers are unaffected.

## Notes

Two-line styling change, no behavioral surface, no test changes. Lint, `oxfmt --check`, and `tsc --noEmit` pass on `packages/react`.

Follow-up worth considering: give `SectionHeader` a first-class embedded/unpadded variant so consumers stop reaching in with `[&>div]:` overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)