### PR TITLE
fix(OneDataCollection): grouped Kanban layout — align header + content-height lanes

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/__stories__/grouping.mdx
+++ b/packages/react/src/patterns/OneDataCollection/__stories__/grouping.mdx
@@ -209,3 +209,21 @@ useful when "select a whole group" isn't a meaningful action for the consumer.
 selection (and bulk actions) while hiding the per-group "Select all" checkbox.
 
 <Canvas of={KanbanStories.KanbanWithGroupingHiddenGroupSelect} />
+
+### Kanban height and scrolling
+
+The Kanban visualization controls its vertical behaviour with the `heightMode`
+prop (defined on the underlying `Kanban` component):
+
+- **`"fill"` (default)** — lanes stretch to fill the available height and each
+  lane scrolls its own cards. This suits a standalone Kanban that owns the
+  viewport, and it stays the default.
+- **`"content"`** — lanes hug their cards (no per-lane scroll) and every lane
+  matches the tallest, so a single outer container owns the vertical scroll.
+
+Grouped Kanban uses `"content"`. A grouped collection stacks one board per
+group inside a single scrollable list — the same container the grouped List and
+Card visualizations already scroll in. With per-lane scroll there you would get
+nested scrolling and could never see a whole group at once, so the grouped
+Kanban lets the group list own the single scroll, keeping it consistent with
+List and Card.

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/Kanban.tsx
@@ -492,7 +492,10 @@ export const KanbanCollection = <
                 >
                   <GroupHeader
                     className={cn(
-                      "rounded-md px-3.5 py-3",
+                      // Left inset matches the collection toolbar's content (the
+                      // search/filters row) so a group's label lines up with it and
+                      // with the board's cards below, instead of hanging further left.
+                      "rounded-md py-3 pl-6 pr-3.5",
                       (collapsible || groupSelectable) &&
                         "cursor-pointer select-none transition-colors hover:bg-f1-background-hover"
                     )}
@@ -523,14 +526,13 @@ export const KanbanCollection = <
                           ease: "easeInOut",
                         }}
                       >
-                        {/* Stacked boards render at content height; the group list
-                          above owns the single vertical scroll — same model as the
-                          grouped List/Card. Each lane still honours ui/Kanban's
-                          400px minimum (KanbanLane MIN_HEIGHT); a true content-hug
-                          for short groups would need an explicit content-height
-                          option on ui/Kanban (pending Foundations). */}
+                        {/* heightMode="content": each group's board hugs its cards
+                          (lanes grow, matched to the tallest, no per-lane scroll) so
+                          the group list above owns the single vertical scroll — same
+                          model as the grouped List/Card. */}
                         <KanbanBoard<R>
                           lanes={board.lanes}
+                          heightMode="content"
                           renderCard={renderCard}
                           getKey={getKey}
                           onCreate={onCreate}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/KanbanBoard.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Kanban/KanbanBoard.tsx
@@ -16,6 +16,7 @@ type KanbanBoardProps<R extends RecordType> = {
   idProvider?: (item: R, index?: number) => string | number | symbol
   allowReorder: boolean
   loading: boolean
+  heightMode?: KanbanProps<R>["heightMode"]
 }
 
 /**
@@ -34,6 +35,7 @@ export const KanbanBoard = <R extends RecordType>({
   idProvider,
   allowReorder,
   loading,
+  heightMode,
 }: KanbanBoardProps<R>) => {
   const [instanceId] = useState(() => Symbol("kanban-visualization"))
 
@@ -73,8 +75,9 @@ export const KanbanBoard = <R extends RecordType>({
       renderCard,
       onCreate,
       dnd,
+      heightMode,
     }),
-    [lanes, loading, getKey, renderCard, onCreate, dnd]
+    [lanes, loading, getKey, renderCard, onCreate, dnd, heightMode]
   )
 
   return !onMove ? (

--- a/packages/react/src/ui/Kanban/Kanban.test.tsx
+++ b/packages/react/src/ui/Kanban/Kanban.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest"
+
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { Kanban } from "./Kanban"
+import type { KanbanProps } from "./types"
+
+type Task = { id: string; title: string }
+
+const lanes: KanbanProps<Task>["lanes"] = [
+  { id: "todo", title: "Todo", items: [{ id: "t1", title: "T1" }] },
+  { id: "done", title: "Done", items: [{ id: "d1", title: "D1" }] },
+]
+
+const renderKanban = (heightMode?: KanbanProps<Task>["heightMode"]) =>
+  render(
+    <Kanban<Task>
+      heightMode={heightMode}
+      lanes={lanes}
+      getKey={(item) => item.id}
+      renderCard={(item) => <div>{item.title}</div>}
+    />
+  )
+
+// The lane's outer element (the one that carries the sizing) is the direct child
+// of the per-lane test-id wrapper; its flex parent is the board row.
+const laneOuter = (id: string) =>
+  screen.getByTestId(`lane-${id}`).firstElementChild as HTMLElement
+const boardRow = (id: string) =>
+  screen.getByTestId(`lane-${id}`).parentElement as HTMLElement
+
+describe("Kanban heightMode", () => {
+  it("content mode: row stretches lanes and no explicit height is applied (h-full owns sizing)", () => {
+    renderKanban("content")
+
+    expect(boardRow("todo")).toHaveClass("items-stretch")
+    const outer = laneOuter("todo")
+    expect(outer).toHaveClass("h-full")
+    // The board's items-stretch matches lane heights — a measured px height here
+    // would shadow h-full, so content mode must never set one.
+    expect(outer.style.height).toBe("")
+  })
+
+  it("fill mode is the default: lanes are top-aligned and sized by measurement, not h-full", () => {
+    renderKanban()
+
+    expect(boardRow("todo")).toHaveClass("items-start")
+    expect(laneOuter("todo")).not.toHaveClass("h-full")
+  })
+})

--- a/packages/react/src/ui/Kanban/Kanban.tsx
+++ b/packages/react/src/ui/Kanban/Kanban.tsx
@@ -304,7 +304,7 @@ export function Kanban<TRecord extends RecordType>(
       <ScrollArea
         className={cn(
           "relative w-full",
-          isContentHeight ? "" : "h-full [&>div>div]:h-full"
+          !isContentHeight && "h-full [&>div>div]:h-full"
         )}
         viewportRef={viewportRef}
       >

--- a/packages/react/src/ui/Kanban/Kanban.tsx
+++ b/packages/react/src/ui/Kanban/Kanban.tsx
@@ -19,6 +19,8 @@ export function Kanban<TRecord extends RecordType>(
   props: KanbanProps<TRecord>
 ): JSX.Element {
   const { lanes, renderCard, getKey, className, dnd, onCreate } = props
+  const heightMode = props.heightMode ?? "fill"
+  const isContentHeight = heightMode === "content"
 
   // Local source-of-truth for lanes to orchestrate moves centrally
   const [localLanes, setLocalLanes] = useState(
@@ -292,12 +294,26 @@ export function Kanban<TRecord extends RecordType>(
   }
 
   return (
-    <div className={cn("relative h-full w-full px-6", className)}>
+    <div
+      className={cn(
+        "relative w-full px-6",
+        !isContentHeight && "h-full",
+        className
+      )}
+    >
       <ScrollArea
-        className={"relative h-full w-full [&>div>div]:h-full"}
+        className={cn(
+          "relative w-full",
+          isContentHeight ? "" : "h-full [&>div>div]:h-full"
+        )}
         viewportRef={viewportRef}
       >
-        <div className="relative mb-2 flex h-full items-start gap-2">
+        <div
+          className={cn(
+            "relative mb-2 flex gap-2",
+            isContentHeight ? "items-stretch" : "h-full items-start"
+          )}
+        >
           {localLanes.map(
             (lane: KanbanLaneAttributes<TRecord>, laneIndex: number) => {
               const liveLane = lanes.find((l) => l.id === lane.id)
@@ -315,6 +331,7 @@ export function Kanban<TRecord extends RecordType>(
                 >
                   <KanbanLane<TRecord>
                     id={lane.id}
+                    heightMode={heightMode}
                     getLaneResourceIndexById={
                       lane.id
                         ? (id) => getIndexById(lane.id as string, id)

--- a/packages/react/src/ui/Kanban/__stories__/Kanban.stories.tsx
+++ b/packages/react/src/ui/Kanban/__stories__/Kanban.stories.tsx
@@ -585,3 +585,48 @@ export const SimpleOnMoveTest: Story = {
     })
   },
 }
+
+export const ContentHeight: Story = {
+  parameters: { docs: { story: { inline: false, height: "560px" } } },
+  args: { lanes: [], renderCard: () => null, getKey: () => "" },
+  render: function Render() {
+    const [instanceId] = useState(() => Symbol("kanban-content-height"))
+    const many: Task[] = Array.from({ length: 14 }, (_, i) => ({
+      id: `m${i}`,
+      title: `Task ${i + 1}`,
+    }))
+    const lanes: KanbanProps<Task>["lanes"] = [
+      { id: "backlog", title: "Backlog", items: many, variant: "neutral" },
+      {
+        id: "in-progress",
+        title: "In Progress",
+        items: mockRight,
+        variant: "info",
+      },
+      { id: "done", title: "Done", items: mockLeft, variant: "positive" },
+    ]
+    return (
+      <DndProvider driver={createAtlaskitDriver(instanceId)}>
+        {/* Constrained, scrollable outer container: with heightMode="content" the
+          lanes should grow to the tallest (Backlog) and this box should scroll —
+          NOT each lane scrolling internally. */}
+        <div className="h-[480px] overflow-auto rounded-lg border border-f1-border-secondary">
+          <Kanban<Task>
+            heightMode="content"
+            lanes={lanes}
+            getKey={(item: Task) => item.id}
+            renderCard={(item: Task, index: number, total: number) => (
+              <KanbanCard<Task>
+                drag={{ id: item.id, type: "list-card", data: { ...item } }}
+                id={item.id}
+                index={index}
+                total={total}
+                title={item.title}
+              />
+            )}
+          />
+        </div>
+      </DndProvider>
+    )
+  },
+}

--- a/packages/react/src/ui/Kanban/components/KanbanLane.tsx
+++ b/packages/react/src/ui/Kanban/components/KanbanLane.tsx
@@ -30,12 +30,14 @@ export function KanbanLane<TRecord extends RecordType>({
   id,
   getLaneResourceIndexById,
   onMove,
+  heightMode = "fill",
   ...laneProps
 }: {
   id?: string
   getLaneResourceIndexById?: (id: string) => number
   onMove?: (param: KanbanOnMoveParam) => Promise<TRecord>
   allowReorder?: boolean
+  heightMode?: "fill" | "content"
 } & LaneProps<TRecord>) {
   const laneRef = useRef<HTMLDivElement | null>(null)
   const outerRef = useRef<HTMLDivElement | null>(null)
@@ -560,8 +562,11 @@ export function KanbanLane<TRecord extends RecordType>({
       window.removeEventListener("kanban-test-move", handler as EventListener)
   }, [id, onMove])
 
-  // Calculate dynamic height based on content and container
+  // Calculate dynamic height based on content and container.
+  // In "content" mode the lane hugs its cards and matches its siblings via the
+  // board's items-stretch, so no explicit height is measured or applied.
   useLayoutEffect(() => {
+    if (heightMode === "content") return
     const measure = measureRef.current
     const outer = outerRef.current
     if (!measure || !outer) return
@@ -646,12 +651,17 @@ export function KanbanLane<TRecord extends RecordType>({
       }
       resizeObserver.disconnect()
     }
-  }, [laneProps.items.length, laneProps.loading, showEmptyLanePlaceholder])
+  }, [
+    laneProps.items.length,
+    laneProps.loading,
+    showEmptyLanePlaceholder,
+    heightMode,
+  ])
 
   return (
     <div
       ref={outerRef}
-      className="relative rounded"
+      className={cn("relative rounded", heightMode === "content" && "h-full")}
       style={{
         height: calculatedHeight ? `${calculatedHeight}px` : undefined,
       }}

--- a/packages/react/src/ui/Kanban/components/KanbanLane.tsx
+++ b/packages/react/src/ui/Kanban/components/KanbanLane.tsx
@@ -566,7 +566,13 @@ export function KanbanLane<TRecord extends RecordType>({
   // In "content" mode the lane hugs its cards and matches its siblings via the
   // board's items-stretch, so no explicit height is measured or applied.
   useLayoutEffect(() => {
-    if (heightMode === "content") return
+    if (heightMode === "content") {
+      // Drop any height measured in a previous "fill" render: an inline px height
+      // would shadow the `h-full` this mode relies on. No-op re-render when it is
+      // already null, so this can't loop.
+      setCalculatedHeight(null)
+      return
+    }
     const measure = measureRef.current
     const outer = outerRef.current
     if (!measure || !outer) return

--- a/packages/react/src/ui/Kanban/types.ts
+++ b/packages/react/src/ui/Kanban/types.ts
@@ -53,6 +53,13 @@ export interface KanbanProps<TRecord extends RecordType> {
   /** Optional callback triggered when requesting a new record in a lane */
   onCreate?: KanbanOnCreate
 
+  /** Vertical sizing of the board.
+   * - `"fill"` (default): lanes fill the available height and scroll internally.
+   * - `"content"`: lanes grow to fit their cards (no inner scroll) and every lane
+   *   matches the tallest, so an outer container owns the single vertical scroll.
+   *   Used by the grouped board, where each group hugs its content. */
+  heightMode?: "fill" | "content"
+
   /** Optional DnD configuration to enable droppable lanes */
   dnd?: {
     instanceId: symbol


### PR DESCRIPTION
## Summary
Two layout fixes for the **grouped Kanban** visualization (the onboarding tracking view is the first consumer):

### 1. Group-header alignment
The group/version label sat ~10px to the **left** of the collection toolbar's content (search/filters) and of the board's cards. The header's left inset now matches the toolbar, so the label lines up.

### 2. Content-height lanes (`heightMode`)
New **opt-in** `heightMode?: "fill" | "content"` on `ui/Kanban` — default `"fill"`, so **every existing board is unchanged**.

- `fill` (default): lanes fill the available height and scroll internally (today's behavior).
- `content`: lanes **hug their cards** — they grow to fit, all lanes **match the tallest** (`items-stretch`, no explicit per-lane height) and there's **no per-lane inner scroll**, so an outer container owns the single vertical scroll — the model grouped boards need (same as grouped List/Card).

Grouped boards (`KanbanBoard` inside `OneDataCollection`'s grouped Kanban) now pass `heightMode="content"`. This replaces the previous behavior where each lane capped at the viewport and scrolled internally (and removes the `pending Foundations` TODO in the viz).

> **Behavior change — `content` drops the 400px lane floor.** In `fill`, a lane with no parent height constraint floors at `KanbanLane`'s `MIN_HEIGHT` (400px). `content` removes that floor: lanes size purely to their cards and match the tallest, so a group whose lanes are all short (or empty) now renders a board shorter than 400px where `fill` would have padded it. This is intentional (it's what "hug their cards" means), and it only affects the grouped board that opts into `content` — every `fill` board is unchanged.

## Changes
- `ui/Kanban/types.ts`: `heightMode?: "fill" | "content"`
- `ui/Kanban/Kanban.tsx`: content mode → container/row not height-capped, `items-stretch`
- `ui/Kanban/components/KanbanLane.tsx`: content mode → skip the measured explicit height; `h-full` so lanes match the stretched row
- `KanbanBoard` wrapper: passthrough; grouped viz sets `heightMode="content"`
- New `ui/Kanban` **ContentHeight** story

## Caveat for Foundations
In `content` mode a lane's **drag-autoscroll** no longer applies (there's no inner scroll to drive). Drag & drop itself is unchanged. A very tall board would need the **outer** container to autoscroll while dragging — not wired here. Flagging in case you'd like that handled before this is used broadly.

## Testing
Verified in Storybook (new ContentHeight story + the grouped viz): equal columns, no inner scroll, outer container scrolls. `fill` mode unchanged. `format`/`tsc`/`lint` clean · Kanban unit suite 9/9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
