### PR TITLE
fix(F0Form): guard post-unmount setState from submit timers

### DIFF
--- a/packages/react/src/patterns/F0Form/F0Form.tsx
+++ b/packages/react/src/patterns/F0Form/F0Form.tsx
@@ -725,6 +725,14 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
   const autosubmitTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const actionBarRef = useRef<F0ActionBarRef | null>(null)
 
+  // Tracks whether the component is still mounted. Guards state updates that
+  // are reached through an async path (`await onSubmit(...)`) or a timer
+  // callback: if the form unmounts while a submit is in flight, the unmount
+  // cleanup below has already run — a timer scheduled *after* the await would
+  // never be captured/cleared, and its callback (or the post-await setState)
+  // would run against a torn-down tree. See the unmount effect that flips this.
+  const isMountedRef = useRef(true)
+
   /**
    * Snapshot of the focused input element + caret position taken before a
    * non-button submit (Enter key or autosubmit debounce). Restored after the
@@ -784,6 +792,11 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
     }
     const result = await onSubmit(cleanedData)
 
+    // The form may have unmounted while `onSubmit` was in flight. The unmount
+    // cleanup has already run, so any state update here — or a timer scheduled
+    // below — would leak past teardown. Bail out.
+    if (!isMountedRef.current) return
+
     if (result.success) {
       form.reset(form.getValues())
       resetErrorNavigation()
@@ -791,6 +804,7 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
       setActionBarStatus("success")
 
       successTimerRef.current = setTimeout(() => {
+        if (!isMountedRef.current) return
         setActionBarStatus("idle")
         setSuccessMessage(undefined)
         successTimerRef.current = null
@@ -812,11 +826,14 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
 
   useEffect(() => {
     return () => {
+      isMountedRef.current = false
       if (successTimerRef.current) {
         clearTimeout(successTimerRef.current)
+        successTimerRef.current = null
       }
       if (autosubmitTimerRef.current) {
         clearTimeout(autosubmitTimerRef.current)
+        autosubmitTimerRef.current = null
       }
     }
   }, [])
@@ -917,6 +934,7 @@ function F0FormSingleSchema<TSchema extends F0FormSchema>(
       }
       autosubmitTimerRef.current = setTimeout(() => {
         autosubmitTimerRef.current = null
+        if (!isMountedRef.current) return
         // Re-check dirtiness at fire time (RHF's `isDirty` has settled by now,
         // unlike inside the synchronous watch callback): skip a save when the
         // form is back to its last-saved state — e.g. a row was added then

--- a/packages/react/src/patterns/F0Form/__tests__/F0FormUnmountCleanup.test.tsx
+++ b/packages/react/src/patterns/F0Form/__tests__/F0FormUnmountCleanup.test.tsx
@@ -1,0 +1,167 @@
+import {
+  zeroRender as render,
+  screen,
+  waitFor,
+  act,
+} from "@/testing/test-utils"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { z } from "zod"
+import userEvent from "@testing-library/user-event"
+
+import { F0Form } from "../F0Form"
+import { f0FormField } from "../f0Schema"
+
+const formSchema = z.object({
+  name: f0FormField(z.string().min(1), { label: "Name" }),
+})
+
+const actionBarConfig = {
+  type: "action-bar" as const,
+  discardable: true,
+}
+
+async function makeFormDirtyAndSubmit(
+  user: ReturnType<typeof userEvent.setup>
+) {
+  const input = screen.getByLabelText("Name")
+  await user.clear(input)
+  await user.type(input, "updated")
+
+  await waitFor(() => {
+    expect(
+      screen.getByText("You have changes pending to be saved")
+    ).toBeInTheDocument()
+  })
+
+  const submitButtons = screen.getAllByText("Submit")
+  await user.click(submitButtons[0])
+}
+
+/**
+ * Regression coverage for a post-unmount setState leak.
+ *
+ * `handleSubmit` schedules the success timer *after* `await onSubmit(...)`. If
+ * the form unmounts while that submit is in flight, the unmount cleanup has
+ * already run (with `successTimerRef.current === null`, since the timer isn't
+ * scheduled yet). Without a mounted-guard the resolved promise would go on to
+ * schedule a timer that nothing clears — it fires after the test env is torn
+ * down and calls a state setter, surfacing in CI as a stray
+ * "ReferenceError: window is not defined" attributed to an unrelated test.
+ */
+describe("F0Form unmount cleanup", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("does not schedule the success timer when unmounted mid-submit", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    let resolveSubmit: (value: { success: true }) => void
+    const onSubmit = vi.fn(
+      () =>
+        new Promise<{ success: true }>((resolve) => {
+          resolveSubmit = resolve
+        })
+    )
+
+    const { unmount } = render(
+      <F0Form
+        name="unmount-mid-submit-test"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+        submitConfig={actionBarConfig}
+      />
+    )
+
+    await makeFormDirtyAndSubmit(user)
+
+    // Submit is in flight; the success timer has not been scheduled yet.
+    await waitFor(() => {
+      expect(screen.getByText("Saving...")).toBeInTheDocument()
+    })
+
+    unmount()
+
+    // Resolving after unmount must NOT schedule a (leaked) success timer.
+    const timersBeforeResolve = vi.getTimerCount()
+    await act(async () => {
+      resolveSubmit!({ success: true })
+    })
+    expect(vi.getTimerCount()).toBe(timersBeforeResolve)
+
+    // Advancing past the success duration must not touch the torn-down tree.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+    expect(errorSpy).not.toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+
+  it("clears a pending success timer on unmount", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    const { unmount } = render(
+      <F0Form
+        name="unmount-success-timer-test"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+        submitConfig={actionBarConfig}
+      />
+    )
+
+    await makeFormDirtyAndSubmit(user)
+
+    // Success timer is now pending (the "saved" message is showing).
+    await waitFor(() => {
+      expect(
+        screen.getByText("Your changes have been saved")
+      ).toBeInTheDocument()
+    })
+
+    unmount()
+
+    // The pending timer must be gone — nothing fires after teardown.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+    act(() => {
+      vi.advanceTimersByTime(5000)
+    })
+    expect(errorSpy).not.toHaveBeenCalled()
+    errorSpy.mockRestore()
+  })
+
+  it("clears a pending autosubmit timer on unmount", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    const onSubmit = vi.fn().mockResolvedValue({ success: true })
+
+    const { unmount } = render(
+      <F0Form
+        name="unmount-autosubmit-timer-test"
+        schema={formSchema}
+        defaultValues={{ name: "initial" }}
+        onSubmit={onSubmit}
+        submitConfig={{ type: "autosubmit" as const, delay: 800 }}
+      />
+    )
+
+    const input = screen.getByLabelText("Name")
+    await user.clear(input)
+    await user.type(input, "updated")
+
+    // Autosubmit timer is pending but has not fired yet.
+    unmount()
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+
+    // The debounced submit must never run after unmount.
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Description

Fixes a post-unmount `setState` leak in `F0Form` that intermittently fails the React "Unit Tests" CI job even when all tests pass. `handleSubmit` schedules the success timer *after* `await onSubmit(...)`, so unmounting while a submit is in flight leaves the unmount cleanup unable to clear a timer created after it ran — the stray timer fires after the jsdom environment is torn down and calls a state setter, surfacing as a `ReferenceError: window is not defined` unhandled error that Vitest attributes to whatever unrelated test was running (e.g. seen blocking #4899).

## Implementation details

- fix: add an `isMountedRef` guard on every `setState` reached through an async (`await onSubmit`) or timer path, so a submit that resolves after unmount bails out instead of scheduling/running a leaked timer

  <details>
  <summary>Why the existing ref cleanup wasn't enough</summary>

  The unmount effect cleared `successTimerRef.current` / `autosubmitTimerRef.current`, but the success timer is created *after* the awaited `onSubmit` resolves. When the form unmounts mid-submit, cleanup runs while the ref is still `null`, so the timer scheduled once the promise settles is never captured or cleared. Guarding the post-await path (and each timer callback) with `isMountedRef` is what actually stops the leak.
  </details>

- chore: null both timer refs when cleared in the unmount effect
- test: add `F0FormUnmountCleanup` covering unmount-mid-submit (asserts no leaked timer is scheduled), plus pending success/autosubmit timers cleared on unmount

## Verification

- Full `@factorialco/f0-react` suite: 4391 passed, 14 skipped — no "Unhandled Errors" section
- New test fails without the fix (`expected 2 to be 1` — the leaked timer) and passes with it
- `tsc --noEmit` and `oxlint` clean