### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.65.1",
+  "packages/react": "4.66.0",
   "packages/react-native": "0.59.0",
   "packages/core": "1.56.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.66.0](https://github.com/factorialco/f0/compare/f0-react-v4.65.1...f0-react-v4.66.0) (2026-07-30)
+
+
+### Features
+
+* **F0Form:** support showSubmitWhenDirty in single-schema mode ([#4869](https://github.com/factorialco/f0/issues/4869)) ([7d67c70](https://github.com/factorialco/f0/commit/7d67c70af276b33a5711f1f50d25d49c75a73429))
+
 ## [4.65.1](https://github.com/factorialco/f0/compare/f0-react-v4.65.0...f0-react-v4.65.1) (2026-07-29)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.65.1",
+  "version": "4.66.0",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.66.0</summary>

## [4.66.0](https://github.com/factorialco/f0/compare/f0-react-v4.65.1...f0-react-v4.66.0) (2026-07-30)


### Features

* **F0Form:** support showSubmitWhenDirty in single-schema mode ([#4869](https://github.com/factorialco/f0/issues/4869)) ([7d67c70](https://github.com/factorialco/f0/commit/7d67c70af276b33a5711f1f50d25d49c75a73429))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).