### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.66.1",
+  "packages/react": "4.66.2",
   "packages/react-native": "0.59.0",
   "packages/core": "1.56.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.66.2](https://github.com/factorialco/f0/compare/f0-react-v4.66.1...f0-react-v4.66.2) (2026-07-30)
+
+
+### Bug Fixes
+
+* **OneDataCollection:** make trailing tagList content fully visible in tables ([#4793](https://github.com/factorialco/f0/issues/4793)) ([d2f8da0](https://github.com/factorialco/f0/commit/d2f8da0b90bca1f0093320c0c52d3167366c243c))
+
 ## [4.66.1](https://github.com/factorialco/f0/compare/f0-react-v4.66.0...f0-react-v4.66.1) (2026-07-30)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.66.1",
+  "version": "4.66.2",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.66.2</summary>

## [4.66.2](https://github.com/factorialco/f0/compare/f0-react-v4.66.1...f0-react-v4.66.2) (2026-07-30)


### Bug Fixes

* **OneDataCollection:** make trailing tagList content fully visible in tables ([#4793](https://github.com/factorialco/f0/issues/4793)) ([d2f8da0](https://github.com/factorialco/f0/commit/d2f8da0b90bca1f0093320c0c52d3167366c243c))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).