### PR TITLE
feat(F0VideoPlayer): add controlled download action

### DIFF
--- a/packages/react/src/components/F0VideoPlayer/__stories__/F0VideoPlayer.mdx
+++ b/packages/react/src/components/F0VideoPlayer/__stories__/F0VideoPlayer.mdx
@@ -20,6 +20,9 @@ controls auto-hide and reveal again on hover or keyboard focus — set
 <Canvas of={Stories.Default} />
 <Controls of={Stories.Playground} />
 
+When several players share a surface, pass a contextual `ariaLabel` such as
+`"Video player: quarterly walkthrough"` so each player region is distinct.
+
 ## Keyboard shortcuts
 
 While the player (or a non-input descendant) holds focus:
@@ -46,6 +49,11 @@ player. The parent receives playback information through the callbacks:
   10s" and "97%". Short videos complete at 97%; long videos in their final 10s.
 - **`restrictForwardSeek`** — prevents seeking past the furthest-watched point and
   renders a marker at that position.
+- **`download`** — adds an explicit download action to the player controls.
+  Native media downloads stay disabled; use this when the embedding surface
+  lets viewers save the source.
+
+<Canvas of={Stories.Downloadable} />
 
 ## Captions
 
@@ -181,6 +189,7 @@ Actions panel below.
 
 - Advanced browser behaviours are always disabled: the native context menu (and
   its "Save video as…" download), Picture-in-Picture, remote playback and drag.
-  This is intentional for embedded product video; there is no opt-in for v1.
+  Embedding surfaces can opt into a controlled download button through
+  `download`; the remaining browser behaviours stay unavailable.
 - The playback-speed menu portals into the player wrapper (not `document.body`)
   so it stays visible and interactive in fullscreen.

--- a/packages/react/src/components/F0VideoPlayer/__stories__/F0VideoPlayer.stories.tsx
+++ b/packages/react/src/components/F0VideoPlayer/__stories__/F0VideoPlayer.stories.tsx
@@ -1,5 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { ReactNode, useEffect, useRef } from "react"
+import { fn } from "storybook/test"
+
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
 import { F0VideoPlayer } from "../F0VideoPlayer"
 import { bigBuckBunnyCaptions } from "./bigBuckBunnyCaptions"
@@ -76,6 +79,50 @@ export const Playground: Story = {
   },
   // No captions — flagged by the video-captions a11y rule.
   parameters: { a11y: { test: "todo" } },
+}
+
+export const Downloadable: Story = {
+  tags: ["no-sidebar"],
+  args: {
+    content: { captions: bigBuckBunnyCaptions },
+    download: {
+      label: "Download sample video",
+      onClick: fn(),
+    },
+  },
+}
+
+export const Snapshot: Story = {
+  tags: ["no-sidebar"],
+  parameters: withSnapshot({}),
+  render: (args) => (
+    <div className="flex flex-col gap-8">
+      <section className="flex flex-col gap-2">
+        <h2 className="text-lg font-medium">Standard controls</h2>
+        <Frame>
+          <F0VideoPlayer
+            {...args}
+            content={{ captions: bigBuckBunnyCaptions }}
+            persistControls
+          />
+        </Frame>
+      </section>
+      <section className="flex flex-col gap-2">
+        <h2 className="text-lg font-medium">With download</h2>
+        <Frame>
+          <F0VideoPlayer
+            {...args}
+            content={{ captions: bigBuckBunnyCaptions }}
+            download={{
+              label: "Download sample video",
+              onClick: fn(),
+            }}
+            persistControls
+          />
+        </Frame>
+      </section>
+    </div>
+  ),
 }
 
 /**

--- a/packages/react/src/components/F0VideoPlayer/__tests__/F0VideoPlayer.test.tsx
+++ b/packages/react/src/components/F0VideoPlayer/__tests__/F0VideoPlayer.test.tsx
@@ -8,8 +8,8 @@ import {
   zeroRender as render,
 } from "@/testing/test-utils"
 
-import { F0VideoPlayer } from "../F0VideoPlayer"
 import { volumeIcon } from "../components/VolumeControl"
+import { F0VideoPlayer } from "../F0VideoPlayer"
 
 const VIDEO_SRC = "https://example.com/video.mp4"
 
@@ -70,6 +70,15 @@ describe("F0VideoPlayer", () => {
       expect(getVideo()).toHaveAttribute("poster", "poster.webp")
     })
 
+    it("accepts a contextual accessible name", () => {
+      render(
+        <F0VideoPlayer src={VIDEO_SRC} ariaLabel="Video player: demo.mp4" />
+      )
+      expect(
+        screen.getByRole("region", { name: "Video player: demo.mp4" })
+      ).toBeInTheDocument()
+    })
+
     it("shows a center play overlay while paused and hides it during playback", () => {
       render(<F0VideoPlayer src={VIDEO_SRC} />)
       expect(
@@ -107,6 +116,31 @@ describe("F0VideoPlayer", () => {
 
       fireEvent.loadedData(getVideo())
       expect(screen.getByRole("button", { name: "Play" })).toBeInTheDocument()
+    })
+
+    it("renders an optional download inside the loaded player controls", async () => {
+      const onDownload = vi.fn()
+      const user = userEvent.setup()
+      render(
+        <F0VideoPlayer
+          src={VIDEO_SRC}
+          download={{ label: "Download demo.mp4", onClick: onDownload }}
+        />
+      )
+
+      expect(
+        screen.queryByRole("button", { name: "Download demo.mp4" })
+      ).not.toBeInTheDocument()
+
+      fireEvent.loadedData(getVideo())
+      const downloadButton = screen.getByRole("button", {
+        name: "Download demo.mp4",
+      })
+      downloadButton.focus()
+      await user.keyboard(" ")
+
+      expect(onDownload).toHaveBeenCalledOnce()
+      expect(HTMLMediaElement.prototype.play).not.toHaveBeenCalled()
     })
   })
 

--- a/packages/react/src/components/F0VideoPlayer/components/Controls.tsx
+++ b/packages/react/src/components/F0VideoPlayer/components/Controls.tsx
@@ -1,5 +1,11 @@
 import { F0Button } from "@/components/F0Button"
-import { Maximize, Minimize, SolidPause, SolidPlay } from "@/icons/app"
+import {
+  Download,
+  Maximize,
+  Minimize,
+  SolidPause,
+  SolidPlay,
+} from "@/icons/app"
 import { type LanguageOption } from "@/lib/localized"
 import { useI18n } from "@/lib/providers/i18n"
 import { cn } from "@/lib/utils"
@@ -68,6 +74,10 @@ export interface ControlsProps {
   /** Toggle audio description on/off — used by the bar toggle (single-language case). */
   onToggleAudioDescription: () => void
   onSeek: (time: number) => void
+  download?: {
+    label: string
+    onClick: () => void
+  }
 }
 
 /** Bottom control bar. Pure presentation; every interaction is delegated up. */
@@ -107,6 +117,7 @@ export function Controls({
   onToggleCaptions,
   onToggleAudioDescription,
   onSeek,
+  download,
 }: ControlsProps) {
   const { t } = useI18n()
 
@@ -229,6 +240,17 @@ export function Controls({
           audioDescriptionOn={audioDescriptionOn}
           onAudioDescriptionLanguageChange={onAudioDescriptionLanguageChange}
           onAudioDescriptionOff={onAudioDescriptionOff}
+        />
+      )}
+
+      {download && (
+        <F0Button
+          variant="ghost"
+          size="sm"
+          hideLabel
+          icon={Download}
+          label={download.label}
+          onClick={download.onClick}
         />
       )}
 

--- a/packages/react/src/components/F0VideoPlayer/hooks/useKeyboardShortcuts.ts
+++ b/packages/react/src/components/F0VideoPlayer/hooks/useKeyboardShortcuts.ts
@@ -13,8 +13,8 @@ export interface UseKeyboardShortcutsOptions {
 }
 
 /**
- * Player keyboard shortcuts (active while the wrapper or a non-input descendant
- * holds focus):
+ * Player keyboard shortcuts (active while the wrapper or a non-interactive
+ * descendant holds focus):
  *
  *   Space    → play/pause
  *   ← / →    → seek ±SEEK_STEP_SECONDS (forward seek runs through `seek`'s clamp)
@@ -34,8 +34,14 @@ export function useKeyboardShortcuts({
     (event: React.KeyboardEvent<HTMLElement>) => {
       const target = event.target
       if (target instanceof HTMLElement) {
-        const tag = target.tagName
-        if (tag === "INPUT" || tag === "TEXTAREA" || target.isContentEditable)
+        // Native/custom controls own their activation keys. In particular,
+        // intercepting Space from a button would cancel its native click and
+        // toggle playback instead.
+        if (
+          target.closest(
+            'button, a, input, textarea, select, [role="button"], [contenteditable="true"]'
+          )
+        )
           return
         // Inside a menu, let the menu own its keys (Arrow/Space/Enter).
         if (target.closest('[role="menu"], [role^="menuitem"]')) return

--- a/packages/react/src/components/F0VideoPlayer/internal.tsx
+++ b/packages/react/src/components/F0VideoPlayer/internal.tsx
@@ -37,12 +37,14 @@ import { F0VideoPlayerProps } from "./types"
 export function F0VideoPlayerInternal({
   src,
   poster,
+  ariaLabel,
   silent = false,
   persistControls = false,
   content,
   defaultLanguage,
   autoPlay = false,
   autoFocus = false,
+  download,
   restrictForwardSeek = false,
   onTrackAction,
   onMilestone,
@@ -238,7 +240,7 @@ export function F0VideoPlayerInternal({
         focusRing()
       )}
       role="region"
-      aria-label={t("videoPlayer.regionLabel")}
+      aria-label={ariaLabel ?? t("videoPlayer.regionLabel")}
       tabIndex={0}
       onKeyDown={handleKeyDown}
       // Accessibility signal for the Storybook a11y check: prerecorded video
@@ -383,6 +385,7 @@ export function F0VideoPlayerInternal({
           onToggleCaptions={captions.toggle}
           onToggleAudioDescription={toggleAudioDescription}
           onSeek={seek}
+          download={download}
         />
       )}
     </div>

--- a/packages/react/src/components/F0VideoPlayer/types.ts
+++ b/packages/react/src/components/F0VideoPlayer/types.ts
@@ -54,6 +54,9 @@ export interface VideoPlayerContent {
 }
 
 export interface F0VideoPlayerProps extends DataAttributes {
+  /** Accessible name for this player region. Defaults to "Video player". */
+  ariaLabel?: string
+
   /**
    * Video source URL. Localizable — pass a per-locale list of dubbed renditions
    * to offer selectable audio languages; an "Audio" selector then appears,
@@ -108,6 +111,15 @@ export interface F0VideoPlayerProps extends DataAttributes {
   autoPlay?: boolean
   /** Focus the player on mount so keyboard shortcuts work immediately. Default `false`. */
   autoFocus?: boolean
+  /**
+   * Optional download action rendered inside the player controls. Native media
+   * downloads remain disabled, so embedded surfaces that allow saving the
+   * source can expose an explicit, keyboard-accessible action here.
+   */
+  download?: {
+    label: string
+    onClick: () => void
+  }
   /**
    * Prevent seeking past the furthest point already watched. Renders a marker at
    * that position and blocks the cursor beyond it. Default `false`.


### PR DESCRIPTION
## Description

Adds a controlled, opt-in download action to `F0VideoPlayer`. Embedding surfaces can now keep native browser downloads disabled while exposing a clearly labelled download button inside the same controls as playback, captions, speed, volume, and fullscreen.

The change also prevents player-level keyboard shortcuts from intercepting Space and other activation keys when focus is on a nested interactive control.

## Type of change

- [ ] New component
- [ ] New pattern
- [ ] New pattern variant
- [x] Component enhancement/variant
- [ ] Pattern enhancement/variant
- [x] Bug fix
- [ ] Refactor/internal change

## Lifecycle phase (if applicable)

- Phase: Validate
- Status: Experimental
- This extends the existing `F0VideoPlayer` API with one optional action and preserves the default behavior when it is omitted.

## Storybook examples

- Downloadable player with captions and persistent controls
- Consolidated snapshot comparing standard controls with the downloadable state
- Existing caption, localization, audio-description, LMS, and silent-video examples remain unchanged

## Implementation details

- Adds `download: { label, onClick }` to `F0VideoPlayerProps`.
- Renders the action as an accessible icon button inside the loaded player controls.
- Keeps native context-menu downloads disabled.
- Ignores player-wide keyboard shortcuts when the event originates from buttons, links, inputs, selects, textareas, custom buttons, menus, or editable content.
- Documents the embedding contract and provides a captioned Storybook example.

## Verification

- 45 `F0VideoPlayer` unit tests pass.
- TypeScript, formatting, circular-dependency checks, ownership checks, and `git diff --check` pass.
- The consolidated Storybook snapshot renders both loaded players and exposes the download action with the expected accessible name.

---
> Factorial is conducting an analysis on the impact of the used skills. This was autogenerated, please don't delete:
> - factorial-f0
> - factorial-pr
> - factorial-skill-tracking
> - factorial-skills
