### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.65.0",
+  "packages/react": "4.65.1",
   "packages/react-native": "0.59.0",
   "packages/core": "1.56.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.65.1](https://github.com/factorialco/f0/compare/f0-react-v4.65.0...f0-react-v4.65.1) (2026-07-29)
+
+
+### Bug Fixes
+
+* **F0ClarifyingPanel:** let custom answer grow multiline instead of clipping ([#4907](https://github.com/factorialco/f0/issues/4907)) ([2f09396](https://github.com/factorialco/f0/commit/2f09396055174c7a6523cc9c13fddd6d23afb6c4))
+
 ## [4.65.0](https://github.com/factorialco/f0/compare/f0-react-v4.64.0...f0-react-v4.65.0) (2026-07-29)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.65.0",
+  "version": "4.65.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.65.1</summary>

## [4.65.1](https://github.com/factorialco/f0/compare/f0-react-v4.65.0...f0-react-v4.65.1) (2026-07-29)


### Bug Fixes

* **F0ClarifyingPanel:** let custom answer grow multiline instead of clipping ([#4907](https://github.com/factorialco/f0/issues/4907)) ([2f09396](https://github.com/factorialco/f0/commit/2f09396055174c7a6523cc9c13fddd6d23afb6c4))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).