### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.66.0",
+  "packages/react": "4.66.1",
   "packages/react-native": "0.59.0",
   "packages/core": "1.56.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.66.1](https://github.com/factorialco/f0/compare/f0-react-v4.66.0...f0-react-v4.66.1) (2026-07-30)
+
+
+### Bug Fixes
+
+* **react:** ignore reordered opaque unions ([#4912](https://github.com/factorialco/f0/issues/4912)) ([7939329](https://github.com/factorialco/f0/commit/7939329681089b40e8878c6496cba6b71f2f4a2c))
+
 ## [4.66.0](https://github.com/factorialco/f0/compare/f0-react-v4.65.1...f0-react-v4.66.0) (2026-07-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.66.0",
+  "version": "4.66.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.66.1</summary>

## [4.66.1](https://github.com/factorialco/f0/compare/f0-react-v4.66.0...f0-react-v4.66.1) (2026-07-30)


### Bug Fixes

* **react:** ignore reordered opaque unions ([#4912](https://github.com/factorialco/f0/issues/4912)) ([7939329](https://github.com/factorialco/f0/commit/7939329681089b40e8878c6496cba6b71f2f4a2c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).