### PR TITLE
fix(react): ignore reordered opaque unions

### DIFF
--- a/packages/react/.scripts/__tests__/check-api-surface.test.ts
+++ b/packages/react/.scripts/__tests__/check-api-surface.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import {
   analyze,
   buildCommentMarkdown,
+  normalize,
   snapshotEntry,
   type AnalysisResult,
   type EntryDiff,
@@ -258,6 +259,36 @@ describe("check-api-surface — external type resolution", () => {
     `
     expect(f0(surface, surface).breaking).toHaveLength(0)
   })
+
+  it("does not flag reordered unions nested in opaque external types", () => {
+    const surface = (refType: string) => `
+      import { RefAttributes } from "react";
+      export declare const ChartRef: RefAttributes<${refType}>;
+    `
+
+    expect(
+      f0(
+        surface("HTMLElement | SVGElement"),
+        surface("SVGElement | HTMLElement")
+      ).breaking
+    ).toHaveLength(0)
+  })
+
+  it("still flags a changed member in a reordered opaque union", () => {
+    const surface = (refType: string) => `
+      import { RefAttributes } from "react";
+      export declare const ChartRef: RefAttributes<${refType}>;
+    `
+
+    expect(
+      names(
+        f0(
+          surface("HTMLElement | SVGElement"),
+          surface("SVGElement | HTMLCanvasElement")
+        )
+      )
+    ).toContain("ChartRef")
+  })
 })
 
 describe("check-api-surface — unions and intersections", () => {
@@ -488,9 +519,9 @@ describe("check-api-surface — arrays are unwrapped, not opaque", () => {
     )
     const changed = diff.breaking.find((b) => b.name === "Collection")
     expect(changed?.kind).toBe("changed")
-    expect(
-      changed?.reasons?.some((r) => r.includes("headerGroupLabels"))
-    ).toBe(true)
+    expect(changed?.reasons?.some((r) => r.includes("headerGroupLabels"))).toBe(
+      true
+    )
   })
 })
 
@@ -637,6 +668,18 @@ describe("check-api-surface — determinism", () => {
     expect(result.hasBreaking).toBe(false)
     expect(result.breakingTotal).toBe(0)
     expect(result.addedTotal).toBe(0)
+  })
+
+  it("normalizes union order at any depth in opaque type text", () => {
+    expect(
+      normalize(
+        'ForwardRefExoticComponent<Omit<any, "ref"> & RefAttributes<HTMLElement | SVGElement>>'
+      )
+    ).toBe(
+      normalize(
+        'ForwardRefExoticComponent<Omit<any, "ref"> & RefAttributes<SVGElement | HTMLElement>>'
+      )
+    )
   })
 })
 

--- a/packages/react/.scripts/check-api-surface.ts
+++ b/packages/react/.scripts/check-api-surface.ts
@@ -364,15 +364,83 @@ function typeParameterText(sym: ts.Symbol): string {
 const TYPE_TO_STRING_FLAGS =
   ts.TypeFormatFlags.NoTruncation | ts.TypeFormatFlags.WriteArrayAsGenericType
 
+const normalizedTypeTextCache = new Map<string, string>()
+const typeNodePrinter = ts.createPrinter({ removeComments: true })
+
+/**
+ * TypeScript may render equivalent unions in a different order when unrelated
+ * declarations move in an api-extractor rollup. Opaque types preserve that
+ * rendered text, so canonicalize every union node before comparing it. Parsing
+ * the whole type lets this reach unions nested inside external generic types
+ * without changing intersection order or other potentially meaningful syntax.
+ */
+function canonicalizeUnionOrder(typeText: string): string {
+  if (!typeText.includes("|")) return typeText
+
+  const cached = normalizedTypeTextCache.get(typeText)
+  if (cached !== undefined) return cached
+
+  const sourceFile = ts.createSourceFile(
+    "__api_surface_type__.ts",
+    `type __ApiSurfaceType = ${typeText}`,
+    ts.ScriptTarget.Latest,
+    false,
+    ts.ScriptKind.TS
+  )
+  const statement = sourceFile.statements[0]
+  if (
+    sourceFile.parseDiagnostics.length > 0 ||
+    !ts.isTypeAliasDeclaration(statement)
+  ) {
+    normalizedTypeTextCache.set(typeText, typeText)
+    return typeText
+  }
+
+  const result = ts.transform<ts.TypeNode>(statement.type, [
+    (context) => {
+      const visit: ts.Visitor = (node) => {
+        const visited = ts.visitEachChild(node, visit, context)
+        if (!ts.isUnionTypeNode(visited)) return visited
+
+        const sortedTypes = [...visited.types]
+          .map((type) => ({
+            text: typeNodePrinter.printNode(
+              ts.EmitHint.Unspecified,
+              type,
+              sourceFile
+            ),
+            type,
+          }))
+          .sort((a, b) => (a.text < b.text ? -1 : a.text > b.text ? 1 : 0))
+          .map(({ type }) => type)
+
+        return context.factory.updateUnionTypeNode(visited, sortedTypes)
+      }
+
+      return (root) => ts.visitNode(root, visit) as ts.TypeNode
+    },
+  ])
+  const normalized = typeNodePrinter.printNode(
+    ts.EmitHint.Unspecified,
+    result.transformed[0],
+    sourceFile
+  )
+  result.dispose()
+  normalizedTypeTextCache.set(typeText, normalized)
+  return normalized
+}
+
 /**
  * Normalize a type string so it is comparable across the two analyzed dirs:
  *  - strip `import("<abs path>").` qualifiers — the path is base-dir vs
  *    head-dir specific and would make every cross-referenced type look changed;
  *  - strip per-program unique-id suffixes on computed/internal names
  *    (e.g. `__@iterator@968`), which differ run-to-run.
+ *  - canonicalize union-member order, including unions nested in opaque types.
  */
 export function normalize(s: string): string {
-  return s.replace(/import\("[^"]*"\)\./g, "").replace(/@\d+/g, "")
+  const stableText = s.replace(/import\("[^"]*"\)\./g, "").replace(/@\d+/g, "")
+  return canonicalizeUnionOrder(stableText)
 }
 
 /** A type declared only outside the analyzed dir (React/DOM/lib) — referenced


### PR DESCRIPTION
## Description

Stops the Public API Surface workflow from treating order-only TypeScript union rendering as a breaking change. This fixes the 79 false positives reported on [#4843](https://github.com/factorialco/f0/pull/4843#issuecomment-5090330364) while preserving detection when a union member is actually replaced or removed.

## Type of change

- [x] Bug fix

## Implementation details

- fix: parse normalized opaque type text and canonicalize union nodes recursively, including unions nested inside external generic types, without reordering intersections or other syntax
- test: reproduce the `RefAttributes<HTMLElement | SVGElement>` order-only false positive and verify that a real member replacement remains breaking

## Verification

- `pnpm vitest run .scripts/__tests__/check-api-surface.test.ts --reporter=verbose` — 43 tests passed
- `pnpm format` and changed-file `format:check` — passed
- `pnpm --filter @factorialco/f0-core build && pnpm --filter @factorialco/f0-react run tsc` — passed
- changed-file `pnpm lint` — passed
- replayed the exact #4843 CI declaration artifacts — breaking total changed from 79 to 0

---
> Factorial is conducting an analysis on the impact of the used skills. This was autogenerated, please don't delete:
> - f0-code-review
> - f0-unit-testing
> - f0-quality-gate
> - f0-pr
> - factorial-pr
