### PR TITLE
fix(react): detect breaking API changes behind array props

### DIFF
--- a/packages/react/.scripts/__tests__/check-api-surface.test.ts
+++ b/packages/react/.scripts/__tests__/check-api-surface.test.ts
@@ -414,6 +414,86 @@ describe("check-api-surface — unions and intersections", () => {
   })
 })
 
+describe("check-api-surface — arrays are unwrapped, not opaque", () => {
+  it("flags a prop removed from an array element type", () => {
+    const diff = f0(
+      `
+      export declare type Row = { id: string; label: string };
+      export declare const Grid: (props: { rows: Row[] }) => unknown;
+      `,
+      `
+      export declare type Row = { id: string };
+      export declare const Grid: (props: { rows: Row[] }) => unknown;
+      `
+    )
+    const changed = diff.breaking.find((b) => b.name === "Grid")
+    expect(changed?.kind).toBe("changed")
+    expect(changed?.reasons?.some((r) => r.includes("label"))).toBe(true)
+  })
+
+  it("flags a required prop added to an array element type", () => {
+    const diff = f0(
+      `export declare const Grid: (props: { rows: ReadonlyArray<{ id: string }> }) => unknown;`,
+      `export declare const Grid: (props: { rows: ReadonlyArray<{ id: string; tenant: string }> }) => unknown;`
+    )
+    const changed = diff.breaking.find((b) => b.name === "Grid")
+    expect(changed?.reasons?.some((r) => /required.*tenant/i.test(r))).toBe(
+      true
+    )
+  })
+
+  it("treats an optional prop added to an array element type as safe", () => {
+    const diff = f0(
+      `export declare const Grid: (props: { rows: Array<{ id: string }> }) => unknown;`,
+      `export declare const Grid: (props: { rows: Array<{ id: string; hint?: string }> }) => unknown;`
+    )
+    expect(diff.breaking).toHaveLength(0)
+  })
+
+  it("treats an unchanged array-typed prop as no change", () => {
+    const surface = `
+      export declare type Row = { id: string; label: string };
+      export declare const Grid: (props: { rows: Row[] }) => unknown;
+    `
+    expect(f0(surface, surface).breaking).toHaveLength(0)
+  })
+
+  it("flags a scalar prop widened to an array (T → T[])", () => {
+    const diff = f0(
+      `export declare type Row = { tag: string };`,
+      `export declare type Row = { tag: string[] };`
+    )
+    const changed = diff.breaking.find((b) => b.name === "Row")
+    expect(changed?.kind).toBe("changed")
+    expect(changed?.reasons?.some((r) => /tag/.test(r))).toBe(true)
+  })
+
+  it("catches a removed prop nested behind an array of a discriminated union (the OneDataCollection `visualizations` shape)", () => {
+    // Mirrors how `headerGroupLabels` reaches the public surface: only through
+    // `OneDataCollection` props → `visualizations` array → a `"table"` variant
+    // → `options` → the prop. Opaque-array handling hid its removal entirely.
+    const surface = (tableOptions: string) => `
+      export declare type TableOptions = ${tableOptions};
+      export declare type CardOptions = { pageSize?: number };
+      export declare type Visualization =
+        | { type: "table"; options: TableOptions }
+        | { type: "card"; options: CardOptions };
+      export declare const Collection: (props: {
+        visualizations?: ReadonlyArray<Visualization>;
+      }) => unknown;
+    `
+    const diff = f0(
+      surface("{ id: string; headerGroupLabels?: Record<string, string> }"),
+      surface("{ id: string; headerGroups?: Record<string, string> }")
+    )
+    const changed = diff.breaking.find((b) => b.name === "Collection")
+    expect(changed?.kind).toBe("changed")
+    expect(
+      changed?.reasons?.some((r) => r.includes("headerGroupLabels"))
+    ).toBe(true)
+  })
+})
+
 describe("check-api-surface — translations are summarized, not listed per export", () => {
   // The real translations dictionary is large; the structural fallback for
   // the inlined `defaultTranslations` object requires that scale, so the

--- a/packages/react/.scripts/check-api-surface.ts
+++ b/packages/react/.scripts/check-api-surface.ts
@@ -42,6 +42,13 @@
  * a change to a shared base, the reshaped variants are aligned and compared
  * structurally so a real breaking prop change is still caught.
  *
+ * Array and tuple types are unwrapped to their element type and compared
+ * structurally, wrapped in an `array` marker so a `T` ↔ `T[]` change still
+ * reads as a shape change. Without this, an array-typed prop collapses to an
+ * opaque `T[]` string and any breaking change to a type reachable *only*
+ * through it — e.g. the visualization options behind OneDataCollection's
+ * `visualizations` array — would be hidden.
+ *
  * The shared translations dictionary (`TranslationsType` / `TranslationShape`
  * / `TranslationKey`, plus the inlined `defaultTranslations` object) is
  * recognized and compared by its key paths instead of structurally. That
@@ -84,9 +91,14 @@ export const ENTRIES = ["f0", "experimental", "ai", "component-status"] as const
 export type Entry = (typeof ENTRIES)[number]
 
 /** How deep to expand object/signature types before treating them as opaque
- * leaves. Bounds the work while still reaching component props
- * (export → call signature → props object → member). */
-const MAX_DEPTH = 4
+ * leaves. Bounds the work while still reaching props nested a few containers
+ * deep — the deepest chain we guard is OneDataCollection's
+ * export → call signature → props object → `visualizations` array → element →
+ * visualization variant → `options` → member. Arrays are unwrapped (see
+ * {@link buildApiItem}) and each container costs one level, so this must clear
+ * that chain. Raising it expands more of every export's type tree, so keep it
+ * to the shallowest value that reaches the props we care about. */
+const MAX_DEPTH = 7
 
 /**
  * A normalized, structural representation of a type used for comparison.
@@ -94,6 +106,7 @@ const MAX_DEPTH = 4
  *    of object shapes are flattened into this (the checker merges members).
  *  - `callable`: a function/component, compared signature by signature.
  *  - `union`: a union, compared variant by variant (pairwise by position).
+ *  - `array`: an array/tuple, compared by its unwrapped element type.
  *  - `translations`: the shared translations dictionary, compared by its
  *    dot-separated key paths and summarized once per analysis.
  *  - `opaque`: anything else (primitive, external type, non-object
@@ -116,6 +129,7 @@ export type ApiItem =
       }>
     }
   | { k: "union"; members: ApiItem[] }
+  | { k: "array"; element: ApiItem }
   | { k: "translations"; keys: string[] }
   | { k: "opaque"; text: string }
 
@@ -645,6 +659,34 @@ function buildApiItem(
   const props = type.getProperties()
   const indexInfos = checker.getIndexInfosOfType(type)
   const isObjectLike = props.length > 0 || indexInfos.length > 0
+
+  // Array/tuple types are lib (external) objects that would otherwise collapse
+  // to an opaque `T[]` string, hiding breaking changes to their element's
+  // shape — e.g. a prop removed from a type nested inside OneDataCollection's
+  // `visualizations` array. Unwrap the numeric-index element type and compare
+  // it structurally; the `array` wrapper is kept so a `T` ↔ `T[]` change still
+  // reads as a shape change. Only lib arrays are unwrapped here — a local
+  // object type carrying a numeric index signature still goes through the
+  // object branch below, so its `index` string is compared as before.
+  if (isObjectType && isExternal(type, dirAbsolute)) {
+    const elementType = indexInfos.find(
+      (info) => !!(info.keyType.flags & ts.TypeFlags.Number)
+    )?.type
+    if (elementType) {
+      const next = new Set(visited).add(type)
+      return {
+        k: "array",
+        element: buildApiItem(
+          elementType,
+          checker,
+          dirAbsolute,
+          depth - 1,
+          next
+        ),
+      }
+    }
+  }
+
   if (isObjectType && isObjectLike && !isExternal(type, dirAbsolute)) {
     const next = new Set(visited).add(type)
     const members: Record<
@@ -831,6 +873,8 @@ export function itemSignature(item: ApiItem): string {
       return `T:${item.keys.join(",")}`
     case "union":
       return `U:[${item.members.map(itemSignature).sort().join("|")}]`
+    case "array":
+      return `A:${itemSignature(item.element)}`
     case "callable":
       return `C:[${item.sigs
         .map(
@@ -898,6 +942,12 @@ function classifyItem(
     return before.text !== after.text
       ? [`${path || "type"} changed: \`${before.text}\` → \`${after.text}\``]
       : []
+  }
+
+  if (before.k === "array" && after.k === "array") {
+    // Same array-ness on both sides: the delta is entirely in the element
+    // shape. (A `T` ↔ `T[]` change is caught by the kind mismatch above.)
+    return classifyItem(before.element, after.element, at(path, "[]"), tx)
   }
 
   if (before.k === "union" && after.k === "union") {


### PR DESCRIPTION
## Description

The public-API breaking-change checker (`.scripts/check-api-surface.ts`) missed a real breaking change on #4884: the removal of the `headerGroupLabels` table option went unflagged, and the bot posted "✅ No breaking public API changes" for a PR that is a deliberate major break. The prop is only reachable through `OneDataCollection` props → the `visualizations` array → a visualization variant → its `options`, and the checker both treated arrays as opaque `T[]` strings and capped structural expansion at depth 4 — so anything nested behind an array-typed prop was invisible. This teaches the checker to look inside arrays and reach a few containers deeper.

## Implementation details

- fix: unwrap array/tuple element types and compare them structurally instead of collapsing to an opaque `T[]` string

  <details>
  <summary>Why?</summary>

  Arrays are lib (external) types, so `buildApiItem` returned an opaque string and never inspected the element. A new `array` `ApiItem` kind now carries the unwrapped element so its shape is compared member-by-member. The wrapper is preserved (not flattened to the element) so a `T` ↔ `T[]` change still reads as a shape change rather than looking identical.
  </details>

- fix: raise `MAX_DEPTH` from 4 to 7 so props nested a few containers deep are reached

  <details>
  <summary>Why?</summary>

  The deepest chain we guard is `OneDataCollection` export → call signature → props object → `visualizations` array → element → visualization variant → `options` → member. Each container (including the unwrapped array) costs one expansion level, so depth 4 stopped short of the member. This expands more of every export's type tree, so the value is kept to the shallowest one that reaches the props we care about; it's the dial to back off if CI time or spurious leaf diffs regress.
  </details>

- test: add cases for a prop removed/added inside an array element, an optional add inside an array (safe), an unchanged array (no-op), a `T → T[]` widening, and the exact `OneDataCollection` `visualizations` shape that motivated the change
