### PR TITLE
feat(F0EmojiPicker): add selectable emoji action

### DIFF
--- a/packages/react/src/experimental/Actions/F0EmojiPicker/F0EmojiPicker.tsx
+++ b/packages/react/src/experimental/Actions/F0EmojiPicker/F0EmojiPicker.tsx
@@ -1,0 +1,158 @@
+import data from "@emoji-mart/data/sets/15/twitter.json"
+import { useControllableState } from "@radix-ui/react-use-controllable-state"
+import { type CSSProperties, useEffect, useState } from "react"
+
+import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon"
+import { F0Button } from "@/components/F0Button"
+import { Reaction } from "@/icons/app"
+import { EmojiPicker } from "@/lib/EmojiPicker"
+import { EmojiImage, type EmojiImageProps } from "@/lib/emojis"
+import { useI18n } from "@/lib/providers/i18n"
+import { cn, focusRing } from "@/lib/utils"
+import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover"
+
+import type { F0EmojiPickerProps, F0EmojiPickerSize } from "./types"
+
+const EMOJI_BUTTON_SIZE = 36
+const EMOJI_BUTTON_RADIUS = "10px"
+const EMOJI_SIZE = 24
+const MAX_FREQUENT_ROWS = 2
+const TRIGGER_CLASSES = {
+  sm: "rounded-sm",
+  md: "rounded-md",
+  lg: "rounded-lg",
+}
+const SELECTED_AVATAR_CLASSES = {
+  sm: "size-6 rounded-sm",
+  md: "size-8 rounded",
+  lg: "size-10 rounded-md",
+}
+const SELECTED_EMOJI_SIZES: Record<F0EmojiPickerSize, EmojiImageProps["size"]> =
+  {
+    sm: "xs",
+    md: "sm",
+    lg: "md",
+  }
+const EMOJI_PICKER_STYLE = {
+  "--background-rgb": "255, 255, 255",
+  "--border-radius": "12px",
+  "--category-icon-size": "20px",
+  "--color-border-over": "hsl(var(--neutral-10))",
+  "--color-border": "hsl(var(--neutral-10))",
+  "--font-size": "14px",
+  "--rgb-accent": "1, 22, 55",
+  "--rgb-background": "255, 255, 255",
+  "--rgb-color": "1, 22, 55",
+  "--rgb-input": "255, 255, 255",
+  "--shadow": "0px 4px 20px 0px #0d162514",
+} as CSSProperties
+
+export const F0EmojiPicker = ({
+  label,
+  value,
+  defaultValue = null,
+  onChange,
+  clearable = false,
+  disabled = false,
+  locale = "en",
+  size = "md",
+}: F0EmojiPickerProps) => {
+  const i18n = useI18n()
+  const [selectedEmoji = null, setSelectedEmoji] = useControllableState({
+    prop: value,
+    defaultProp: defaultValue,
+    onChange,
+  })
+  const [isOpen, setIsOpen] = useState(false)
+
+  useEffect(() => {
+    if (disabled) {
+      setIsOpen(false)
+    }
+  }, [disabled])
+
+  const handleEmojiSelect = (emoji: { native: string }) => {
+    setSelectedEmoji(emoji.native)
+    setIsOpen(false)
+  }
+
+  const handleClear = () => {
+    setSelectedEmoji(null)
+    setIsOpen(false)
+  }
+
+  return (
+    <Popover
+      open={!disabled && isOpen}
+      onOpenChange={disabled ? undefined : setIsOpen}
+    >
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={selectedEmoji ? `${label}: ${selectedEmoji}` : label}
+          title={label}
+          disabled={disabled}
+          className={cn(
+            "disabled:cursor-not-allowed disabled:opacity-30",
+            TRIGGER_CLASSES[size],
+            focusRing()
+          )}
+        >
+          {selectedEmoji ? (
+            <div
+              className={cn(
+                "flex aspect-square items-center justify-center border border-solid border-f1-border-secondary bg-f1-background-inverse-secondary dark:bg-f1-background-tertiary",
+                SELECTED_AVATAR_CLASSES[size]
+              )}
+            >
+              <EmojiImage
+                emoji={selectedEmoji}
+                size={SELECTED_EMOJI_SIZES[size]}
+                alt=""
+              />
+            </div>
+          ) : (
+            <F0AvatarIcon icon={Reaction} size={size} />
+          )}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        side="bottom"
+        align="start"
+        aria-label={label}
+        style={EMOJI_PICKER_STYLE}
+        className="flex h-[min(500px,var(--radix-popover-content-available-height))] w-fit flex-col !overflow-hidden border-none bg-transparent p-2 shadow-none [&>div:first-child]:min-h-0 [&>div:first-child]:flex-1 [&>div:first-child]:overflow-hidden [&_em-emoji-picker]:!h-full [&_em-emoji-picker]:!w-[372px] [&_em-emoji-picker]:!max-w-[calc(100vw-32px)] [&_em-emoji-picker]:!max-h-[min(451px,calc(100vh-81px))]"
+      >
+        <EmojiPicker
+          data={data}
+          onEmojiSelect={handleEmojiSelect}
+          locale={locale}
+          icons="outline"
+          set="twitter"
+          theme="light"
+          emojiButtonSize={EMOJI_BUTTON_SIZE}
+          emojiButtonRadius={EMOJI_BUTTON_RADIUS}
+          emojiSize={EMOJI_SIZE}
+          maxFrequentRows={MAX_FREQUENT_ROWS}
+          skinTonePosition="none"
+          previewPosition="none"
+          searchPosition="top"
+          navPosition="top"
+          dynamicWidth
+        />
+        {clearable && selectedEmoji ? (
+          <div className="flex shrink-0 justify-end border-0 border-t border-solid border-[#e5e7eb] bg-white pt-2 [&_button]:!text-[#011637] [&_button:hover]:!bg-[#f5f6f8]">
+            <F0Button
+              label={i18n.actions.clear}
+              variant="ghost"
+              size="sm"
+              onClick={handleClear}
+            />
+          </div>
+        ) : null}
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+F0EmojiPicker.displayName = "F0EmojiPicker"

--- a/packages/react/src/experimental/Actions/F0EmojiPicker/__stories__/F0EmojiPicker.mdx
+++ b/packages/react/src/experimental/Actions/F0EmojiPicker/__stories__/F0EmojiPicker.mdx
@@ -1,0 +1,379 @@
+import { Canvas, Controls, Meta, Unstyled } from "@storybook/addon-docs/blocks"
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
+import * as Stories from "./F0EmojiPicker.stories"
+
+<Meta of={Stories} />
+
+# F0EmojiPicker
+
+Selects one emoji as the compact visual identifier of an object. The trigger
+starts with the Reaction avatar icon and displays the selected emoji without
+changing size.
+
+## Anatomy
+
+<Canvas of={Stories.Default} />
+
+<Controls of={Stories.Default} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Prop</th>
+        <th className="text-left">Type</th>
+        <th className="text-left">Default</th>
+        <th className="text-left">Required</th>
+        <th className="text-left">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>label</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>—</td>
+        <td>Yes</td>
+        <td>
+          Accessible name and tooltip for the trigger, such as “Choose group
+          emoji”.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>value</code>
+        </td>
+        <td>
+          <code>string | null</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>Selected emoji when a parent controls the value.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>defaultValue</code>
+        </td>
+        <td>
+          <code>string | null</code>
+        </td>
+        <td>
+          <code>null</code>
+        </td>
+        <td>—</td>
+        <td>Initially selected emoji in uncontrolled usage.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>onChange</code>
+        </td>
+        <td>
+          <code>(emoji: string | null) =&gt; void</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>Called with the selected emoji, or null when cleared.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>clearable</code>
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>
+          <code>false</code>
+        </td>
+        <td>—</td>
+        <td>
+          Shows a localized clear action while an emoji is selected and the
+          picker is open.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>disabled</code>
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>
+          <code>false</code>
+        </td>
+        <td>—</td>
+        <td>Prevents opening the picker or changing its value.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>locale</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>
+          <code>"en"</code>
+        </td>
+        <td>—</td>
+        <td>Locale for search and category labels inside the picker.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>size</code>
+        </td>
+        <td>
+          <code>"sm" | "md" | "lg"</code>
+        </td>
+        <td>
+          <code>"md"</code>
+        </td>
+        <td>—</td>
+        <td>Size of the trigger avatar.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>dataTestId</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>Test identifier exposed by the public component wrapper.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+The trigger uses `F0AvatarIcon` with the Reaction icon by default and switches
+to the selected emoji after selection. Both states keep the configured size,
+followed by a popover containing search, categories and the emoji grid.
+Clearable instances add a footer action whenever they have a value.
+
+### Sizes
+
+<Canvas of={Stories.Sizes} />
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Size</th>
+        <th className="text-left">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>sm</code>
+        </td>
+        <td>24 × 24 px trigger.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>md</code>
+        </td>
+        <td>32 × 32 px trigger; this is the default.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>lg</code>
+        </td>
+        <td>40 × 40 px trigger.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+## Guidelines
+
+### Design best practices
+
+**When to use**
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Situation</th>
+        <th className="text-left">When to use F0EmojiPicker</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>A chat group needs a compact visual identifier</td>
+        <td>Place it beside the group name in create or edit settings.</td>
+      </tr>
+      <tr>
+        <td>An optional emoji value has not been chosen yet</td>
+        <td>
+          Use the Reaction fallback so the chosen emoji replaces it in place.
+        </td>
+      </tr>
+      <tr>
+        <td>A form owns the selected emoji</td>
+        <td>
+          Provide <code>value</code> and <code>onChange</code> as a controlled
+          field.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+**When not to use**
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Situation</th>
+        <th className="text-left">Use instead</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Adding an emoji reaction to content</td>
+        <td>The reactions picker, which owns reaction-specific behavior.</td>
+      </tr>
+      <tr>
+        <td>Selecting several emojis</td>
+        <td>
+          A multi-select pattern; <code>F0EmojiPicker</code> represents one
+          value.
+        </td>
+      </tr>
+      <tr>
+        <td>Triggering an action with a decorative icon</td>
+        <td>
+          <code>F0Button</code> with an icon.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+**Do's and don'ts**
+
+<DoDonts
+  do={{
+    description:
+      "Use a specific label that names the setting the emoji belongs to.",
+    guidelines: [
+      "“Choose group emoji” for a group identifier",
+      "Keep the picker next to the group name it affects",
+    ],
+  }}
+  dont={{
+    description:
+      "Do not use a generic label or reuse this control for content reactions.",
+    guidelines: [
+      "Avoid labels such as “Open” or “Emoji” without context",
+      "Use the reactions picker when the action adds a reaction",
+    ],
+  }}
+/>
+
+### Behavior
+
+- WHEN neither `value` nor `defaultValue` is provided → THEN the trigger shows
+  `<F0AvatarIcon icon={Reaction} />` at the configured size with the supplied
+  accessible `label`; the default `md` size is 32 × 32 px.
+- WHEN an emoji is selected → THEN the trigger displays it, announces it as the
+  current value, calls `onChange` and closes the popover.
+- WHEN `value` is provided → THEN the parent remains the source of truth and
+  must update it after `onChange`.
+- WHEN `value={null}` → THEN the controlled trigger displays the Reaction
+  fallback.
+- WHEN `defaultValue` is provided without `value` → THEN the component owns
+  subsequent selection state.
+- WHEN `disabled={true}` → THEN the trigger cannot open and any open popover
+  closes.
+- WHEN `locale` is provided → THEN emoji search and category labels use that
+  locale.
+- WHEN `size` is provided → THEN both the Reaction fallback and the selected
+  emoji use the corresponding 24, 32 or 40 px trigger size.
+- WHEN `clearable={true}` and an emoji is selected → THEN a localized clear
+  action is shown; activating it calls `onChange(null)`, closes the popover and
+  restores the Reaction fallback in uncontrolled usage.
+
+### Usage examples
+
+**Choose an emoji from the Reaction fallback**
+
+<Canvas of={Stories.Default} />
+
+**Keep the value in a form or parent component**
+
+<Canvas of={Stories.Controlled} />
+
+**Choose a trigger size for its surrounding layout**
+
+<Canvas of={Stories.Sizes} />
+
+**Allow an optional emoji to be removed**
+
+<Canvas of={Stories.Clearable} />
+
+**Compare default, selected and disabled states**
+
+<Canvas of={Stories.Snapshot} />
+
+## Accessibility
+
+The required `label` is always the trigger's accessible name. After a selection,
+the chosen emoji is appended to that name so screen readers announce both the
+setting and its current value. The picker popover uses the same label as its
+dialog name. The optional clear action uses the localized “Clear” label.
+
+### Keyboard interaction
+
+<Unstyled>
+  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
+    <thead>
+      <tr>
+        <th className="text-left">Key</th>
+        <th className="text-left">Behavior</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <kbd>Tab</kbd>
+        </td>
+        <td>Moves focus to the trigger and through the picker controls.</td>
+      </tr>
+      <tr>
+        <td>
+          <kbd>Enter</kbd> / <kbd>Space</kbd>
+        </td>
+        <td>
+          Opens the picker from the trigger and activates an emoji or the clear
+          action.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <kbd>Arrow keys</kbd>
+        </td>
+        <td>Move through the emoji grid.</td>
+      </tr>
+      <tr>
+        <td>
+          <kbd>Escape</kbd>
+        </td>
+        <td>Closes the picker and restores focus to the trigger.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+### Screen reader behavior
+
+- The default Reaction trigger is announced as a button using `label`.
+- A selected trigger is announced with both `label` and the selected emoji.
+- The optional clear action is announced using its localized label.
+- Expanded and collapsed state is exposed by the popover trigger.
+- The open picker is announced as a named dialog.

--- a/packages/react/src/experimental/Actions/F0EmojiPicker/__stories__/F0EmojiPicker.stories.tsx
+++ b/packages/react/src/experimental/Actions/F0EmojiPicker/__stories__/F0EmojiPicker.stories.tsx
@@ -1,0 +1,259 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { useState } from "react"
+import { expect, fn, userEvent, waitFor, within } from "storybook/test"
+
+import { dataTestIdArgs } from "@/lib/data-testid/__stories__/args"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
+
+import { F0EmojiPicker, f0EmojiPickerSizes } from "../index"
+
+const meta = {
+  title: "F0EmojiPicker",
+  component: F0EmojiPicker,
+  tags: ["experimental", "!autodocs"],
+  parameters: {
+    layout: "centered",
+    a11y: {
+      test: "error",
+    },
+  },
+  args: {
+    label: "Choose group emoji",
+    clearable: false,
+    disabled: false,
+    locale: "en",
+    size: "md",
+    onChange: fn(),
+  },
+  argTypes: {
+    value: {
+      control: "text",
+      description:
+        "Selected emoji in controlled usage. Use null for an empty value.",
+    },
+    defaultValue: {
+      control: "text",
+      description:
+        "Initially selected emoji in uncontrolled usage. Null starts empty.",
+    },
+    onChange: {
+      description: "Called with the selected emoji, or null when cleared.",
+    },
+    clearable: {
+      control: "boolean",
+      description:
+        "Shows an action for clearing the current selection from the picker.",
+      table: {
+        defaultValue: { summary: "false" },
+      },
+    },
+    size: {
+      control: "select",
+      options: f0EmojiPickerSizes,
+      description: "Size of the trigger avatar.",
+      table: {
+        type: { summary: f0EmojiPickerSizes.join(" | ") },
+        defaultValue: { summary: "md" },
+      },
+    },
+    ...dataTestIdArgs,
+  },
+} satisfies Meta<typeof F0EmojiPicker>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+const ControlledExample = () => {
+  const [emoji, setEmoji] = useState<string | null>("💬")
+
+  return (
+    <div className="flex items-center gap-3">
+      <F0EmojiPicker
+        label="Choose group emoji"
+        value={emoji}
+        onChange={setEmoji}
+      />
+      <span className="text-sm text-f1-foreground-secondary">
+        Selected: {emoji ?? "None"}
+      </span>
+    </div>
+  )
+}
+
+export const Controlled: Story = {
+  tags: ["no-sidebar"],
+  render: () => <ControlledExample />,
+}
+
+export const Interaction: Story = {
+  tags: ["no-sidebar"],
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+    const trigger = canvas.getByRole("button", {
+      name: "Choose group emoji",
+    })
+
+    trigger.focus()
+    await userEvent.keyboard("{Enter}")
+    await expect(trigger).toHaveAttribute("aria-expanded", "true")
+
+    await userEvent.keyboard("{Escape}")
+    await expect(trigger).toHaveAttribute("aria-expanded", "false")
+    await waitFor(() => expect(trigger).toHaveFocus())
+
+    await userEvent.click(trigger)
+    await expect(trigger).toHaveAttribute("aria-expanded", "true")
+
+    const picker = canvasElement.ownerDocument.querySelector("em-emoji-picker")
+    await waitFor(() => expect(picker?.shadowRoot).not.toBeNull())
+
+    const partyEmoji = picker?.shadowRoot?.querySelector<HTMLButtonElement>(
+      'button[aria-label="🥳"]'
+    )
+    await expect(partyEmoji).not.toBeNull()
+    await userEvent.click(partyEmoji!)
+
+    await expect(args.onChange).toHaveBeenCalledWith("🥳")
+    await expect(trigger).toHaveAttribute("aria-expanded", "false")
+    await expect(trigger).toHaveAttribute(
+      "aria-label",
+      "Choose group emoji: 🥳"
+    )
+  },
+}
+
+export const Clearable: Story = {
+  tags: ["no-sidebar"],
+  args: {
+    clearable: true,
+    defaultValue: "💬",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const trigger = canvas.getByRole("button", {
+      name: "Choose group emoji: 💬",
+    })
+
+    await userEvent.click(trigger)
+
+    const document = within(canvasElement.ownerDocument.body)
+    const dialog = await document.findByRole("dialog", {
+      name: "Choose group emoji",
+    })
+    const clearButton = await within(dialog).findByRole("button", {
+      name: "Clear",
+    })
+    await waitFor(() => expect(clearButton).toBeVisible())
+  },
+}
+
+export const ClearableInteraction: Story = {
+  tags: ["no-sidebar"],
+  args: {
+    clearable: true,
+    defaultValue: "💬",
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement)
+    const trigger = canvas.getByRole("button", {
+      name: "Choose group emoji: 💬",
+    })
+
+    await userEvent.click(trigger)
+
+    const document = within(canvasElement.ownerDocument.body)
+    const dialog = await document.findByRole("dialog", {
+      name: "Choose group emoji",
+    })
+    const clearButton = await within(dialog).findByRole("button", {
+      name: "Clear",
+    })
+    clearButton.focus()
+    await userEvent.keyboard("{Enter}")
+
+    await expect(args.onChange).toHaveBeenCalledWith(null)
+    await expect(trigger).toHaveAttribute("aria-expanded", "false")
+    await expect(trigger).toHaveAttribute("aria-label", "Choose group emoji")
+    await waitFor(() => expect(trigger).toHaveFocus())
+  },
+}
+
+export const Sizes: Story = {
+  tags: ["no-sidebar"],
+  render: (args) => (
+    <div className="flex items-end gap-4">
+      {f0EmojiPickerSizes.map((size) => (
+        <div key={size} className="flex flex-col items-center gap-2">
+          <div className="flex items-center gap-2">
+            <F0EmojiPicker {...args} size={size} value={null} />
+            <F0EmojiPicker {...args} size={size} value="💬" />
+          </div>
+          <span className="text-sm text-f1-foreground-secondary">{size}</span>
+        </div>
+      ))}
+    </div>
+  ),
+}
+
+export const Snapshot: Story = {
+  tags: ["no-sidebar"],
+  parameters: {
+    ...withSnapshot({}),
+  },
+  render: (args) => (
+    <div className="flex flex-col gap-8">
+      <div className="flex items-end gap-4">
+        {f0EmojiPickerSizes.map((size) => (
+          <div key={size} className="flex flex-col items-center gap-2">
+            <div className="flex items-center gap-2">
+              <F0EmojiPicker {...args} size={size} value={null} />
+              <F0EmojiPicker {...args} size={size} value="💬" />
+            </div>
+            <span className="text-sm text-f1-foreground-secondary">{size}</span>
+          </div>
+        ))}
+      </div>
+      <div className="flex items-end gap-8">
+        <div className="flex flex-col items-center gap-2">
+          <F0EmojiPicker {...args} defaultValue="💬" />
+          <span className="text-sm text-f1-foreground-secondary">Selected</span>
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <F0EmojiPicker {...args} defaultValue="🎉" disabled />
+          <span className="text-sm text-f1-foreground-secondary">Disabled</span>
+        </div>
+        <div className="flex flex-col items-center gap-2">
+          <F0EmojiPicker
+            {...args}
+            label="Choose removable group emoji"
+            defaultValue="💬"
+            clearable
+          />
+          <span className="text-sm text-f1-foreground-secondary">
+            Clearable
+          </span>
+        </div>
+      </div>
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    await userEvent.click(
+      canvas.getByRole("button", {
+        name: "Choose removable group emoji: 💬",
+      })
+    )
+
+    const document = within(canvasElement.ownerDocument.body)
+    const dialog = await document.findByRole("dialog", {
+      name: "Choose removable group emoji",
+    })
+    const clearButton = await within(dialog).findByRole("button", {
+      name: "Clear",
+    })
+    await waitFor(() => expect(clearButton).toBeVisible())
+  },
+}

--- a/packages/react/src/experimental/Actions/F0EmojiPicker/__tests__/F0EmojiPicker.test.tsx
+++ b/packages/react/src/experimental/Actions/F0EmojiPicker/__tests__/F0EmojiPicker.test.tsx
@@ -1,0 +1,338 @@
+import { userEvent } from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { defaultTranslations, I18nProvider } from "@/lib/providers/i18n"
+import { zeroRender as render, screen, waitFor } from "@/testing/test-utils"
+
+import { F0EmojiPicker } from "../index"
+
+vi.mock("@/lib/EmojiPicker", () => ({
+  EmojiPicker: ({
+    locale,
+    onEmojiSelect,
+  }: {
+    locale?: string
+    onEmojiSelect?: (emoji: { native: string }) => void
+  }) => (
+    <>
+      <button
+        type="button"
+        data-locale={locale}
+        onClick={() => onEmojiSelect?.({ native: "🎉" })}
+      >
+        Select celebration
+      </button>
+      <button type="button" onClick={() => onEmojiSelect?.({ native: "👨‍👩‍👧‍👦" })}>
+        Select family
+      </button>
+    </>
+  ),
+}))
+
+describe("F0EmojiPicker", () => {
+  it("renders the Reaction fallback with an accessible label", () => {
+    const { container } = render(<F0EmojiPicker label="Choose group emoji" />)
+
+    const trigger = screen.getByRole("button", { name: "Choose group emoji" })
+
+    expect(trigger).toHaveAttribute("type", "button")
+    expect(trigger).toHaveAttribute("title", "Choose group emoji")
+    expect(container.querySelector("svg")).toBeInTheDocument()
+    expect(container.querySelector("img")).not.toBeInTheDocument()
+  })
+
+  it("stores and displays the selected emoji when uncontrolled", async () => {
+    const user = userEvent.setup()
+    const { container } = render(<F0EmojiPicker label="Choose group emoji" />)
+
+    await user.click(screen.getByRole("button", { name: "Choose group emoji" }))
+    await user.click(screen.getByRole("button", { name: "Select celebration" }))
+
+    expect(container.querySelector("img")).toHaveAttribute(
+      "src",
+      expect.stringContaining("1f389")
+    )
+    expect(
+      screen.queryByRole("button", { name: "Select celebration" })
+    ).not.toBeInTheDocument()
+    expect(
+      screen.getByRole("button", { name: "Choose group emoji: 🎉" })
+    ).toBeInTheDocument()
+  })
+
+  it("preserves multi-codepoint emoji selections", async () => {
+    const user = userEvent.setup()
+    const { container } = render(<F0EmojiPicker label="Choose group emoji" />)
+
+    await user.click(screen.getByRole("button", { name: "Choose group emoji" }))
+    await user.click(screen.getByRole("button", { name: "Select family" }))
+
+    expect(container.querySelector("img")).toHaveAttribute(
+      "src",
+      expect.stringContaining("1f468-200d-1f469-200d-1f467-200d-1f466")
+    )
+    expect(
+      screen.getByRole("button", {
+        name: "Choose group emoji: 👨‍👩‍👧‍👦",
+      })
+    ).toBeInTheDocument()
+  })
+
+  it("clears an uncontrolled selection to null when clearable", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    const { container } = render(
+      <F0EmojiPicker
+        label="Choose group emoji"
+        defaultValue="💬"
+        clearable
+        onChange={onChange}
+      />
+    )
+
+    const trigger = screen.getByRole("button", {
+      name: "Choose group emoji: 💬",
+    })
+
+    await user.click(trigger)
+    await user.click(screen.getByRole("button", { name: "Clear" }))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenLastCalledWith(null)
+    expect(
+      screen.getByRole("button", { name: "Choose group emoji" })
+    ).toHaveAttribute("aria-expanded", "false")
+    await waitFor(() => expect(trigger).toHaveFocus())
+    expect(container.querySelector("svg")).toBeInTheDocument()
+    expect(container.querySelector("img")).not.toBeInTheDocument()
+  })
+
+  it("requests a null value without mutating a controlled selection", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    const { container, rerender } = render(
+      <F0EmojiPicker
+        label="Choose group emoji"
+        value="💬"
+        clearable
+        onChange={onChange}
+      />
+    )
+
+    const trigger = screen.getByRole("button", {
+      name: "Choose group emoji: 💬",
+    })
+
+    await user.click(trigger)
+    await user.click(screen.getByRole("button", { name: "Clear" }))
+
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenLastCalledWith(null)
+    expect(
+      screen.getByRole("button", { name: "Choose group emoji: 💬" })
+    ).toHaveAttribute("aria-expanded", "false")
+    await waitFor(() => expect(trigger).toHaveFocus())
+    expect(container.querySelector("img")).toHaveAttribute(
+      "src",
+      expect.stringContaining("1f4ac")
+    )
+
+    rerender(
+      <F0EmojiPicker
+        label="Choose group emoji"
+        value={null}
+        clearable
+        onChange={onChange}
+      />
+    )
+
+    expect(
+      screen.getByRole("button", { name: "Choose group emoji" })
+    ).toBeInTheDocument()
+    expect(container.querySelector("svg")).toBeInTheDocument()
+    expect(container.querySelector("img")).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole("button", { name: "Choose group emoji" }))
+    expect(
+      screen.queryByRole("button", { name: "Clear" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("uses the localized clear action label", async () => {
+    const user = userEvent.setup()
+    const translations = {
+      ...defaultTranslations,
+      actions: {
+        ...defaultTranslations.actions,
+        clear: "Borrar",
+      },
+    }
+
+    render(
+      <I18nProvider translations={translations}>
+        <F0EmojiPicker label="Choose group emoji" defaultValue="💬" clearable />
+      </I18nProvider>
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: "Choose group emoji: 💬" })
+    )
+
+    expect(screen.getByRole("button", { name: "Borrar" })).toBeInTheDocument()
+    expect(
+      screen.queryByRole("button", { name: "Clear" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("only shows the clear action for a clearable selected value", async () => {
+    const user = userEvent.setup()
+    const { unmount } = render(
+      <F0EmojiPicker label="Choose group emoji" defaultValue="💬" />
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: "Choose group emoji: 💬" })
+    )
+    expect(
+      screen.queryByRole("button", { name: "Clear" })
+    ).not.toBeInTheDocument()
+
+    unmount()
+    render(<F0EmojiPicker label="Choose group emoji" clearable />)
+    await user.click(screen.getByRole("button", { name: "Choose group emoji" }))
+
+    expect(
+      screen.queryByRole("button", { name: "Clear" })
+    ).not.toBeInTheDocument()
+  })
+
+  it.each([
+    ["sm", "size-6"],
+    ["md", "size-8"],
+    ["lg", "size-10"],
+  ] as const)(
+    "renders the %s trigger size in both states",
+    (size, className) => {
+      const { rerender } = render(
+        <F0EmojiPicker label="Choose group emoji" size={size} value={null} />
+      )
+
+      expect(
+        screen.getByRole("button", { name: "Choose group emoji" })
+          .firstElementChild
+      ).toHaveClass(className)
+
+      rerender(
+        <F0EmojiPicker label="Choose group emoji" size={size} value="🎉" />
+      )
+
+      expect(
+        screen.getByRole("button", { name: "Choose group emoji: 🎉" })
+          .firstElementChild
+      ).toHaveClass(className)
+    }
+  )
+
+  it("calls onChange without mutating a controlled value", async () => {
+    const user = userEvent.setup()
+    const onChange = vi.fn()
+    const { container } = render(
+      <F0EmojiPicker
+        label="Choose group emoji"
+        value="💬"
+        onChange={onChange}
+      />
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: "Choose group emoji: 💬" })
+    )
+    await user.click(screen.getByRole("button", { name: "Select celebration" }))
+
+    expect(onChange).toHaveBeenCalledWith("🎉")
+    expect(container.querySelector("img")).toHaveAttribute(
+      "src",
+      expect.stringContaining("1f4ac")
+    )
+  })
+
+  it("uses defaultValue as the initial uncontrolled selection", () => {
+    const { container } = render(
+      <F0EmojiPicker label="Choose group emoji" defaultValue="💬" />
+    )
+
+    expect(container.querySelector("img")).toHaveAttribute(
+      "src",
+      expect.stringContaining("1f4ac")
+    )
+  })
+
+  it("does not open when disabled", async () => {
+    const user = userEvent.setup()
+    render(<F0EmojiPicker label="Choose group emoji" disabled />)
+
+    await user.click(screen.getByRole("button", { name: "Choose group emoji" }))
+
+    expect(
+      screen.queryByRole("button", { name: "Select celebration" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("closes when disabled while open and stays closed when re-enabled", async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(<F0EmojiPicker label="Choose group emoji" />)
+
+    await user.click(screen.getByRole("button", { name: "Choose group emoji" }))
+    expect(
+      screen.getByRole("button", { name: "Select celebration" })
+    ).toBeInTheDocument()
+
+    rerender(<F0EmojiPicker label="Choose group emoji" disabled />)
+    expect(
+      screen.queryByRole("button", { name: "Select celebration" })
+    ).not.toBeInTheDocument()
+
+    rerender(<F0EmojiPicker label="Choose group emoji" />)
+    expect(
+      screen.queryByRole("button", { name: "Select celebration" })
+    ).not.toBeInTheDocument()
+  })
+
+  it("displays externally updated controlled values", () => {
+    const { rerender } = render(
+      <F0EmojiPicker label="Choose group emoji" value="💬" />
+    )
+
+    expect(
+      screen.getByRole("button", { name: "Choose group emoji: 💬" })
+    ).toBeInTheDocument()
+
+    rerender(<F0EmojiPicker label="Choose group emoji" value="🎉" />)
+
+    expect(
+      screen.getByRole("button", { name: "Choose group emoji: 🎉" })
+    ).toBeInTheDocument()
+  })
+
+  it("forwards the locale to the emoji picker", async () => {
+    const user = userEvent.setup()
+    render(<F0EmojiPicker label="Choose group emoji" locale="es" />)
+
+    await user.click(screen.getByRole("button", { name: "Choose group emoji" }))
+
+    expect(
+      screen.getByRole("button", { name: "Select celebration" })
+    ).toHaveAttribute("data-locale", "es")
+  })
+
+  it("exposes dataTestId through the public component", () => {
+    render(
+      <F0EmojiPicker
+        label="Choose group emoji"
+        dataTestId="group-emoji-picker"
+      />
+    )
+
+    expect(screen.getByTestId("group-emoji-picker")).toBeInTheDocument()
+  })
+})

--- a/packages/react/src/experimental/Actions/F0EmojiPicker/index.tsx
+++ b/packages/react/src/experimental/Actions/F0EmojiPicker/index.tsx
@@ -1,0 +1,17 @@
+import { withDataTestId } from "@/lib/data-testid"
+import { experimentalComponent } from "@/lib/experimental"
+
+import { F0EmojiPicker as F0EmojiPickerComponent } from "./F0EmojiPicker"
+
+export {
+  f0EmojiPickerSizes,
+  type F0EmojiPickerProps,
+  type F0EmojiPickerSize,
+} from "./types"
+
+/**
+ * @experimental This is an experimental component, use it at your own risk.
+ */
+export const F0EmojiPicker = withDataTestId(
+  experimentalComponent("F0EmojiPicker", F0EmojiPickerComponent)
+)

--- a/packages/react/src/experimental/Actions/F0EmojiPicker/types.ts
+++ b/packages/react/src/experimental/Actions/F0EmojiPicker/types.ts
@@ -1,0 +1,38 @@
+export const f0EmojiPickerSizes = ["sm", "md", "lg"] as const
+
+export type F0EmojiPickerSize = (typeof f0EmojiPickerSizes)[number]
+
+export interface F0EmojiPickerProps {
+  /**
+   * Accessible label and tooltip for the trigger button.
+   */
+  label: string
+  /**
+   * Selected emoji. Use with `onChange` to control the component.
+   */
+  value?: string | null
+  /**
+   * Initially selected emoji when the component is uncontrolled.
+   */
+  defaultValue?: string | null
+  /**
+   * Called with the selected emoji, or `null` when cleared.
+   */
+  onChange?: (emoji: string | null) => void
+  /**
+   * Allows clearing the selected emoji from the picker.
+   */
+  clearable?: boolean
+  /**
+   * Prevents opening the picker and changing the selected emoji.
+   */
+  disabled?: boolean
+  /**
+   * Locale used by the search and category labels in the picker.
+   */
+  locale?: string
+  /**
+   * Size of the trigger avatar.
+   */
+  size?: F0EmojiPickerSize
+}

--- a/packages/react/src/experimental/Actions/exports.ts
+++ b/packages/react/src/experimental/Actions/exports.ts
@@ -1,2 +1,3 @@
 export * from "../../components/F0ButtonToggle"
+export * from "./F0EmojiPicker"
 export * from "./F0SegmentedControl"

--- a/packages/react/src/lib/EmojiPicker.test.tsx
+++ b/packages/react/src/lib/EmojiPicker.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react"
+import { render, waitFor } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { EmojiPicker } from "./EmojiPicker"
@@ -72,6 +72,33 @@ describe("EmojiPicker", () => {
     expect(stub.props).toMatchObject({ set: "twitter", onEmojiSelect })
     // The seed must happen before the append, not after.
     expect(propsAtAppendTime).toMatchObject({ set: "twitter", onEmojiSelect })
+  })
+
+  it("removes listbox-only ARIA attributes from emoji buttons", async () => {
+    const stub = stubPickerElement()
+    const root = stub.attachShadow({ mode: "open" })
+    const scrollRegion = realCreateElement("div")
+    scrollRegion.className = "scroll"
+    const button = realCreateElement("button")
+    button.setAttribute("aria-label", "🥳")
+    button.setAttribute("aria-selected", "false")
+    button.setAttribute("aria-posinset", "1")
+    button.setAttribute("aria-setsize", "100")
+    scrollRegion.appendChild(button)
+    root.appendChild(scrollRegion)
+    vi.spyOn(document, "createElement").mockImplementation((tag: string) =>
+      tag === "em-emoji-picker" ? stub : realCreateElement(tag)
+    )
+
+    render(<EmojiPicker data={{}} />)
+
+    await waitFor(() => {
+      expect(button).not.toHaveAttribute("aria-selected")
+      expect(button).not.toHaveAttribute("aria-posinset")
+      expect(button).not.toHaveAttribute("aria-setsize")
+    })
+    expect(button).toHaveAccessibleName("🥳")
+    expect(scrollRegion).toHaveAttribute("tabindex", "0")
   })
 
   it("degrades to nothing instead of crashing when the element fails to construct", () => {

--- a/packages/react/src/lib/EmojiPicker.tsx
+++ b/packages/react/src/lib/EmojiPicker.tsx
@@ -15,6 +15,67 @@ type EmojiMartElement = HTMLElement & {
   update?: (props: object) => void
 }
 
+const INVALID_EMOJI_BUTTON_ARIA = [
+  "aria-posinset",
+  "aria-selected",
+  "aria-setsize",
+] as const
+
+/**
+ * emoji-mart currently places listbox-only ARIA attributes on native buttons.
+ * Keep the valid button names/activation model while removing attributes that
+ * are not permitted for the button role. The observer also covers search and
+ * category changes that replace buttons inside the shadow root.
+ */
+function observeEmojiButtonAria(element: EmojiMartElement): () => void {
+  let observer: MutationObserver | null = null
+  let animationFrame: number | null = null
+  let attempts = 0
+
+  const connect = () => {
+    const root = element.shadowRoot
+    if (!root) {
+      if (attempts < 10) {
+        attempts += 1
+        animationFrame = requestAnimationFrame(connect)
+      }
+      return
+    }
+
+    const normalize = () => {
+      const selector = INVALID_EMOJI_BUTTON_ARIA.map(
+        (attribute) => `button[${attribute}]`
+      ).join(",")
+      for (const button of root.querySelectorAll(selector)) {
+        for (const attribute of INVALID_EMOJI_BUTTON_ARIA) {
+          button.removeAttribute(attribute)
+        }
+      }
+
+      // Emoji buttons use roving tabindex and are not tabbable until the
+      // picker moves focus into them. Make the independently scrollable list
+      // reachable so keyboard users can scroll it before choosing an emoji.
+      root.querySelector<HTMLElement>(".scroll")?.setAttribute("tabindex", "0")
+    }
+
+    normalize()
+    observer = new MutationObserver(normalize)
+    observer.observe(root, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      attributeFilter: [...INVALID_EMOJI_BUTTON_ARIA],
+    })
+  }
+
+  connect()
+
+  return () => {
+    observer?.disconnect()
+    if (animationFrame !== null) cancelAnimationFrame(animationFrame)
+  }
+}
+
 export type EmojiPickerProps = {
   data?: unknown
   onEmojiSelect?: (emoji: { native: string }) => void
@@ -58,8 +119,10 @@ function EmojiPickerElement(props: EmojiPickerProps) {
     // and options unset — so selecting an emoji would do nothing.
     element.props = propsRef.current
     container.appendChild(element)
+    const stopObservingAria = observeEmojiButtonAria(element)
 
     return () => {
+      stopObservingAria()
       element.remove()
       elementRef.current = null
     }


### PR DESCRIPTION
## Description

Introduces `F0EmojiPicker` as a new experimental action component for selecting the emoji that represents a group or similar entity.

The trigger starts with `<F0AvatarIcon icon={Reaction} />`, replaces it with the selected emoji, supports controlled and uncontrolled usage, and can optionally restore the value to `null`. The picker also exposes `sm`, `md`, and `lg` trigger sizes and remains completely inert while disabled.

## Type of change

- [x] New component
- [ ] New pattern
- [ ] New pattern variant
- [ ] Component enhancement/variant
- [ ] Pattern enhancement/variant
- [ ] Bug fix
- [ ] Refactor/internal change

## Lifecycle phase (if applicable)

- Phase: Build
- Status: Experimental
- Exit criteria covered here: public types and export, controlled/uncontrolled behavior, disabled and clearable states, complete MDX guidance, interaction stories, consolidated visual snapshot, unit coverage, and axe-enabled stories.
- Remaining before promotion: validate the API in a real product flow and collect design/consumer feedback.

## Storybook examples

- Default empty and selected triggers
- Controlled value
- Emoji selection interaction
- Clearable and clearable-interaction flows
- `sm`, `md`, and `lg` sizes
- Disabled behavior
- Consolidated snapshot with all meaningful states

## Implementation details

- Adds the experimental `F0EmojiPicker` component and public prop types.
- Uses `F0AvatarIcon` with the `Reaction` icon until an emoji is selected.
- Supports `value`/`onChange` and `defaultValue` APIs.
- Adds opt-in `clearable` behavior that emits `null`.
- Prevents the popover from opening and prevents changes while disabled.
- Constrains the emoji picker to the available viewport height so the complete picker, including the clear action, scrolls and remains visible.
- Normalizes invalid listbox-only ARIA attributes emitted by emoji-mart while keeping emoji buttons named and keyboard reachable.

## Verification

- 21 unit tests pass across `F0EmojiPicker` and the shared emoji-picker wrapper.
- TypeScript passes with no errors.
- Formatting, circular-dependency checks, ownership checks, and `git diff --check` pass.
- All 7 component stories pass their interaction and accessibility checks.

---
> Factorial is conducting an analysis on the impact of the used skills. This was autogenerated, please don't delete:
> - factorial-f0
> - factorial-pr
> - factorial-skill-tracking
> - factorial-skills
