### PR TITLE
feat(F0MeetingCard): add experimental component

### DIFF
--- a/packages/react/.storybook/main.ts
+++ b/packages/react/.storybook/main.ts
@@ -68,6 +68,10 @@ const config: StorybookConfig = {
       titlePrefix: "Components",
     },
     {
+      directory: "../src/experimental/F0MeetingCard",
+      titlePrefix: "Components",
+    },
+    {
       directory: "../src/experimental/F0ProgressSeries",
       titlePrefix: "Components",
     },

--- a/packages/react/src/experimental/F0MeetingCard/F0MeetingCard.tsx
+++ b/packages/react/src/experimental/F0MeetingCard/F0MeetingCard.tsx
@@ -163,11 +163,7 @@ const F0MeetingCardBase = forwardRef<HTMLDivElement, F0MeetingCardProps>(
           />
         ))}
         {showsJoin && join && (
-          <MeetingJoinButton
-            join={join}
-            disabled={joinDisabled}
-            compact={compact}
-          />
+          <MeetingJoinButton join={join} disabled={joinDisabled} />
         )}
       </>
     )

--- a/packages/react/src/experimental/F0MeetingCard/F0MeetingCard.tsx
+++ b/packages/react/src/experimental/F0MeetingCard/F0MeetingCard.tsx
@@ -1,0 +1,279 @@
+import { forwardRef } from "react"
+
+import { F0Button } from "@/components/F0Button"
+import { withDataTestId } from "@/lib/data-testid"
+import { experimentalComponent } from "@/lib/experimental"
+import { useI18n } from "@/lib/providers/i18n"
+import { withSkeleton } from "@/lib/skeleton"
+import { cn } from "@/lib/utils"
+import { Card } from "@/ui/Card"
+import { Skeleton } from "@/ui/skeleton"
+import { Text } from "@/ui/Text"
+
+import { MeetingAttendees } from "./components/MeetingAttendees"
+import { MeetingJoinButton } from "./components/MeetingJoinButton"
+import { MeetingStatusTag } from "./components/MeetingStatusTag"
+import { MeetingSummary } from "./components/MeetingSummary"
+import { useMeetingLabels } from "./hooks/useMeetingLabels"
+import type { F0MeetingCardProps } from "./types"
+import {
+  DEFAULT_MAX_AVATARS,
+  hasStatusTag,
+  isJoinRelevant,
+  isWithinJoinWindow,
+  resolveAttendeesDisplay,
+  resolveRelevantCount,
+} from "./utils"
+
+const F0MeetingCardBase = forwardRef<HTMLDivElement, F0MeetingCardProps>(
+  function F0MeetingCard(
+    {
+      state,
+      title,
+      startsAt,
+      endsAt,
+      now,
+      attendees = [],
+      invitedCount,
+      presentCount,
+      attendeesDisplay = "auto",
+      maxAvatars = DEFAULT_MAX_AVATARS,
+      summary,
+      join,
+      secondaryActions,
+      compact = false,
+    },
+    ref
+  ) {
+    const { meetingCard } = useI18n()
+    // Resolved once per render rather than on a timer: the card is a pure
+    // function of its props, and the consumer already re-renders as the
+    // meeting's real state changes.
+    const reference = now ?? new Date()
+
+    const relevantCount = resolveRelevantCount({
+      state,
+      attendees,
+      invitedCount,
+      presentCount,
+    })
+
+    const {
+      leadLabel,
+      timeLabel,
+      durationLabel,
+      countdownLabel,
+      attendeesLabel,
+    } = useMeetingLabels({
+      state,
+      startsAt,
+      endsAt,
+      now: reference,
+      windowMinutes: join?.windowMinutes,
+      invitedCount: relevantCount,
+      presentCount,
+    })
+
+    const display = resolveAttendeesDisplay(attendeesDisplay, state)
+    const showsAvatars = display === "avatars" && attendees.length > 0
+    const countLabel = display === "count" ? attendeesLabel : undefined
+
+    // A running meeting with no title of its own says what it is instead.
+    const headline =
+      title ??
+      (state === "inProgress" ? meetingCard.inProgressTitle : undefined)
+    const headlineCarriesState = !title && state === "inProgress"
+
+    const metaSegments = compact
+      ? [
+          // No footer band in compact, so the countdown has to ride along the
+          // headline as text. The clock time is dropped while the meeting runs —
+          // "started 4 mins ago" is the useful fact then, not when it began.
+          countdownLabel ?? leadLabel,
+          state === "inProgress" ? undefined : timeLabel,
+          countLabel,
+        ].filter(Boolean)
+      : [leadLabel, timeLabel, durationLabel, countLabel].filter(Boolean)
+
+    const showsJoin = isJoinRelevant(state) && !!join
+    const joinDisabled =
+      join?.disabled ??
+      !isWithinJoinWindow({
+        state,
+        startsAt,
+        now: reference,
+        windowMinutes: join?.windowMinutes,
+      })
+
+    const showsStatusTag =
+      hasStatusTag({ state, hasCountdown: !!countdownLabel }) &&
+      // In compact the state travels with the headline: the countdown became
+      // text above, and an in-progress row without a title already says so.
+      !(compact && (state === "scheduled" || headlineCarriesState))
+    const hasActions = showsJoin || !!secondaryActions?.length
+
+    const titleBlock = (
+      <>
+        {headline && (
+          <Text
+            variant="body"
+            content={headline}
+            className={cn(
+              "break-words font-medium",
+              // Struck through but at full contrast: the strike says it's off, and
+              // dimming on top would make the title harder to read for no
+              // additional meaning — the "Cancelled" tag already carries it.
+              state === "cancelled" && "line-through"
+            )}
+          />
+        )}
+        {metaSegments.length > 0 && (
+          <Text variant="description" content={metaSegments.join(" · ")} />
+        )}
+      </>
+    )
+
+    const attendeesBlock = showsAvatars && (
+      <MeetingAttendees
+        attendees={attendees}
+        relevantCount={relevantCount}
+        maxAvatars={maxAvatars}
+        size={compact ? "xs" : "sm"}
+      />
+    )
+
+    const summaryBlock = state === "finished" && summary && (
+      <MeetingSummary summary={summary} />
+    )
+
+    const statusTagBlock = showsStatusTag && (
+      <MeetingStatusTag state={state} countdownLabel={countdownLabel} />
+    )
+
+    const actionsBlock = hasActions && (
+      <>
+        {secondaryActions?.map((action) => (
+          <F0Button
+            key={action.label}
+            label={action.label}
+            icon={action.icon}
+            variant="outline"
+            size="sm"
+            onClick={action.onClick}
+          />
+        ))}
+        {showsJoin && join && (
+          <MeetingJoinButton
+            join={join}
+            disabled={joinDisabled}
+            compact={compact}
+          />
+        )}
+      </>
+    )
+
+    return (
+      <Card
+        ref={ref}
+        className={cn(
+          // Container geometry and border deliberately match F0AudioPlayerCard
+          // (rounded-2xl / p-3 / border-f1-border-secondary) rather than the
+          // heavier ui/Card defaults, so a meeting and its recording read as the
+          // same family when they sit next to each other.
+          "rounded-2xl border-f1-border-secondary bg-f1-background p-3 shadow-none",
+          compact ? "gap-1.5" : "gap-2.5"
+        )}
+        data-testid="meeting-card"
+      >
+        {compact ? (
+          <div className="flex flex-row items-center gap-3">
+            <div className="flex min-w-0 flex-1 flex-col gap-1.5">
+              <div className="flex flex-row flex-wrap items-baseline gap-1.5">
+                {titleBlock}
+                {statusTagBlock}
+              </div>
+              {attendeesBlock}
+              {summaryBlock}
+            </div>
+            {hasActions && (
+              <div className="flex shrink-0 flex-row items-center gap-2">
+                {actionsBlock}
+              </div>
+            )}
+          </div>
+        ) : (
+          <>
+            <div className="flex min-w-0 flex-col gap-0">{titleBlock}</div>
+
+            {attendeesBlock}
+            {summaryBlock}
+
+            {/* Stretched over the card padding so the divider reaches both edges. */}
+            {(hasActions || showsStatusTag) && (
+              <div
+                className={cn(
+                  "flex flex-row items-center gap-2",
+                  hasActions &&
+                    "-mx-3 -mb-3 mt-0.5 border-0 border-t border-solid border-t-f1-border-secondary px-3 pb-3 pt-3"
+                )}
+              >
+                <div className="flex flex-1 flex-row items-center gap-2">
+                  {statusTagBlock}
+                </div>
+                {hasActions && (
+                  <div className="flex flex-row items-center gap-2">
+                    {actionsBlock}
+                  </div>
+                )}
+              </div>
+            )}
+          </>
+        )}
+      </Card>
+    )
+  }
+)
+
+F0MeetingCardBase.displayName = "F0MeetingCard"
+
+const F0MeetingCardSkeleton = ({ compact = false }: { compact?: boolean }) => (
+  <Card
+    className={cn(
+      "rounded-2xl border-f1-border-secondary bg-f1-background p-3 shadow-none",
+      compact ? "gap-1.5" : "gap-2.5"
+    )}
+    aria-busy="true"
+    aria-live="polite"
+  >
+    {compact ? (
+      <div className="flex flex-row items-center gap-3">
+        <div className="flex flex-1 flex-col gap-1.5">
+          <Skeleton className="h-4 w-40 rounded-md" />
+          <Skeleton className="h-5 w-20 rounded-md" />
+        </div>
+        <Skeleton className="h-8 w-20 rounded-md" />
+      </div>
+    ) : (
+      <>
+        <div className="flex flex-col gap-1">
+          <Skeleton className="h-4 w-40 rounded-md" />
+          <Skeleton className="h-3 w-28 rounded-md" />
+        </div>
+        <div className="flex flex-row items-center justify-between">
+          <Skeleton className="h-6 w-20 rounded-md" />
+          <Skeleton className="h-8 w-20 rounded-md" />
+        </div>
+      </>
+    )}
+  </Card>
+)
+
+/**
+ * @experimental This is an experimental component, use it at your own risk.
+ */
+export const F0MeetingCard = withDataTestId(
+  experimentalComponent(
+    "F0MeetingCard",
+    withSkeleton(F0MeetingCardBase, F0MeetingCardSkeleton)
+  )
+)

--- a/packages/react/src/experimental/F0MeetingCard/F0MeetingCard.tsx
+++ b/packages/react/src/experimental/F0MeetingCard/F0MeetingCard.tsx
@@ -158,7 +158,6 @@ const F0MeetingCardBase = forwardRef<HTMLDivElement, F0MeetingCardProps>(
             label={action.label}
             icon={action.icon}
             variant="outline"
-            size="sm"
             onClick={action.onClick}
           />
         ))}

--- a/packages/react/src/experimental/F0MeetingCard/__stories__/F0MeetingCard.mdx
+++ b/packages/react/src/experimental/F0MeetingCard/__stories__/F0MeetingCard.mdx
@@ -85,8 +85,9 @@ But if you can pass the identities, pass them.
 
 `compact` is the dense layout for embedding the card inline or inside a tight
 list. Headline and relative time sit on one line — wrapping onto a second when a
-long title won't fit rather than truncating — attendees shrink to `xs`, the footer
-band disappears, and Join drops to `outline` so it doesn't shout over its host.
+long title won't fit rather than truncating — attendees shrink to `xs`, and the
+footer band disappears. Join keeps its regular emphasis: joining is the same
+action whatever the density, so it shouldn't look weaker here.
 
 Because there is no footer band, the state has to travel with the headline: the
 countdown becomes part of the text line, and a running meeting **with no title of

--- a/packages/react/src/experimental/F0MeetingCard/__stories__/F0MeetingCard.mdx
+++ b/packages/react/src/experimental/F0MeetingCard/__stories__/F0MeetingCard.mdx
@@ -1,0 +1,158 @@
+import { Canvas, Controls, Meta } from "@storybook/addon-docs/blocks"
+
+import * as Stories from "./F0MeetingCard.stories"
+
+<Meta of={Stories} />
+
+# F0MeetingCard
+
+A card for a single meeting — before, during and after it happens. It shows when
+the meeting is, who is attending, how to join, and once it's over, the recap.
+
+<Canvas of={Stories.Default} />
+
+## When to use it
+
+Use it wherever a meeting appears as an item rather than a page: a list of
+upcoming 1:1s, an interview in a hiring pipeline, an AI call on a candidate's
+profile, a widget of today's agenda.
+
+Don't use it as a calendar entry inside a timeline or agenda grid — that's
+`CalendarEvent`. And don't use it for a recording with no meeting around it: a
+standalone audio recap belongs in `F0AudioPlayer`.
+
+## The state is yours, the formatting is ours
+
+`state` is **always controlled**. Only your backend knows whether a meeting truly
+started, whether it ended, or whether the recap is still being generated — so the
+card never infers it from the clock. Pass `"scheduled"`, `"inProgress"`,
+`"summarizing"`, `"finished"` or `"cancelled"`.
+
+Everything derived from time is the card's job: the day label, the countdown, the
+elapsed time, the duration, and whether Join is actionable. Give it `Date`
+objects and it formats them in the viewer's locale — that's what keeps the same
+meeting reading identically in every product.
+
+The card **does not tick**. It renders from its props, and `now` defaults to the
+current time at render. Since you're already re-rendering as the meeting's real
+state changes, that re-render is the refresh. Pass a fixed `now` when you need
+determinism — that's what the stories do so their snapshots don't drift.
+
+## Joining
+
+`join` is only rendered while the meeting is `scheduled` or `inProgress`. It
+becomes actionable `windowMinutes` before the start (10 by default) and stays
+actionable while the meeting runs — including for someone arriving late. Pass
+`join.disabled` to force it off, e.g. while the room is still being provisioned.
+
+<Canvas of={Stories.StartingSoon} />
+
+## Attendees
+
+Attendees can be internal (employees, with a picture) or external (rendered as
+initials — an email alone is enough). Which treatment shows is derived from the
+state: while the meeting runs, **who is in the room** matters, so faces appear;
+otherwise **how many were invited** matters, so a written count appears. Override
+it with `attendeesDisplay` when a surface genuinely needs the other one.
+
+Only `maxAvatars` faces are shown (3 by default); the rest collapse into a `+N`
+counter. **Hover that counter and the collapsed attendees are listed** with their
+name and email — the same behaviour as the avatar list in `ResourceHeader`, since
+both go through `F0AvatarList`.
+
+<Canvas of={Stories.InProgress} />
+
+### Counting people you don't hand over
+
+`invitedCount` and `presentCount` exist for the case where the backend gives you a
+total but not every identity. Whatever they count beyond `attendees.length` is
+added to the `+N`.
+
+Be aware of the trade-off, because it is easy to trip over:
+
+- Hand over **every** person you count (`presentCount === attendees.length`) and
+  the `+N` popover lists the collapsed ones. This is the case worth aiming for.
+- Force a count **higher** than the list and `F0AvatarList` drops the popover
+  entirely — the `+N` becomes a plain badge, hiding even the attendees the card
+  _does_ have. The number stays correct; the names disappear.
+- The written count (`12 guests`) is text, with no hover or click.
+
+That degradation is acceptable: a card is a summary, and meeting tools stop naming
+people past a threshold too. The full roster belongs on a meeting detail surface.
+But if you can pass the identities, pass them.
+
+## Compact
+
+`compact` is the dense layout for embedding the card inline or inside a tight
+list. Headline and relative time sit on one line — wrapping onto a second when a
+long title won't fit rather than truncating — attendees shrink to `xs`, the footer
+band disappears, and Join drops to `outline` so it doesn't shout over its host.
+
+Because there is no footer band, the state has to travel with the headline: the
+countdown becomes part of the text line, and a running meeting **with no title of
+its own** is titled "Call in progress" instead of carrying a tag. States the
+headline can't express — summarizing, cancelled — keep their tag inline.
+
+<Canvas of={Stories.Compact} />
+
+<Canvas of={Stories.CompactScheduled} />
+
+## After the meeting
+
+While the recap is being generated, the card says so and offers nothing to read.
+
+<Canvas of={Stories.Summarizing} />
+
+Once `finished`, the card is tagged green — completed, as opposed to a cancelled
+one, which stays neutral — and `summary` renders **in full**, with no toggle to
+open it. A recap is only worth having if it gets read, and putting it behind a
+control makes that a second decision for the reader. The trade-off is that card
+heights vary with the length of the recap; revisit if design asks for a fixed row
+height.
+
+The transcript is **not** part of the card: transcripts are long, and where they
+open (a modal, a side panel, another page) is a product decision. Pass it as a
+`secondaryActions` entry and own the destination.
+
+<Canvas of={Stories.Finished} />
+
+## Status colours
+
+The tag escalates with urgency rather than repeating one neutral grey:
+
+| State                      | Tag                                      |
+| -------------------------- | ---------------------------------------- |
+| `scheduled`, far out       | none — the time in the date line says it |
+| `scheduled`, in the window | `warning` — amber: act soon              |
+| `inProgress`               | `info` + pulsing dot: happening now      |
+| `summarizing`              | `neutral` with F0's AI mark              |
+| `finished`                 | `positive` — green: completed            |
+| `cancelled`                | `neutral`, and the title struck through  |
+
+`critical` (red) is deliberately unused. Red in F0 means destructive or failed,
+and neither a running nor a cancelled meeting is either of those. The join button
+does use the solid brand `default` variant, which is red-ish — that is the primary
+action colour, not a status.
+
+## Accessibility
+
+- The in-progress pulse is dropped when the viewer prefers reduced motion — the
+  label alone still carries the state.
+- Cancelled meetings are struck through but keep full text contrast: the strike is
+  the signal and the tag names it, so dimming would only cost legibility.
+- Attendees and the recap are labelled groups, so both are announced as a unit.
+- **Known gap:** the `+N` popover is a Radix `HoverCard` whose trigger is a
+  non-focusable `div`, so it opens on pointer hover but not from the keyboard.
+  Nothing in this card depends on it for meaning, but it is a limitation of the
+  shared `F0AvatarList` worth fixing upstream.
+
+## Deliberately not here
+
+- **No whole-card link or `onClick`.** There is no use case for navigating from the
+  card itself; its actions are the interactive parts.
+- **No overflow (⋯) menu.** Nothing has been designed to go in it yet.
+- **No transcript viewer.** See above — pass a `secondaryActions` entry.
+
+## Props
+
+<Controls of={Stories.Default} />

--- a/packages/react/src/experimental/F0MeetingCard/__stories__/F0MeetingCard.stories.tsx
+++ b/packages/react/src/experimental/F0MeetingCard/__stories__/F0MeetingCard.stories.tsx
@@ -119,7 +119,7 @@ const meta: Meta<typeof F0MeetingCard> = {
     compact: {
       control: "boolean",
       description:
-        "Dense single-row layout: headline and relative time share a line, avatars shrink to `xs`, no footer band, and Join drops to `outline`.",
+        "Dense single-row layout: headline and relative time share a line, avatars shrink to `xs`, and there is no footer band.",
       table: { defaultValue: { summary: "false" } },
     },
   },
@@ -198,9 +198,9 @@ export const InProgress: Story = {
 
 /**
  * `compact` is the dense layout for embedding the card inline or in a tight
- * list: headline and relative time share one line, attendees shrink to `xs`,
- * there is no footer band, and Join drops to `outline` so it doesn't shout over
- * its host. A running meeting with no title of its own reads "Call in progress".
+ * list: headline and relative time share one line, attendees shrink to `xs`, and
+ * there is no footer band. A running meeting with no title of its own reads
+ * "Call in progress".
  */
 export const Compact: Story = {
   args: {

--- a/packages/react/src/experimental/F0MeetingCard/__stories__/F0MeetingCard.stories.tsx
+++ b/packages/react/src/experimental/F0MeetingCard/__stories__/F0MeetingCard.stories.tsx
@@ -1,0 +1,377 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { expect, fn, userEvent, waitFor, within } from "storybook/test"
+
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
+
+import { F0MeetingCard } from "../F0MeetingCard"
+import {
+  attendeesDisplays,
+  meetingStates,
+  type MeetingAttendee,
+} from "../types"
+
+/**
+ * Fixed reference instant. The card never reads a clock of its own, so pinning
+ * `now` keeps every story (and its Chromatic snapshot) identical across runs.
+ */
+const NOW = new Date("2026-03-12T09:00:00")
+
+const at = (time: string) => new Date(`2026-03-12T${time}:00`)
+
+const attendees: MeetingAttendee[] = [
+  { type: "internal", firstName: "Ada", lastName: "Lovelace" },
+  { type: "internal", firstName: "Alan", lastName: "Turing" },
+  { type: "internal", firstName: "Marta", lastName: "Ferrer" },
+  { type: "internal", firstName: "Jordi", lastName: "Puig" },
+  { type: "internal", firstName: "Noa", lastName: "Ramírez" },
+  {
+    type: "external",
+    name: "Grace Hopper",
+    email: "grace.hopper@example.com",
+  },
+  { type: "external", name: "Marie Curie", email: "marie.curie@example.com" },
+  { type: "external", email: "katherine.johnson@example.com" },
+]
+
+const summary =
+  "Marta covers the first shift and Jordi publishes the revised rota today. The team agreed to review staffing again on Friday, once the new hires finish onboarding."
+
+const meta: Meta<typeof F0MeetingCard> = {
+  component: F0MeetingCard,
+  title: "F0MeetingCard",
+  parameters: {
+    docs: {
+      // Prose lives in F0MeetingCard.mdx (autodocs disabled below).
+      story: { inline: false, height: "200px" },
+    },
+  },
+  tags: ["!autodocs", "experimental"],
+  decorators: [(Story) => <div className="max-w-[420px]">{Story()}</div>],
+  // Explicit argTypes: docgen can't infer props through the
+  // withDataTestId(experimentalComponent(withSkeleton(...))) wrappers.
+  argTypes: {
+    state: {
+      control: "select",
+      options: meetingStates,
+      description:
+        "Lifecycle of the meeting. Always controlled — only the backend knows whether a meeting really started, ended or is still being summarised.",
+      table: { type: { summary: meetingStates.join(" | ") } },
+    },
+    title: { control: "text", description: "The meeting title." },
+    startsAt: {
+      control: "date",
+      description:
+        "When the meeting starts. Drives the date line, the countdown and the join window.",
+    },
+    endsAt: {
+      control: "date",
+      description: "When it ends. Only used for the duration label once over.",
+    },
+    now: {
+      control: "date",
+      description:
+        "Reference instant for every time-derived label. Defaults to the current time at render; the card never ticks, so re-render to refresh.",
+    },
+    attendees: {
+      control: "object",
+      description:
+        "Known attendees, internal (employees) and external (initials only).",
+    },
+    invitedCount: {
+      control: "number",
+      description:
+        "Total invited people, when `attendees` is a truncated list.",
+    },
+    presentCount: {
+      control: "number",
+      description:
+        "How many attendees are in the room. Only used while in progress.",
+    },
+    attendeesDisplay: {
+      control: "select",
+      options: attendeesDisplays,
+      description:
+        "`auto` shows avatars while in progress and a written count otherwise.",
+      table: { defaultValue: { summary: "auto" } },
+    },
+    maxAvatars: {
+      control: "number",
+      description:
+        "Avatars shown before the rest collapse into a `+N` counter.",
+      table: { defaultValue: { summary: "3" } },
+    },
+    summary: {
+      control: "text",
+      description:
+        "Recap of the meeting. Rendered in full, and only once `finished`.",
+    },
+    join: {
+      control: "object",
+      description:
+        "Join affordance. Enabled from `windowMinutes` (default 10) before the start and while running.",
+    },
+    secondaryActions: {
+      control: "object",
+      description:
+        "Extra footer buttons — e.g. a Transcript action whose destination the consumer owns.",
+    },
+    compact: {
+      control: "boolean",
+      description:
+        "Dense single-row layout: headline and relative time share a line, avatars shrink to `xs`, no footer band, and Join drops to `outline`.",
+      table: { defaultValue: { summary: "false" } },
+    },
+  },
+  args: {
+    now: NOW,
+  },
+}
+
+export default meta
+
+type Story = StoryObj<typeof meta>
+
+/**
+ * An upcoming meeting still outside its join window: the exact time is what
+ * matters, so there is no countdown tag and Join is not actionable yet.
+ */
+export const Default: Story = {
+  args: {
+    state: "scheduled",
+    title: "Morning shift briefing",
+    startsAt: at("11:30"),
+    attendees,
+    invitedCount: 12,
+    join: { onJoin: fn() },
+  },
+}
+
+/**
+ * Inside the 10-minute window the countdown appears and Join becomes actionable.
+ */
+export const StartingSoon: Story = {
+  args: {
+    ...Default.args,
+    startsAt: at("09:08"),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(canvas.getByText("In 8 mins")).toBeVisible()
+    const join = canvas.getByRole("button", { name: /Join/ })
+    await expect(join).toBeEnabled()
+    await userEvent.click(join)
+  },
+}
+
+/**
+ * While the meeting runs, who is in the room matters more than how many were
+ * invited, so attendees switch to faces and the lead label reports elapsed time.
+ * The status tag pulses instead of turning red — red in F0 means destructive.
+ *
+ * Hover the `+N` counter to see the attendees it collapsed. That popover only
+ * exists when the card was handed every person it counts — see the docs on
+ * `invitedCount` / `presentCount`.
+ */
+export const InProgress: Story = {
+  args: {
+    state: "inProgress",
+    title: "Morning shift briefing",
+    startsAt: at("08:56"),
+    attendees,
+    presentCount: attendees.length,
+    join: { onJoin: fn() },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    const counter = await canvas.findByText(`+${attendees.length - 3}`)
+    await userEvent.hover(counter)
+
+    // The popover renders in a portal, outside the story canvas, and fades in —
+    // so wait for it to actually become visible, not just to exist.
+    const collapsed = await within(document.body).findByText("Marie Curie")
+    await waitFor(() => expect(collapsed).toBeVisible())
+  },
+}
+
+/**
+ * `compact` is the dense layout for embedding the card inline or in a tight
+ * list: headline and relative time share one line, attendees shrink to `xs`,
+ * there is no footer band, and Join drops to `outline` so it doesn't shout over
+ * its host. A running meeting with no title of its own reads "Call in progress".
+ */
+export const Compact: Story = {
+  args: {
+    state: "inProgress",
+    startsAt: at("08:56"),
+    attendees,
+    presentCount: attendees.length,
+    join: { onJoin: fn() },
+    compact: true,
+  },
+}
+
+/**
+ * Compact isn't tied to the state. Waiting to start, the countdown becomes part
+ * of the text line, since there is no footer band to hold a tag.
+ */
+export const CompactScheduled: Story = {
+  args: {
+    state: "scheduled",
+    title: "Morning shift briefing",
+    startsAt: at("09:08"),
+    attendees,
+    invitedCount: 12,
+    join: { onJoin: fn() },
+    compact: true,
+  },
+}
+
+/**
+ * The meeting is over but the recap is not ready yet — flagged, and nothing to
+ * read or join.
+ */
+export const Summarizing: Story = {
+  args: {
+    state: "summarizing",
+    title: "Morning shift briefing",
+    startsAt: at("08:00"),
+    endsAt: at("08:23"),
+    attendees,
+    invitedCount: 12,
+  },
+}
+
+/**
+ * Once finished, the recap is shown in full — no toggle to open it — and the
+ * footer carries the state alongside consumer-owned actions. Where Transcript
+ * leads is the product's decision, not the card's.
+ */
+export const Finished: Story = {
+  args: {
+    state: "finished",
+    title: "Morning shift briefing",
+    startsAt: at("08:00"),
+    endsAt: at("08:23"),
+    attendees,
+    invitedCount: 12,
+    summary,
+    secondaryActions: [{ label: "Transcript", onClick: fn() }],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    const group = await canvas.findByRole("group", { name: "Summary" })
+    await expect(group).toHaveTextContent(summary)
+    await expect(canvas.getByText("Finished")).toBeVisible()
+  },
+}
+
+export const Cancelled: Story = {
+  args: {
+    state: "cancelled",
+    title: "Morning shift briefing",
+    startsAt: at("11:30"),
+    attendees,
+    invitedCount: 12,
+    join: { onJoin: fn() },
+  },
+}
+
+export const Skeleton: Story = {
+  args: {
+    state: "scheduled",
+    startsAt: at("11:30"),
+  },
+  render: () => <F0MeetingCard.Skeleton />,
+}
+
+export const Snapshot: Story = {
+  args: {
+    state: "scheduled",
+    startsAt: at("11:30"),
+  },
+  parameters: withSnapshot({}),
+  render: () => (
+    <div className="flex w-[420px] flex-col gap-4">
+      <F0MeetingCard
+        state="scheduled"
+        title="Morning shift briefing"
+        startsAt={at("11:30")}
+        now={NOW}
+        attendees={attendees}
+        invitedCount={12}
+        join={{ onJoin: fn() }}
+      />
+      <F0MeetingCard
+        state="scheduled"
+        title="Morning shift briefing"
+        startsAt={at("09:08")}
+        now={NOW}
+        attendees={attendees}
+        invitedCount={12}
+        join={{ onJoin: fn() }}
+      />
+      <F0MeetingCard
+        state="inProgress"
+        title="Morning shift briefing"
+        startsAt={at("08:56")}
+        now={NOW}
+        attendees={attendees}
+        presentCount={attendees.length}
+        join={{ onJoin: fn() }}
+      />
+      <F0MeetingCard
+        state="inProgress"
+        startsAt={at("08:56")}
+        now={NOW}
+        attendees={attendees}
+        presentCount={attendees.length}
+        join={{ onJoin: fn() }}
+        compact
+      />
+      <F0MeetingCard
+        state="scheduled"
+        title="Morning shift briefing"
+        startsAt={at("09:08")}
+        now={NOW}
+        attendees={attendees}
+        invitedCount={12}
+        join={{ onJoin: fn() }}
+        compact
+      />
+      <F0MeetingCard
+        state="summarizing"
+        title="Morning shift briefing"
+        startsAt={at("08:00")}
+        endsAt={at("08:23")}
+        now={NOW}
+        attendees={attendees}
+        invitedCount={12}
+      />
+      <F0MeetingCard
+        state="finished"
+        title="Morning shift briefing"
+        startsAt={at("08:00")}
+        endsAt={at("08:23")}
+        now={NOW}
+        attendees={attendees}
+        invitedCount={12}
+        summary={summary}
+        secondaryActions={[{ label: "Transcript", onClick: fn() }]}
+      />
+      <F0MeetingCard
+        state="cancelled"
+        title="Morning shift briefing"
+        startsAt={at("11:30")}
+        now={NOW}
+        attendees={attendees}
+        invitedCount={12}
+      />
+      <F0MeetingCard.Skeleton />
+      <F0MeetingCard.Skeleton compact />
+    </div>
+  ),
+}

--- a/packages/react/src/experimental/F0MeetingCard/__tests__/F0MeetingCard.test.tsx
+++ b/packages/react/src/experimental/F0MeetingCard/__tests__/F0MeetingCard.test.tsx
@@ -1,0 +1,364 @@
+import { describe, expect, it, vi } from "vitest"
+import "@testing-library/jest-dom/vitest"
+import { screen, userEvent, zeroRender as render } from "@/testing/test-utils"
+
+import { F0MeetingCard } from "../F0MeetingCard"
+import type { MeetingAttendee } from "../types"
+
+const now = new Date("2026-03-12T09:00:00")
+
+const attendees: MeetingAttendee[] = [
+  { type: "internal", firstName: "Ada", lastName: "Lovelace" },
+  { type: "internal", firstName: "Alan", lastName: "Turing" },
+  { type: "external", name: "Grace Hopper", email: "grace@example.com" },
+]
+
+describe("F0MeetingCard", () => {
+  it("renders the title and the meta line for an upcoming meeting", () => {
+    render(
+      <F0MeetingCard
+        state="scheduled"
+        title="Morning shift briefing"
+        startsAt={new Date("2026-03-12T09:30:00")}
+        now={now}
+        attendees={attendees}
+        invitedCount={12}
+      />
+    )
+
+    expect(screen.getByText("Morning shift briefing")).toBeInTheDocument()
+    expect(screen.getByText(/Today/)).toBeInTheDocument()
+    expect(screen.getByText(/12 guests/)).toBeInTheDocument()
+  })
+
+  it("labels a meeting held the previous day", () => {
+    render(
+      <F0MeetingCard
+        state="finished"
+        title="Retro"
+        startsAt={new Date("2026-03-11T16:00:00")}
+        now={now}
+        attendees={attendees}
+      />
+    )
+
+    expect(screen.getByText(/Yesterday/)).toBeInTheDocument()
+  })
+
+  it("shows the duration once the meeting is over", () => {
+    render(
+      <F0MeetingCard
+        state="finished"
+        title="Retro"
+        startsAt={new Date("2026-03-12T08:00:00")}
+        endsAt={new Date("2026-03-12T08:23:00")}
+        now={now}
+      />
+    )
+
+    expect(screen.getByText(/23 mins/)).toBeInTheDocument()
+  })
+
+  it("keeps the join button disabled outside the join window", () => {
+    render(
+      <F0MeetingCard
+        state="scheduled"
+        title="Morning shift briefing"
+        startsAt={new Date("2026-03-12T11:00:00")}
+        now={now}
+        join={{ onJoin: vi.fn() }}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: /Join/ })).toBeDisabled()
+    expect(screen.queryByText(/In \d+ min/)).not.toBeInTheDocument()
+  })
+
+  it("enables the join button and counts down inside the window", async () => {
+    const onJoin = vi.fn()
+    render(
+      <F0MeetingCard
+        state="scheduled"
+        title="Morning shift briefing"
+        startsAt={new Date("2026-03-12T09:08:00")}
+        now={now}
+        join={{ onJoin }}
+      />
+    )
+
+    expect(screen.getByText("In 8 mins")).toBeInTheDocument()
+
+    const join = screen.getByRole("button", { name: /Join/ })
+    expect(join).toBeEnabled()
+
+    await userEvent.click(join)
+    expect(onJoin).toHaveBeenCalledOnce()
+  })
+
+  it("respects a custom join window", () => {
+    render(
+      <F0MeetingCard
+        state="scheduled"
+        title="Morning shift briefing"
+        startsAt={new Date("2026-03-12T09:25:00")}
+        now={now}
+        join={{ onJoin: vi.fn(), windowMinutes: 30 }}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: /Join/ })).toBeEnabled()
+    expect(screen.getByText("In 25 mins")).toBeInTheDocument()
+  })
+
+  it("lets the consumer force the join button off", () => {
+    render(
+      <F0MeetingCard
+        state="inProgress"
+        title="Morning shift briefing"
+        startsAt={new Date("2026-03-12T08:56:00")}
+        now={now}
+        join={{ onJoin: vi.fn(), disabled: true }}
+      />
+    )
+
+    expect(screen.getByRole("button", { name: /Join/ })).toBeDisabled()
+  })
+
+  it("reports elapsed time and shows attendee faces while in progress", () => {
+    render(
+      <F0MeetingCard
+        state="inProgress"
+        title="Morning shift briefing"
+        startsAt={new Date("2026-03-12T08:56:00")}
+        now={now}
+        attendees={attendees}
+        presentCount={8}
+      />
+    )
+
+    expect(screen.getByText(/4 mins ago/)).toBeInTheDocument()
+    expect(screen.getByText("In progress")).toBeInTheDocument()
+    expect(screen.getByRole("group", { name: "Attendees" })).toBeInTheDocument()
+    expect(screen.queryByText(/8 inside/)).not.toBeInTheDocument()
+  })
+
+  it("reads 'Starting now' instead of zero minutes", () => {
+    render(
+      <F0MeetingCard
+        state="inProgress"
+        title="Morning shift briefing"
+        startsAt={now}
+        now={now}
+      />
+    )
+
+    expect(screen.getByText(/Starting now/)).toBeInTheDocument()
+  })
+
+  it("switches to a written count when asked to", () => {
+    render(
+      <F0MeetingCard
+        state="inProgress"
+        title="Morning shift briefing"
+        startsAt={new Date("2026-03-12T08:56:00")}
+        now={now}
+        attendees={attendees}
+        presentCount={8}
+        attendeesDisplay="count"
+      />
+    )
+
+    expect(screen.getByText(/8 inside/)).toBeInTheDocument()
+    expect(
+      screen.queryByRole("group", { name: "Attendees" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("flags a recap still being generated and hides the summary", () => {
+    render(
+      <F0MeetingCard
+        state="summarizing"
+        title="Morning shift briefing"
+        startsAt={new Date("2026-03-12T08:00:00")}
+        now={now}
+        summary="Marta covers the first shift."
+      />
+    )
+
+    expect(screen.getByText("Summarizing")).toBeInTheDocument()
+    expect(
+      screen.queryByRole("group", { name: "Summary" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("shows the summary and drops the join button once finished", () => {
+    render(
+      <F0MeetingCard
+        state="finished"
+        title="Morning shift briefing"
+        startsAt={new Date("2026-03-12T08:00:00")}
+        now={now}
+        summary="Marta covers the first shift."
+        join={{ onJoin: vi.fn() }}
+      />
+    )
+
+    expect(screen.getByRole("group", { name: "Summary" })).toHaveTextContent(
+      "Marta covers the first shift."
+    )
+    expect(screen.getByText("Finished")).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: /Join/ })
+    ).not.toBeInTheDocument()
+  })
+
+  it("strikes through a cancelled meeting and tags it", () => {
+    render(
+      <F0MeetingCard
+        state="cancelled"
+        title="Morning shift briefing"
+        startsAt={new Date("2026-03-12T11:00:00")}
+        now={now}
+        join={{ onJoin: vi.fn() }}
+      />
+    )
+
+    expect(screen.getByText("Cancelled")).toBeInTheDocument()
+    expect(screen.getByText("Morning shift briefing")).toHaveClass(
+      "line-through"
+    )
+    expect(
+      screen.queryByRole("button", { name: /Join/ })
+    ).not.toBeInTheDocument()
+  })
+
+  it("renders consumer-owned footer actions", async () => {
+    const onClick = vi.fn()
+    render(
+      <F0MeetingCard
+        state="finished"
+        title="Morning shift briefing"
+        startsAt={new Date("2026-03-12T08:00:00")}
+        now={now}
+        secondaryActions={[{ label: "Transcript", onClick }]}
+      />
+    )
+
+    await userEvent.click(screen.getByRole("button", { name: "Transcript" }))
+    expect(onClick).toHaveBeenCalledOnce()
+  })
+
+  it("works without a title, letting the status tag carry the meaning", () => {
+    render(
+      <F0MeetingCard
+        state="inProgress"
+        startsAt={new Date("2026-03-12T08:56:00")}
+        now={now}
+        attendees={attendees}
+        join={{ onJoin: vi.fn() }}
+      />
+    )
+
+    expect(screen.getByText("In progress")).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: /Join/ })).toBeEnabled()
+  })
+
+  describe("compact", () => {
+    it("titles a running untitled meeting and drops the redundant tag", () => {
+      render(
+        <F0MeetingCard
+          state="inProgress"
+          startsAt={new Date("2026-03-12T08:56:00")}
+          now={now}
+          attendees={attendees}
+          presentCount={8}
+          join={{ onJoin: vi.fn() }}
+          compact
+        />
+      )
+
+      expect(screen.getByText("Call in progress")).toBeInTheDocument()
+      expect(screen.getByText("4 mins ago")).toBeInTheDocument()
+      // The headline already says it — a tag would repeat itself.
+      expect(screen.queryByText("In progress")).not.toBeInTheDocument()
+    })
+
+    it("keeps a provided title and still tags the running state", () => {
+      render(
+        <F0MeetingCard
+          state="inProgress"
+          title="Morning shift briefing"
+          startsAt={new Date("2026-03-12T08:56:00")}
+          now={now}
+          attendees={attendees}
+          presentCount={8}
+          compact
+        />
+      )
+
+      expect(screen.getByText("Morning shift briefing")).toBeInTheDocument()
+      expect(screen.getByText("In progress")).toBeInTheDocument()
+      expect(screen.queryByText("Call in progress")).not.toBeInTheDocument()
+    })
+
+    it("moves the countdown into the text line, with no tag", () => {
+      render(
+        <F0MeetingCard
+          state="scheduled"
+          title="Morning shift briefing"
+          startsAt={new Date("2026-03-12T09:08:00")}
+          now={now}
+          invitedCount={12}
+          join={{ onJoin: vi.fn() }}
+          compact
+        />
+      )
+
+      expect(screen.getByText(/In 8 mins/)).toBeInTheDocument()
+      expect(screen.getByText(/12 guests/)).toBeInTheDocument()
+      expect(screen.getByRole("button", { name: /Join/ })).toBeEnabled()
+    })
+
+    it("still surfaces states the headline cannot carry", () => {
+      render(
+        <F0MeetingCard
+          state="cancelled"
+          title="Morning shift briefing"
+          startsAt={new Date("2026-03-12T11:00:00")}
+          now={now}
+          compact
+        />
+      )
+
+      expect(screen.getByText("Cancelled")).toBeInTheDocument()
+    })
+
+    it("drops the clock time while the meeting runs", () => {
+      render(
+        <F0MeetingCard
+          state="inProgress"
+          startsAt={new Date("2026-03-12T08:56:00")}
+          now={now}
+          compact
+        />
+      )
+
+      expect(screen.getByText("4 mins ago")).toBeInTheDocument()
+      expect(screen.queryByText(/8:56/)).not.toBeInTheDocument()
+    })
+  })
+
+  it("exposes a dataTestId", () => {
+    render(
+      <F0MeetingCard
+        state="scheduled"
+        title="Morning shift briefing"
+        startsAt={new Date("2026-03-12T09:30:00")}
+        now={now}
+        dataTestId="meeting"
+      />
+    )
+
+    expect(screen.getByTestId("meeting")).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/experimental/F0MeetingCard/__tests__/utils.test.ts
+++ b/packages/react/src/experimental/F0MeetingCard/__tests__/utils.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  getDayKind,
+  getDurationMinutes,
+  getMinutesSinceStart,
+  getMinutesUntilStart,
+  hasStatusTag,
+  isJoinRelevant,
+  isWithinJoinWindow,
+  normalizeAttendees,
+  pluralize,
+  resolveAttendeesDisplay,
+  resolveRelevantCount,
+  shouldShowCountdown,
+} from "../utils"
+
+const now = new Date("2026-03-12T09:00:00Z")
+
+describe("getDayKind", () => {
+  it("names the neighbouring days and falls back to other", () => {
+    expect(getDayKind(new Date("2026-03-12T18:00:00Z"), now)).toBe("today")
+    expect(getDayKind(new Date("2026-03-11T08:00:00Z"), now)).toBe("yesterday")
+    expect(getDayKind(new Date("2026-03-13T08:00:00Z"), now)).toBe("tomorrow")
+    expect(getDayKind(new Date("2026-03-20T08:00:00Z"), now)).toBe("other")
+  })
+})
+
+describe("minute helpers", () => {
+  it("counts minutes until the start, going negative once it passed", () => {
+    expect(getMinutesUntilStart(new Date("2026-03-12T09:10:00Z"), now)).toBe(10)
+    expect(getMinutesUntilStart(new Date("2026-03-12T08:55:00Z"), now)).toBe(-5)
+  })
+
+  it("never reports negative elapsed time", () => {
+    expect(getMinutesSinceStart(new Date("2026-03-12T08:56:00Z"), now)).toBe(4)
+    expect(getMinutesSinceStart(new Date("2026-03-12T09:30:00Z"), now)).toBe(0)
+  })
+})
+
+describe("isWithinJoinWindow", () => {
+  it("is always open while the meeting runs", () => {
+    expect(
+      isWithinJoinWindow({
+        state: "inProgress",
+        startsAt: new Date("2026-03-12T20:00:00Z"),
+        now,
+      })
+    ).toBe(true)
+  })
+
+  it("opens the default 10 minutes before the start", () => {
+    expect(
+      isWithinJoinWindow({
+        state: "scheduled",
+        startsAt: new Date("2026-03-12T09:10:00Z"),
+        now,
+      })
+    ).toBe(true)
+    expect(
+      isWithinJoinWindow({
+        state: "scheduled",
+        startsAt: new Date("2026-03-12T09:11:00Z"),
+        now,
+      })
+    ).toBe(false)
+  })
+
+  it("honours a custom window", () => {
+    expect(
+      isWithinJoinWindow({
+        state: "scheduled",
+        startsAt: new Date("2026-03-12T09:25:00Z"),
+        now,
+        windowMinutes: 30,
+      })
+    ).toBe(true)
+  })
+
+  it("keeps a late attendee able to join", () => {
+    expect(
+      isWithinJoinWindow({
+        state: "scheduled",
+        startsAt: new Date("2026-03-12T08:40:00Z"),
+        now,
+      })
+    ).toBe(true)
+  })
+
+  it("is closed once the meeting is over", () => {
+    expect(
+      isWithinJoinWindow({
+        state: "finished",
+        startsAt: new Date("2026-03-12T09:00:00Z"),
+        now,
+      })
+    ).toBe(false)
+  })
+})
+
+describe("isJoinRelevant", () => {
+  it("only covers the states where joining is possible", () => {
+    expect(isJoinRelevant("scheduled")).toBe(true)
+    expect(isJoinRelevant("inProgress")).toBe(true)
+    expect(isJoinRelevant("summarizing")).toBe(false)
+    expect(isJoinRelevant("finished")).toBe(false)
+    expect(isJoinRelevant("cancelled")).toBe(false)
+  })
+})
+
+describe("shouldShowCountdown", () => {
+  it("shows only for a scheduled meeting inside the window", () => {
+    expect(
+      shouldShowCountdown({
+        state: "scheduled",
+        startsAt: new Date("2026-03-12T09:08:00Z"),
+        now,
+      })
+    ).toBe(true)
+    expect(
+      shouldShowCountdown({
+        state: "scheduled",
+        startsAt: new Date("2026-03-12T11:00:00Z"),
+        now,
+      })
+    ).toBe(false)
+    expect(
+      shouldShowCountdown({
+        state: "inProgress",
+        startsAt: new Date("2026-03-12T08:58:00Z"),
+        now,
+      })
+    ).toBe(false)
+  })
+})
+
+describe("resolveAttendeesDisplay", () => {
+  it("shows faces while the meeting runs and a count otherwise", () => {
+    expect(resolveAttendeesDisplay("auto", "inProgress")).toBe("avatars")
+    expect(resolveAttendeesDisplay("auto", "scheduled")).toBe("count")
+    expect(resolveAttendeesDisplay("auto", "finished")).toBe("count")
+  })
+
+  it("respects an explicit override", () => {
+    expect(resolveAttendeesDisplay("count", "inProgress")).toBe("count")
+    expect(resolveAttendeesDisplay("avatars", "finished")).toBe("avatars")
+  })
+})
+
+describe("resolveRelevantCount", () => {
+  const attendees = [
+    { type: "internal" as const, firstName: "Ada", lastName: "Lovelace" },
+  ]
+
+  it("prefers who is inside while the meeting runs", () => {
+    expect(
+      resolveRelevantCount({
+        state: "inProgress",
+        attendees,
+        invitedCount: 12,
+        presentCount: 8,
+      })
+    ).toBe(8)
+  })
+
+  it("falls back to the invited total, then to the list length", () => {
+    expect(
+      resolveRelevantCount({ state: "scheduled", attendees, invitedCount: 12 })
+    ).toBe(12)
+    expect(resolveRelevantCount({ state: "scheduled", attendees })).toBe(1)
+  })
+})
+
+describe("normalizeAttendees", () => {
+  it("keeps internal attendees as they are and exposes the email as tooltip", () => {
+    expect(
+      normalizeAttendees([
+        {
+          type: "internal",
+          firstName: "Ada",
+          lastName: "Lovelace",
+          src: "ada.jpg",
+          email: "ada@factorial.co",
+        },
+      ])
+    ).toEqual([
+      {
+        firstName: "Ada",
+        lastName: "Lovelace",
+        src: "ada.jpg",
+        tooltipDescription: "ada@factorial.co",
+      },
+    ])
+  })
+
+  it("splits an external display name so initials still work", () => {
+    expect(
+      normalizeAttendees([{ type: "external", name: "Grace Brewster Hopper" }])
+    ).toEqual([
+      {
+        firstName: "Grace",
+        lastName: "Brewster Hopper",
+        tooltipDescription: undefined,
+      },
+    ])
+  })
+
+  it("derives a name from the email when that is all there is", () => {
+    expect(
+      normalizeAttendees([{ type: "external", email: "grace@example.com" }])
+    ).toEqual([
+      {
+        firstName: "grace",
+        lastName: "",
+        tooltipDescription: "grace@example.com",
+      },
+    ])
+  })
+})
+
+describe("hasStatusTag", () => {
+  it("names every state except a scheduled meeting still far out", () => {
+    expect(hasStatusTag({ state: "finished", hasCountdown: false })).toBe(true)
+    expect(hasStatusTag({ state: "scheduled", hasCountdown: false })).toBe(
+      false
+    )
+    expect(hasStatusTag({ state: "scheduled", hasCountdown: true })).toBe(true)
+    expect(hasStatusTag({ state: "inProgress", hasCountdown: false })).toBe(
+      true
+    )
+    expect(hasStatusTag({ state: "summarizing", hasCountdown: false })).toBe(
+      true
+    )
+    expect(hasStatusTag({ state: "cancelled", hasCountdown: false })).toBe(true)
+  })
+})
+
+describe("getDurationMinutes", () => {
+  it("returns whole minutes, or nothing when unknown or non-positive", () => {
+    expect(
+      getDurationMinutes(
+        new Date("2026-03-12T09:00:00Z"),
+        new Date("2026-03-12T09:23:00Z")
+      )
+    ).toBe(23)
+    expect(
+      getDurationMinutes(new Date("2026-03-12T09:00:00Z"), undefined)
+    ).toBe(undefined)
+    expect(
+      getDurationMinutes(
+        new Date("2026-03-12T09:00:00Z"),
+        new Date("2026-03-12T09:00:00Z")
+      )
+    ).toBe(undefined)
+  })
+})
+
+describe("pluralize", () => {
+  it("picks the form and interpolates the count", () => {
+    const forms = { one: "{{count}} guest", other: "{{count}} guests" }
+    expect(pluralize(forms, 1)).toBe("1 guest")
+    expect(pluralize(forms, 12)).toBe("12 guests")
+  })
+})

--- a/packages/react/src/experimental/F0MeetingCard/components/MeetingAttendees.tsx
+++ b/packages/react/src/experimental/F0MeetingCard/components/MeetingAttendees.tsx
@@ -1,0 +1,42 @@
+import { F0AvatarList } from "@/components/avatars/F0AvatarList"
+import { useI18n } from "@/lib/providers/i18n"
+
+import { DEFAULT_MAX_AVATARS, normalizeAttendees } from "../utils"
+import type { MeetingAttendee } from "../types"
+
+export const MeetingAttendees = ({
+  attendees,
+  relevantCount,
+  maxAvatars = DEFAULT_MAX_AVATARS,
+  size = "sm",
+}: {
+  attendees: MeetingAttendee[]
+  /**
+   * How many people the count refers to — present attendees while the meeting
+   * runs, invited ones otherwise. May exceed `attendees.length` when the list
+   * arrives truncated, in which case the extra people fold into the `+N` counter.
+   */
+  relevantCount: number
+  maxAvatars?: number
+  size?: "xs" | "sm"
+}) => {
+  const { meetingCard } = useI18n()
+
+  if (attendees.length === 0) return null
+
+  // Only force the counter when people are genuinely missing from the list —
+  // F0AvatarList shows a "+0" badge for any defined `remainingCount`.
+  const notListed = Math.max(0, relevantCount - attendees.length)
+
+  return (
+    <div role="group" aria-label={meetingCard.attendees}>
+      <F0AvatarList
+        type="person"
+        avatars={normalizeAttendees(attendees)}
+        size={size}
+        max={maxAvatars}
+        remainingCount={notListed > 0 ? notListed : undefined}
+      />
+    </div>
+  )
+}

--- a/packages/react/src/experimental/F0MeetingCard/components/MeetingJoinButton.tsx
+++ b/packages/react/src/experimental/F0MeetingCard/components/MeetingJoinButton.tsx
@@ -1,0 +1,51 @@
+import { F0Button } from "@/components/F0Button"
+import { VideoRecorder } from "@/icons/app"
+import { useI18n } from "@/lib/providers/i18n"
+
+import type { MeetingJoin } from "../types"
+
+/**
+ * `href` and `onClick` are mutually exclusive on F0Button, so the navigating and
+ * the handling variants are rendered as two distinct buttons rather than one with
+ * optional props.
+ */
+export const MeetingJoinButton = ({
+  join,
+  disabled,
+  compact = false,
+}: {
+  join: MeetingJoin
+  disabled: boolean
+  /**
+   * Drops the button to `outline` emphasis. A compact card is embedded inside
+   * denser surroundings, where a solid primary would shout over its host.
+   */
+  compact?: boolean
+}) => {
+  const { meetingCard } = useI18n()
+  const label = join.label ?? meetingCard.join
+  const variant = compact ? "outline" : "default"
+
+  if (join.href && !disabled) {
+    return (
+      <F0Button
+        label={label}
+        icon={VideoRecorder}
+        variant={variant}
+        size="sm"
+        href={join.href}
+      />
+    )
+  }
+
+  return (
+    <F0Button
+      label={label}
+      icon={VideoRecorder}
+      variant={variant}
+      size="sm"
+      disabled={disabled}
+      onClick={join.onJoin}
+    />
+  )
+}

--- a/packages/react/src/experimental/F0MeetingCard/components/MeetingJoinButton.tsx
+++ b/packages/react/src/experimental/F0MeetingCard/components/MeetingJoinButton.tsx
@@ -12,26 +12,19 @@ import type { MeetingJoin } from "../types"
 export const MeetingJoinButton = ({
   join,
   disabled,
-  compact = false,
 }: {
   join: MeetingJoin
   disabled: boolean
-  /**
-   * Drops the button to `outline` emphasis. A compact card is embedded inside
-   * denser surroundings, where a solid primary would shout over its host.
-   */
-  compact?: boolean
 }) => {
   const { meetingCard } = useI18n()
   const label = join.label ?? meetingCard.join
-  const variant = compact ? "outline" : "default"
 
   if (join.href && !disabled) {
     return (
       <F0Button
         label={label}
         icon={VideoRecorder}
-        variant={variant}
+        variant="default"
         size="sm"
         href={join.href}
       />
@@ -42,7 +35,7 @@ export const MeetingJoinButton = ({
     <F0Button
       label={label}
       icon={VideoRecorder}
-      variant={variant}
+      variant="default"
       size="sm"
       disabled={disabled}
       onClick={join.onJoin}

--- a/packages/react/src/experimental/F0MeetingCard/components/MeetingJoinButton.tsx
+++ b/packages/react/src/experimental/F0MeetingCard/components/MeetingJoinButton.tsx
@@ -25,7 +25,6 @@ export const MeetingJoinButton = ({
         label={label}
         icon={VideoRecorder}
         variant="default"
-        size="sm"
         href={join.href}
       />
     )
@@ -36,7 +35,6 @@ export const MeetingJoinButton = ({
       label={label}
       icon={VideoRecorder}
       variant="default"
-      size="sm"
       disabled={disabled}
       onClick={join.onJoin}
     />

--- a/packages/react/src/experimental/F0MeetingCard/components/MeetingStatusTag.tsx
+++ b/packages/react/src/experimental/F0MeetingCard/components/MeetingStatusTag.tsx
@@ -1,0 +1,77 @@
+import { F0TagStatus } from "@/components/tags/F0TagStatus"
+import { BaseTag } from "@/components/tags/internal/BaseTag"
+import { Ai } from "@/icons/app"
+import { useReducedMotion } from "@/lib/a11y"
+import { useI18n } from "@/lib/providers/i18n"
+import { cn } from "@/lib/utils"
+
+import type { MeetingState } from "../types"
+
+/**
+ * "Live" indicator for a running meeting. It deliberately avoids the `critical`
+ * variant: red in F0 means destructive or failed, and a meeting in progress is
+ * neither. The pulse is what carries the "happening right now" meaning, so it is
+ * dropped when the viewer asked for reduced motion — the tag still reads
+ * correctly from its label alone.
+ */
+const LiveTag = ({ text }: { text: string }) => {
+  const shouldReduceMotion = useReducedMotion()
+
+  return (
+    <BaseTag
+      className="bg-f1-background-info text-f1-foreground-info"
+      left={
+        <div
+          className={cn(
+            "m-1 aspect-square w-2 rounded-full bg-f1-icon-info",
+            !shouldReduceMotion && "animate-pulse"
+          )}
+          aria-hidden
+        />
+      }
+      text={text}
+    />
+  )
+}
+
+export const MeetingStatusTag = ({
+  state,
+  countdownLabel,
+}: {
+  state: MeetingState
+  /** Countdown copy shown while waiting inside the join window, e.g. "In 10 mins". */
+  countdownLabel?: string
+}) => {
+  const { meetingCard } = useI18n()
+
+  switch (state) {
+    case "inProgress":
+      return <LiveTag text={meetingCard.inProgress} />
+    case "summarizing":
+      // The recap is AI-generated, so the tag carries F0's AI mark instead of the
+      // default status dot. `icons/ai/Summary` is closer in meaning but its text
+      // lines blur at tag size; this one stays legible at 14px.
+      return (
+        <F0TagStatus
+          text={meetingCard.summarizing}
+          variant="neutral"
+          icon={Ai}
+        />
+      )
+    case "finished":
+      // `positive` (green) so a completed meeting is distinguishable at a glance
+      // from a cancelled one, which stays neutral — grey for both would make the
+      // outcome depend on reading the label.
+      return <F0TagStatus text={meetingCard.finished} variant="positive" />
+    case "cancelled":
+      return <F0TagStatus text={meetingCard.cancelled} variant="neutral" />
+    case "scheduled":
+      // `warning` rather than `neutral`: a meeting minutes away is something to
+      // act on now, and the amber reads as that without implying anything failed.
+      return countdownLabel ? (
+        <F0TagStatus text={countdownLabel} variant="warning" />
+      ) : null
+    default:
+      return null
+  }
+}

--- a/packages/react/src/experimental/F0MeetingCard/components/MeetingSummary.tsx
+++ b/packages/react/src/experimental/F0MeetingCard/components/MeetingSummary.tsx
@@ -1,0 +1,20 @@
+import { useI18n } from "@/lib/providers/i18n"
+import { Text } from "@/ui/Text"
+
+/**
+ * The recap of a finished meeting, rendered in full.
+ *
+ * It is shown whole rather than clamped with a toggle: a recap is only worth
+ * having if it's read, and hiding it behind a control makes that a second
+ * decision the reader has to take. The trade-off is that card heights vary with
+ * the length of the recap — revisit if design asks for a fixed row height.
+ */
+export const MeetingSummary = ({ summary }: { summary: string }) => {
+  const { meetingCard } = useI18n()
+
+  return (
+    <div role="group" aria-label={meetingCard.summary}>
+      <Text variant="body" content={summary} className="break-words" />
+    </div>
+  )
+}

--- a/packages/react/src/experimental/F0MeetingCard/hooks/useMeetingLabels.ts
+++ b/packages/react/src/experimental/F0MeetingCard/hooks/useMeetingLabels.ts
@@ -1,0 +1,112 @@
+import { useMemo } from "react"
+
+import { useI18n } from "@/lib/providers/i18n"
+
+import type { MeetingState } from "../types"
+import {
+  formatShortDate,
+  formatTime,
+  getDayKind,
+  getDurationMinutes,
+  getMinutesSinceStart,
+  getMinutesUntilStart,
+  pluralize,
+  resolveLocale,
+  shouldShowCountdown,
+} from "../utils"
+
+/**
+ * Every human-readable string the card derives from its dates and counts.
+ *
+ * The card owns this formatting on purpose: leaving it to consumers is how the
+ * same meeting ends up reading differently in each product. Nothing here reads a
+ * clock of its own — `now` is passed in.
+ */
+export const useMeetingLabels = ({
+  state,
+  startsAt,
+  endsAt,
+  now,
+  windowMinutes,
+  invitedCount,
+  presentCount,
+}: {
+  state: MeetingState
+  startsAt: Date
+  endsAt?: Date
+  now: Date
+  windowMinutes?: number
+  invitedCount: number
+  presentCount?: number
+}) => {
+  const { meetingCard } = useI18n()
+
+  return useMemo(() => {
+    const locale = resolveLocale()
+
+    const dayLabels: Record<string, string | undefined> = {
+      today: meetingCard.today,
+      yesterday: meetingCard.yesterday,
+      tomorrow: meetingCard.tomorrow,
+    }
+
+    const dayKind = getDayKind(startsAt, now)
+    const dayLabel = dayLabels[dayKind] ?? formatShortDate(startsAt, locale)
+
+    const elapsedMinutes = getMinutesSinceStart(startsAt, now)
+    // A meeting that just started reads better as "Starting now" than as
+    // "0 mins ago", which looks like a rounding bug.
+    const leadLabel =
+      state === "inProgress"
+        ? elapsedMinutes === 0
+          ? meetingCard.startingNow
+          : pluralize(meetingCard.startedAgo, elapsedMinutes)
+        : dayLabel
+
+    const remainingMinutes = getMinutesUntilStart(startsAt, now)
+    const countdownLabel = shouldShowCountdown({
+      state,
+      startsAt,
+      now,
+      windowMinutes,
+    })
+      ? remainingMinutes <= 0
+        ? meetingCard.startingNow
+        : pluralize(meetingCard.startsIn, remainingMinutes)
+      : undefined
+
+    const attendeesLabel =
+      state === "inProgress" && presentCount !== undefined
+        ? pluralize(meetingCard.inside, presentCount)
+        : invitedCount > 0
+          ? pluralize(meetingCard.invited, invitedCount)
+          : undefined
+
+    // Only meaningful once the meeting is over — a duration on an upcoming
+    // meeting would read as its length, which nobody has committed to yet.
+    const durationMinutes =
+      state === "finished" || state === "summarizing"
+        ? getDurationMinutes(startsAt, endsAt)
+        : undefined
+
+    return {
+      leadLabel,
+      timeLabel: formatTime(startsAt, locale),
+      durationLabel:
+        durationMinutes !== undefined
+          ? pluralize(meetingCard.duration, durationMinutes)
+          : undefined,
+      countdownLabel,
+      attendeesLabel,
+    }
+  }, [
+    meetingCard,
+    state,
+    startsAt,
+    endsAt,
+    now,
+    windowMinutes,
+    invitedCount,
+    presentCount,
+  ])
+}

--- a/packages/react/src/experimental/F0MeetingCard/index.tsx
+++ b/packages/react/src/experimental/F0MeetingCard/index.tsx
@@ -1,0 +1,9 @@
+export { F0MeetingCard } from "./F0MeetingCard"
+export { attendeesDisplays, meetingStates } from "./types"
+export type {
+  AttendeesDisplay,
+  F0MeetingCardProps,
+  MeetingAttendee,
+  MeetingJoin,
+  MeetingState,
+} from "./types"

--- a/packages/react/src/experimental/F0MeetingCard/types.ts
+++ b/packages/react/src/experimental/F0MeetingCard/types.ts
@@ -76,8 +76,9 @@ export interface F0MeetingCardProps
   /**
    * Dense layout for embedding the card inline or in a tight list: the headline
    * and the relative time sit on one line (wrapping when they don't fit),
-   * attendees shrink to `xs`, the footer band is dropped and the state travels
-   * with the headline, and the join button drops to `outline` emphasis.
+   * attendees shrink to `xs`, and the footer band is dropped so the state travels
+   * with the headline. The join button keeps the same emphasis as in the regular
+   * layout.
    * @default false
    */
   compact?: boolean

--- a/packages/react/src/experimental/F0MeetingCard/types.ts
+++ b/packages/react/src/experimental/F0MeetingCard/types.ts
@@ -1,0 +1,138 @@
+import type { CardSecondaryAction } from "@/components/F0Card/components/CardActions"
+import { DataAttributes } from "@/global.types"
+import { WithDataTestIdProps } from "@/lib/data-testid"
+
+/**
+ * Lifecycle of the meeting. It is always **controlled** — only the backend knows
+ * whether a meeting really started, ended or is still being summarised, so the
+ * card never infers it from the clock. Time-derived presentation (the countdown,
+ * the elapsed label, whether Join is actionable) is computed from `startsAt` and
+ * `now`.
+ */
+export const meetingStates = [
+  "scheduled",
+  "inProgress",
+  "summarizing",
+  "finished",
+  "cancelled",
+] as const
+
+export type MeetingState = (typeof meetingStates)[number]
+
+export const attendeesDisplays = ["auto", "avatars", "count"] as const
+
+export type AttendeesDisplay = (typeof attendeesDisplays)[number]
+
+/**
+ * A meeting participant. Internal attendees are employees, so they carry a
+ * first/last name and an optional picture. External attendees are identified by
+ * whatever the invitation exposed — a display name, an email, or both — and
+ * always render as initials.
+ */
+export type MeetingAttendee =
+  | {
+      type: "internal"
+      firstName: string
+      lastName: string
+      src?: string
+      email?: string
+    }
+  | {
+      type: "external"
+      name?: string
+      email?: string
+    }
+
+export interface MeetingJoin {
+  /** Called when the Join button is pressed. */
+  onJoin?: () => void
+  /** Navigates to the meeting room instead of handling the click. */
+  href?: string
+  /**
+   * How many minutes before `startsAt` the meeting can be joined.
+   * @default 10
+   */
+  windowMinutes?: number
+  /**
+   * Forces the button into its disabled state regardless of the join window —
+   * e.g. while the room is still being provisioned.
+   */
+  disabled?: boolean
+  /** Overrides the default "Join" label. */
+  label?: string
+}
+
+export interface F0MeetingCardProps
+  extends WithDataTestIdProps, DataAttributes {
+  /** Lifecycle of the meeting. See {@link meetingStates}. */
+  state: MeetingState
+
+  /**
+   * The meeting title. When omitted, an in-progress meeting falls back to the
+   * "Call in progress" headline so the row still says what it is.
+   */
+  title?: string
+
+  /**
+   * Dense layout for embedding the card inline or in a tight list: the headline
+   * and the relative time sit on one line (wrapping when they don't fit),
+   * attendees shrink to `xs`, the footer band is dropped and the state travels
+   * with the headline, and the join button drops to `outline` emphasis.
+   * @default false
+   */
+  compact?: boolean
+
+  /** When the meeting starts. Drives the date line, the countdown and the join window. */
+  startsAt: Date
+
+  /** When the meeting ends. Only used for the duration label. */
+  endsAt?: Date
+
+  /**
+   * Reference instant for every time-derived label. Defaults to the current time
+   * at render — the card never ticks on its own, so pass a fixed value to keep
+   * stories and tests deterministic, and re-render to refresh.
+   */
+  now?: Date
+
+  /**
+   * Known attendees, internal and external. May be a subset of the real
+   * invitation list — pass `invitedCount` for the true total.
+   */
+  attendees?: MeetingAttendee[]
+
+  /** Total number of invited people, when `attendees` is a truncated list. */
+  invitedCount?: number
+
+  /** How many attendees are currently in the meeting. Only used while in progress. */
+  presentCount?: number
+
+  /**
+   * Whether attendees render as stacked avatars or as a plain count.
+   * `"auto"` shows avatars while the meeting is in progress (who is in the room
+   * matters) and a count otherwise (how many were invited matters).
+   * @default "auto"
+   */
+  attendeesDisplay?: AttendeesDisplay
+
+  /**
+   * How many avatars to show before collapsing the rest into a `+N` counter.
+   * @default 3
+   */
+  maxAvatars?: number
+
+  /**
+   * Short recap of the meeting. Rendered in full, and only once the meeting is
+   * `finished`.
+   */
+  summary?: string
+
+  /** Join affordance. Only rendered while the meeting is scheduled or in progress. */
+  join?: MeetingJoin
+
+  /**
+   * Extra footer buttons — e.g. a "Transcript" action whose destination the
+   * consumer owns.
+   */
+  secondaryActions?: CardSecondaryAction[]
+}

--- a/packages/react/src/experimental/F0MeetingCard/utils.ts
+++ b/packages/react/src/experimental/F0MeetingCard/utils.ts
@@ -1,0 +1,194 @@
+import { differenceInMinutes, format, isSameDay, type Locale } from "date-fns"
+
+import { getLocale } from "@/components/OneCalendar/utils"
+
+import type { AttendeesDisplay, MeetingAttendee, MeetingState } from "./types"
+
+export const DEFAULT_JOIN_WINDOW_MINUTES = 10
+
+export const DEFAULT_MAX_AVATARS = 3
+
+export type MeetingDayKind = "today" | "yesterday" | "tomorrow" | "other"
+
+/** Resolve the browser's `date-fns` locale, falling back to the library default. */
+export const resolveLocale = (): Locale | undefined => {
+  if (typeof navigator === "undefined") return undefined
+  return getLocale(navigator.language)
+}
+
+const addDays = (date: Date, days: number): Date => {
+  const result = new Date(date)
+  result.setDate(result.getDate() + days)
+  return result
+}
+
+/**
+ * Which calendar day `date` falls on relative to `now`. Only the neighbouring
+ * days get a word of their own; anything further reads better as a date.
+ */
+export const getDayKind = (date: Date, now: Date): MeetingDayKind => {
+  if (isSameDay(date, now)) return "today"
+  if (isSameDay(date, addDays(now, -1))) return "yesterday"
+  if (isSameDay(date, addDays(now, 1))) return "tomorrow"
+  return "other"
+}
+
+/** Whole minutes left until `startsAt`. Negative once the start time has passed. */
+export const getMinutesUntilStart = (startsAt: Date, now: Date): number =>
+  differenceInMinutes(startsAt, now)
+
+/** Whole minutes elapsed since `startsAt`. Never negative. */
+export const getMinutesSinceStart = (startsAt: Date, now: Date): number =>
+  Math.max(0, differenceInMinutes(now, startsAt))
+
+/**
+ * The meeting is joinable while it is running, and from `windowMinutes` before
+ * the scheduled start. A scheduled meeting whose start time already passed stays
+ * joinable — the attendee is late, not locked out.
+ */
+export const isWithinJoinWindow = ({
+  state,
+  startsAt,
+  now,
+  windowMinutes = DEFAULT_JOIN_WINDOW_MINUTES,
+}: {
+  state: MeetingState
+  startsAt: Date
+  now: Date
+  windowMinutes?: number
+}): boolean => {
+  if (state === "inProgress") return true
+  if (state !== "scheduled") return false
+  return getMinutesUntilStart(startsAt, now) <= windowMinutes
+}
+
+/** The Join affordance only makes sense before and during the meeting. */
+export const isJoinRelevant = (state: MeetingState): boolean =>
+  state === "scheduled" || state === "inProgress"
+
+/**
+ * Whether a countdown tag should be shown. Only while waiting inside the join
+ * window — outside it the exact time in the date line is the useful information.
+ */
+export const shouldShowCountdown = ({
+  state,
+  startsAt,
+  now,
+  windowMinutes = DEFAULT_JOIN_WINDOW_MINUTES,
+}: {
+  state: MeetingState
+  startsAt: Date
+  now: Date
+  windowMinutes?: number
+}): boolean => {
+  if (state !== "scheduled") return false
+  const minutes = getMinutesUntilStart(startsAt, now)
+  return minutes <= windowMinutes
+}
+
+/**
+ * Whether any status tag is rendered for this state. Kept separate from the tag
+ * component so the layout can tell an empty footer band from a populated one.
+ *
+ * Every state names itself except a scheduled meeting still far out, where the
+ * exact time in the date line is the useful information and a tag would only
+ * repeat "upcoming".
+ */
+export const hasStatusTag = ({
+  state,
+  hasCountdown,
+}: {
+  state: MeetingState
+  hasCountdown: boolean
+}): boolean => {
+  if (state === "scheduled") return hasCountdown
+  return true
+}
+
+/** Length of the meeting in whole minutes, once it is known to have ended. */
+export const getDurationMinutes = (
+  startsAt: Date,
+  endsAt: Date | undefined
+): number | undefined => {
+  if (!endsAt) return undefined
+  const minutes = differenceInMinutes(endsAt, startsAt)
+  return minutes > 0 ? minutes : undefined
+}
+
+export const resolveAttendeesDisplay = (
+  display: AttendeesDisplay,
+  state: MeetingState
+): "avatars" | "count" => {
+  if (display !== "auto") return display
+  return state === "inProgress" ? "avatars" : "count"
+}
+
+/**
+ * The attendee total that matters for the current state: who is in the room
+ * while the meeting runs, how many were invited otherwise.
+ */
+export const resolveRelevantCount = ({
+  state,
+  attendees,
+  invitedCount,
+  presentCount,
+}: {
+  state: MeetingState
+  attendees: MeetingAttendee[]
+  invitedCount?: number
+  presentCount?: number
+}): number => {
+  if (state === "inProgress" && presentCount !== undefined) return presentCount
+  return invitedCount ?? attendees.length
+}
+
+export type NormalizedAttendee = {
+  firstName: string
+  lastName: string
+  src?: string
+  tooltipDescription?: string
+}
+
+/**
+ * `F0AvatarList` speaks first/last name, but an external attendee may only come
+ * with a display name or an email. Split what we have so the avatar still derives
+ * sensible initials, and surface the email as the tooltip's secondary line.
+ */
+export const normalizeAttendees = (
+  attendees: MeetingAttendee[]
+): NormalizedAttendee[] =>
+  attendees.map((attendee) => {
+    if (attendee.type === "internal") {
+      return {
+        firstName: attendee.firstName,
+        lastName: attendee.lastName,
+        src: attendee.src,
+        tooltipDescription: attendee.email,
+      }
+    }
+
+    const label = attendee.name?.trim() || attendee.email?.split("@")[0] || ""
+    const [firstName = "", ...rest] = label.split(/\s+/)
+
+    return {
+      firstName,
+      lastName: rest.join(" "),
+      tooltipDescription: attendee.email,
+    }
+  })
+
+/**
+ * The library has no plural resolver — translations expose `one`/`other` forms
+ * and components pick between them. See the i18n conventions.
+ */
+export const pluralize = (
+  forms: { one: string; other: string },
+  count: number
+): string =>
+  (count === 1 ? forms.one : forms.other).replace("{{count}}", String(count))
+
+export const formatTime = (date: Date, locale?: Locale): string =>
+  format(date, "p", { locale })
+
+export const formatShortDate = (date: Date, locale?: Locale): string =>
+  format(date, "d MMM", { locale })

--- a/packages/react/src/experimental/exports.ts
+++ b/packages/react/src/experimental/exports.ts
@@ -24,6 +24,7 @@ export * from "../kits/Charts/exports"
  */
 export * from "../components/F0ActionBar"
 export * from "./F0CardHorizontal"
+export * from "./F0MeetingCard"
 export * from "./F0ProgressSeries"
 export * from "./F0SegmentedBar"
 export * from "./F0VersionHistory"

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -66,6 +66,40 @@ export const defaultTranslations = {
     language: "Language",
     audio: "Audio",
   },
+  meetingCard: {
+    today: "Today",
+    yesterday: "Yesterday",
+    tomorrow: "Tomorrow",
+    inProgress: "In progress",
+    inProgressTitle: "Call in progress",
+    summarizing: "Summarizing",
+    finished: "Finished",
+    cancelled: "Cancelled",
+    startingNow: "Starting now",
+    startsIn: {
+      one: "In {{count}} min",
+      other: "In {{count}} mins",
+    },
+    startedAgo: {
+      one: "{{count}} min ago",
+      other: "{{count}} mins ago",
+    },
+    invited: {
+      one: "{{count}} guest",
+      other: "{{count}} guests",
+    },
+    inside: {
+      one: "{{count}} inside",
+      other: "{{count}} inside",
+    },
+    duration: {
+      one: "{{count}} min",
+      other: "{{count}} mins",
+    },
+    attendees: "Attendees",
+    join: "Join",
+    summary: "Summary",
+  },
   actions: {
     add: "Add",
     edit: "Edit",


### PR DESCRIPTION
## Description

Adds `F0MeetingCard` to `experimental/`: a card for a single meeting before, during and after it happens — when it is, who is attending, how to join, and the recap once it's over. It exists because every surface that lists meetings (upcoming 1:1s, an interview in a hiring pipeline, an AI call on a candidate's profile, an agenda widget) otherwise reimplements the same two things differently: the time-derived presentation (day label, countdown, elapsed time, join window) and the attendee treatment for internal and external people. The design is not final — the API and the states were built to drive that conversation, which is why it lands experimental.

<img width="454" height="638" alt="image" src="https://github.com/user-attachments/assets/b535f30f-1318-46fe-9969-4550d8c1e895" />

## Type of change

- [x] New component (aligned in #f0-support, lands in `experimental/`)

## Lifecycle phase (if applicable)

- Linked #f0-support thread: **not yet opened** — see the note below.
- Phase exit criteria met: Phase 3 (Build) technical criteria are met (stories, unit tests, play + axe, MDX, quality gate). **Phases 1 and 2 are not**: there is no Foundations alignment thread and no design review yet.

> Opening this as a draft on purpose. The design was not final, so the stories were built as the artefact to align on rather than after the fact. Please treat the API and the visual decisions below as proposals, not as done.

## Screenshots (if applicable)

Every state is in the image above, taken from the consolidated `Snapshot` story — the same one Chromatic captures, so a visual change produces exactly one diff to review. To poke at it live: `pnpm storybook dev` → **Components / F0MeetingCard**.

## Implementation details

- feat: add `F0MeetingCard` in `src/experimental/F0MeetingCard/` with `state`, `startsAt`/`endsAt`/`now`, attendees, `join`, `summary`, `secondaryActions` and `compact`

  <details>
  <summary>Why the state is controlled but the formatting is not</summary>

  `state` is always supplied by the consumer. Only the backend knows whether a
  meeting truly started, whether it ended, or whether the recap is still being
  generated — a card that inferred those from the clock would say "in progress"
  for a meeting nobody joined.

  Everything *derived* from time is the card's job instead: the day label
  ("Today", "Yesterday"), the countdown, the elapsed time, the duration and
  whether Join is actionable. Leaving that to consumers is how the same meeting
  ends up reading differently in each product — ATS already formats these by
  hand.

  The card never ticks. There is no `setInterval`: `now` is a prop defaulting to
  render time, so the component is a pure function of its props. The consumer is
  already re-rendering as the meeting's real state changes, and an injectable
  clock keeps stories and Chromatic snapshots deterministic.
  </details>

- feat: derive the join window from `startsAt` — actionable from `windowMinutes` (10 by default) and while the meeting runs, including for a late attendee; `join.disabled` forces it off

- feat: switch attendees between stacked avatars and a written count based on state — faces while the meeting runs (who is in the room), a count otherwise (how many were invited) — overridable with `attendeesDisplay`

  <details>
  <summary>External attendees and partial lists</summary>

  `F0AvatarList` speaks first/last name, but an external attendee may arrive with
  only a display name or an email, so they are normalised into initials with the
  email as the tooltip's secondary line.

  `invitedCount` / `presentCount` cover the case where the backend gives a total
  but not every identity; the excess folds into the `+N`. Worth knowing: forcing
  a count higher than the list makes `F0AvatarList` drop its `+N` popover
  entirely, so the names disappear while the number stays right. Documented in
  the MDX — pass the identities when you have them.
  </details>

- feat: add a `compact` layout for embedding the card inline or in tight lists — headline and relative time on one line, `xs` avatars, no footer band, and the state carried by the headline instead of a tag

  <details>
  <summary>Join keeps its regular emphasis here</summary>

  It first dropped to `outline` in compact, on the reasoning that an embedded card
  shouldn't shout over its host. Reverted: joining is the same action with the
  same weight whatever the density, so looking weaker there was wrong.
  </details>

- fix: let the footer buttons follow F0's default size (`md`) instead of pinning them to `sm`

  <details>
  <summary>It also makes the skeleton honest</summary>

  The skeleton's button placeholder is 32px, which matched `md` but not the 24px
  `sm` button it stood in for — so the card shifted slightly on load. They now
  line up.
  </details>

- feat: render the recap in full once `finished`, with no expand toggle

  <details>
  <summary>Why no "show more"</summary>

  It started clamped to two lines with a toggle. Dropped deliberately: a recap is
  only worth having if it gets read, and hiding it behind a control makes that a
  second decision for the reader. The trade-off is that card heights vary with
  the length of the recap — flagged in the MDX and in the component, to revisit
  if design wants a fixed row height.
  </details>

- feat: match `F0AudioPlayerCard`'s container geometry (`rounded-2xl`, `p-3`, `border-f1-border-secondary`) instead of the heavier `ui/Card` defaults

  <details>
  <summary>Worth a Foundations decision</summary>

  A meeting and its recording sit next to each other, and with `ui/Card`'s
  defaults the meeting card had a border at twice the opacity, a 16px radius and
  16px padding against the audio player's 0.1 alpha / 20px / 12px.

  Aligning it fixes the pairing but means F0 now has two card geometries in
  circulation. Either `ui/Card` is out of date or the audio player stepped
  outside the standard — that is a call for Foundations, not for this PR.
  </details>

- feat: add `meetingCard.*` translations (day labels, countdown and elapsed plurals, attendee counts, duration, status labels, join)

  <details>
  <summary>Why the API-surface bot flags this</summary>

  The breaking-change bot reports the added `meetingCard` key, because
  `TranslationsType` demands the full shape: a consumer maintaining its own
  translations object has to add it.

  Kept as a plain `feat:` rather than `feat!:` — that is the standing convention
  here. Every new component with copy trips this, and none of the last 40 commits
  touching the translation defaults (`F0VideoPlayer`, `F0ProgressSeries`,
  `F0PdfViewer` among them) was marked breaking. The check is non-blocking, and
  everything else it reports is additive.
  </details>

- test: 41 unit tests — pure time/window/normalisation logic plus rendering across all six state combinations

- test: 10 stories with play functions covering the join window, the `+N` popover and the finished state, all running axe

- docs: MDX covering the controlled-state contract, the join window, attendee visibility limits, `compact`, the status colour scale, the accessibility gaps and what is deliberately absent


### Known accessibility gap (not introduced here)

The `+N` popover is a Radix `HoverCard` in `F0AvatarList` whose trigger is a non-focusable `div`, so it opens on hover but not from the keyboard. Nothing in this card depends on it for meaning, but it is worth fixing upstream.

### Deliberately absent

No whole-card link or `onClick` (no use case for navigating from the card itself), no overflow `⋯` menu (nothing designed to go in it yet), and no transcript viewer — transcripts are long and where they open is a product decision, so it is passed as a `secondaryActions` entry.

