### PR TITLE
fix(F0ClarifyingPanel): let custom answer grow multiline instead of clipping

### DIFF
--- a/packages/react/src/kits/ai/F0ClarifyingPanel/F0ClarifyingPanel.tsx
+++ b/packages/react/src/kits/ai/F0ClarifyingPanel/F0ClarifyingPanel.tsx
@@ -77,7 +77,7 @@ const F0ClarifyingPanelContent = ({
     isCustomAnswerActive,
   } = currentStep
 
-  const customInputRef = useRef<HTMLInputElement>(null)
+  const customInputRef = useRef<HTMLTextAreaElement>(null)
 
   const mode = selectionMode ?? "single"
   const isMultiStep = totalSteps > 1

--- a/packages/react/src/kits/ai/F0ClarifyingPanel/__stories__/F0ClarifyingPanel.stories.tsx
+++ b/packages/react/src/kits/ai/F0ClarifyingPanel/__stories__/F0ClarifyingPanel.stories.tsx
@@ -68,13 +68,15 @@ const FORMAT_OPTIONS = [
 // dependency on F0AiChat / useAiChat.
 // ---------------------------------------------------------------------------
 
-function useLocalClarifyingState(steps: StoryStep[]) {
+function useLocalClarifyingState(
+  steps: StoryStep[],
+  initialInteractions: Record<string, StepInteraction> = {}
+) {
   const [resolved, setResolved] = useState<string[]>([])
   const [stepIndex, setStepIndex] = useState(0)
   const [dismissed, setDismissed] = useState(false)
-  const [interactions, setInteractions] = useState<
-    Record<string, StepInteraction>
-  >({})
+  const [interactions, setInteractions] =
+    useState<Record<string, StepInteraction>>(initialInteractions)
 
   const currentStep = steps[stepIndex]
   const interaction = currentStep
@@ -233,11 +235,16 @@ function useLocalClarifyingState(steps: StoryStep[]) {
 const StoryShell = ({
   steps,
   isSubmitDisabled,
+  initialInteractions,
 }: {
   steps: StoryStep[]
   isSubmitDisabled?: boolean
+  initialInteractions?: Record<string, StepInteraction>
 }) => {
-  const { state, resolved, reset } = useLocalClarifyingState(steps)
+  const { state, resolved, reset } = useLocalClarifyingState(
+    steps,
+    initialInteractions
+  )
 
   return (
     <div className="w-[360px] space-y-3">
@@ -396,6 +403,47 @@ export const CustomAnswerMultiple: Story = {
       []
     )
     return <StoryShell steps={steps} />
+  },
+}
+
+/**
+ * Long free-text answer: the custom answer field is a textarea that grows with
+ * its content (up to a max height, then scrolls) so long or multi-line
+ * responses stay fully visible instead of being clipped to a single line.
+ * Seeded with a long value — edit it or add newlines (Shift+Enter) to see it
+ * grow and shrink.
+ */
+export const CustomAnswerLongText: Story = {
+  render: () => {
+    const question = "Anything else we should know about this report?"
+    const steps = useMemo<StoryStep[]>(
+      () => [
+        {
+          question,
+          options: SINGLE_OPTIONS,
+          selectionMode: "single",
+          allowCustomAnswer: true,
+        },
+      ],
+      []
+    )
+    const initialInteractions = useMemo<Record<string, StepInteraction>>(
+      () => ({
+        [question]: {
+          selectedIds: [],
+          isCustomActive: true,
+          customText:
+            "Please group the results by department and then by team, " +
+            "exclude anyone who joined in the last 30 days, and add a " +
+            "summary row at the top with the company-wide totals so I can " +
+            "share it directly with the leadership team without editing it.",
+        },
+      }),
+      []
+    )
+    return (
+      <StoryShell steps={steps} initialInteractions={initialInteractions} />
+    )
   },
 }
 

--- a/packages/react/src/kits/ai/F0ClarifyingPanel/__tests__/F0ClarifyingPanel.test.tsx
+++ b/packages/react/src/kits/ai/F0ClarifyingPanel/__tests__/F0ClarifyingPanel.test.tsx
@@ -245,4 +245,74 @@ describe("F0ClarifyingPanel", () => {
       expect(state.confirm).not.toHaveBeenCalled()
     })
   })
+
+  describe("custom answer multiline input", () => {
+    it("renders the custom answer field as a multiline textarea", () => {
+      const state = buildState({}, { allowCustomAnswer: true })
+      render(<F0ClarifyingPanel clarifyingQuestion={state} />)
+      // A <textarea> keeps the "textbox" role but is a distinct element from
+      // a single-line <input>. Assert the tag so long answers can wrap.
+      expect(screen.getByRole("textbox").tagName).toBe("TEXTAREA")
+    })
+
+    it("does not restrict the custom answer to a single line", () => {
+      const state = buildState({}, { allowCustomAnswer: true })
+      render(<F0ClarifyingPanel clarifyingQuestion={state} />)
+      // resize is disabled (handled by auto-grow), but the element must not be
+      // the old single-line input that clipped long text.
+      const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+      expect(textarea).toBeInstanceOf(HTMLTextAreaElement)
+      expect(textarea).not.toHaveAttribute("type", "text")
+    })
+
+    it("preserves newlines in a multiline custom answer value", () => {
+      // A single-line <input> sanitizes newlines out of its value; a
+      // <textarea> keeps them. This is what lets long/multi-line answers
+      // render across several lines instead of being clipped to one.
+      const multiline = "first line\nsecond line\nthird line"
+      const state = buildState(
+        {},
+        {
+          allowCustomAnswer: true,
+          isCustomAnswerActive: true,
+          customAnswerText: multiline,
+        }
+      )
+      render(<F0ClarifyingPanel clarifyingQuestion={state} />)
+      const textarea = screen.getByRole("textbox") as HTMLTextAreaElement
+      expect(textarea.value).toBe(multiline)
+    })
+
+    it("inserts a newline (does not submit) on Shift+Enter", async () => {
+      const state = buildState(
+        {},
+        {
+          allowCustomAnswer: true,
+          isCustomAnswerActive: true,
+          customAnswerText: "line one",
+        }
+      )
+      render(<F0ClarifyingPanel clarifyingQuestion={state} />)
+      const textarea = screen.getByRole("textbox")
+      textarea.focus()
+      await userEvent.keyboard("{Shift>}{Enter}{/Shift}")
+      expect(state.confirm).not.toHaveBeenCalled()
+    })
+
+    it("submits on plain Enter when a custom answer can proceed", async () => {
+      const state = buildState(
+        {},
+        {
+          allowCustomAnswer: true,
+          isCustomAnswerActive: true,
+          customAnswerText: "my answer",
+        }
+      )
+      render(<F0ClarifyingPanel clarifyingQuestion={state} />)
+      const textarea = screen.getByRole("textbox")
+      textarea.focus()
+      await userEvent.keyboard("{Enter}")
+      expect(state.confirm).toHaveBeenCalledOnce()
+    })
+  })
 })

--- a/packages/react/src/kits/ai/F0ClarifyingPanel/components/CustomAnswerRow.tsx
+++ b/packages/react/src/kits/ai/F0ClarifyingPanel/components/CustomAnswerRow.tsx
@@ -1,4 +1,5 @@
-import type { Ref } from "react"
+import { useComposedRefs } from "@radix-ui/react-compose-refs"
+import { useLayoutEffect, useRef, type Ref } from "react"
 
 import { F0Checkbox } from "@/components/F0Checkbox"
 import { useI18n } from "@/lib/providers/i18n"
@@ -8,6 +9,10 @@ import type { ClarifyingSelectionMode } from "../types"
 
 import { RadioIndicator } from "./RadioIndicator"
 
+// Cap on auto-growth: beyond this the textarea scrolls internally instead of
+// pushing the whole panel taller. Roughly six lines of text.
+const MAX_TEXTAREA_HEIGHT = 132
+
 interface CustomAnswerRowProps {
   mode: ClarifyingSelectionMode
   hasSelection: boolean
@@ -15,7 +20,7 @@ interface CustomAnswerRowProps {
   customAnswerText: string | undefined
   isCustomAnswerActive: boolean
   canProceed: boolean
-  inputRef: Ref<HTMLInputElement>
+  inputRef: Ref<HTMLTextAreaElement>
   onActivate: () => void
   onChangeText: (text: string) => void
   onToggleActive: (active: boolean) => void
@@ -38,6 +43,24 @@ export const CustomAnswerRow = ({
   const translation = useI18n()
   const typeYourAnswer = translation.ai.clarifyingQuestion.typeYourAnswer
 
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const composedRef = useComposedRefs(textareaRef, inputRef)
+
+  // Auto-grow: mirror the textarea's height to its content so long answers
+  // wrap and stay visible instead of scrolling out of a single line. Runs
+  // after every value change via useLayoutEffect to avoid a visible reflow.
+  useLayoutEffect(() => {
+    const textarea = textareaRef.current
+    if (!textarea) return
+    // Collapse first so scrollHeight reports the true content height rather
+    // than the previous (possibly taller) height.
+    textarea.style.height = "auto"
+    const nextHeight = Math.min(textarea.scrollHeight, MAX_TEXTAREA_HEIGHT)
+    textarea.style.height = `${nextHeight}px`
+    textarea.style.overflowY =
+      textarea.scrollHeight > MAX_TEXTAREA_HEIGHT ? "auto" : "hidden"
+  }, [customAnswerText])
+
   const indicator =
     mode === "single" ? (
       <RadioIndicator isSelected={hasCustomText && !hasSelection} />
@@ -53,26 +76,27 @@ export const CustomAnswerRow = ({
   return (
     <div
       className={cn(
-        "flex items-center gap-2 rounded-md px-2 py-2",
+        "flex items-start gap-2 rounded-md px-2 py-2",
         "transition-colors hover:bg-f1-background-hover"
       )}
     >
       {indicator}
-      <input
-        ref={inputRef}
-        type="text"
+      <textarea
+        ref={composedRef}
+        rows={1}
         value={customAnswerText ?? ""}
         onChange={(e) => onChangeText(e.target.value)}
         onFocus={onActivate}
         onKeyDown={(e) => {
-          if (e.key === "Enter" && canProceed) {
+          // Enter submits; Shift+Enter inserts a newline for multi-line answers.
+          if (e.key === "Enter" && !e.shiftKey && canProceed) {
             e.preventDefault()
             onConfirm()
           }
         }}
         placeholder={typeYourAnswer}
         aria-label={typeYourAnswer}
-        className="min-w-0 flex-1 bg-transparent text-base text-f1-foreground outline-none placeholder:text-f1-foreground-tertiary"
+        className="min-w-0 flex-1 resize-none bg-transparent text-base text-f1-foreground outline-none placeholder:text-f1-foreground-tertiary"
       />
     </div>
   )

--- a/packages/react/src/kits/ai/F0ClarifyingPanel/components/OptionsList.tsx
+++ b/packages/react/src/kits/ai/F0ClarifyingPanel/components/OptionsList.tsx
@@ -19,7 +19,7 @@ interface OptionsListProps {
   customAnswerText: string | undefined
   isCustomAnswerActive: boolean
   canProceed: boolean
-  customInputRef: Ref<HTMLInputElement>
+  customInputRef: Ref<HTMLTextAreaElement>
   /** When true, auto-focus the first option when the list mounts */
   autoFocus?: boolean
   onToggleOption: (optionId: string) => void


### PR DESCRIPTION
## Description

The **custom ("other") answer** field in `F0ClarifyingPanel` was a single-line `<input type="text">`. When a user typed a long free-text answer, the text scrolled horizontally out of view — the beginning of the answer became invisible and the field was hard to read and edit.

This PR makes the custom answer field grow to fit its content: it now renders a `<textarea>` that auto-grows with the text (up to a max height, then scrolls internally), so long and multi-line answers stay fully visible.

## Type of change

- [x] Bug fix

## Implementation details

- `CustomAnswerRow`: replaced the single-line `<input>` with a `<textarea rows={1}>` styled to look identical (bare, transparent, no resize handle). A `useLayoutEffect` mirrors the element's height to its `scrollHeight` on every value change, capped at `MAX_TEXTAREA_HEIGHT` (~6 lines) after which it scrolls internally instead of pushing the panel taller.
  - The internal auto-grow ref is merged with the forwarded focus ref via `useComposedRefs` (already a repo dependency).
  - Row alignment changed from `items-center` to `items-start` so the radio/checkbox indicator stays anchored to the first line as the field grows.
- **Keyboard:** `Enter` still submits (unchanged); `Shift+Enter` now inserts a newline for explicit multi-line answers.
- Ref types threaded through `OptionsList` and `F0ClarifyingPanel` updated from `HTMLInputElement` → `HTMLTextAreaElement`.
- **Tests:** added 5 unit tests covering the textarea element, newline preservation in the value, `Shift+Enter` (no submit), and plain `Enter` (submit). All 26 tests pass.
- **Storybook:** added a `CustomAnswerLongText` story seeded with a long answer for quick visual validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
