### PR TITLE
fix(EditableTable): allow overriding read-only cellHint icon position

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/DisabledCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/DisabledCell.test.tsx
@@ -68,6 +68,25 @@ describe("DisabledCell", () => {
     ).toBeTruthy()
   })
 
+  it("renders the hint icon before the cell content when hint.hintPosition is left", () => {
+    render(
+      <DisabledCell
+        {...defaultProps}
+        hint={{
+          icon: InfoCircleLine,
+          message: "Locked by policy",
+          hintPosition: "left",
+        }}
+      />
+    )
+
+    const button = screen.getByRole("button", { name: "Locked by policy" })
+    const content = screen.getByText("John Doe")
+    expect(
+      button.compareDocumentPosition(content) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
   it("does not render a hint icon when hint is omitted", () => {
     render(<DisabledCell {...defaultProps} />)
 

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NonEditableCell.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/__tests__/NonEditableCell.test.tsx
@@ -57,6 +57,27 @@ describe("NonEditableCell", () => {
     ).toBeTruthy()
   })
 
+  it("renders the hint icon before the cell content when hint.hintPosition is left", () => {
+    render(
+      <NonEditableCell
+        {...defaultProps}
+        hint={{
+          icon: InfoCircleLine,
+          message: "Backfilling Jane's position",
+          hintPosition: "left",
+        }}
+      />
+    )
+
+    const button = screen.getByRole("button", {
+      name: "Backfilling Jane's position",
+    })
+    const content = screen.getByText("John Doe")
+    expect(
+      button.compareDocumentPosition(content) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy()
+  })
+
   it("renders a hint icon when hint is provided", () => {
     render(
       <NonEditableCell

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/index.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/index.ts
@@ -24,7 +24,12 @@ export type EditableCellProps<R extends RecordType> = {
   ) => void
   item: R
   isLastColumn?: boolean
-  hint?: { icon: IconType; message: string; iconColor?: F0IconProps["color"] }
+  hint?: {
+    icon: IconType
+    message: string
+    iconColor?: F0IconProps["color"]
+    hintPosition?: "left" | "right"
+  }
 }
 
 /** The edit mode for a column cell in the editable table. */

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/DisabledCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/DisabledCell.tsx
@@ -14,7 +14,7 @@ export function DisabledCell<R extends RecordType>({
       disabled
       borderOnHover={false}
       hint={hint}
-      hintPosition="right"
+      hintPosition={hint?.hintPosition ?? "right"}
       cursor="not-allowed"
     >
       <ReadOnlyCellContent

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/NonEditableCell.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/components/cells/status/NonEditableCell.tsx
@@ -15,7 +15,7 @@ export function NonEditableCell<R extends RecordType>({
       showRightBorder={!isLastColumn}
       borderOnHover={false}
       hint={hint}
-      hintPosition="right"
+      hintPosition={hint?.hintPosition ?? "right"}
       cursor="default"
     >
       <ReadOnlyCellContent

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/EditableTable/types.ts
@@ -227,6 +227,11 @@ export type EditableTableColumnDefinition<
    *
    * Return `undefined` to hide the hint.
    *
+   * For `display-only` / `disabled` cells, the hint icon renders on the
+   * right by default. Pass `hintPosition: "left"` to override this for a
+   * specific column (e.g. when the hint always sits next to the value it
+   * annotates, regardless of the cell's editable state).
+   *
    * @example
    * cellHint: (item) => {
    *   if (item._inferredSalary != null && item.salary !== item._inferredSalary) {
@@ -239,6 +244,7 @@ export type EditableTableColumnDefinition<
         icon: IconType
         message: string
         iconColor?: F0IconProps["color"]
+        hintPosition?: "left" | "right"
       }
     | undefined
 }


### PR DESCRIPTION
## Description

`cellHint` icons on `display-only`/`disabled` cells default to rendering on the right of the cell content (per FCT-56432, for the Headcount Planning "Backfill" column). Some columns need the hint icon to always sit on the left of the value, regardless of whether the cell is currently editable or locked — the Salary column's expected-range tooltip flips sides depending on plan state, which reads as a bug. This adds an opt-in `hintPosition` override on `cellHint` so a column can force "left" without changing the default for existing columns like Backfill.

Jira: [FCT-59350](https://factorialmakers.atlassian.net/browse/FCT-59350)

## Screenshots (if applicable)
Before: the salary column has different places depending of the cell beings editable or locked
<img width="1759" height="939" alt="Screenshot 2026-07-30 at 14 26 28" src="https://github.com/user-attachments/assets/3d759483-7bdb-45f3-85f3-f74e8bf526ee" />
<img width="1803" height="859" alt="Screenshot 2026-07-30 at 14 26 44" src="https://github.com/user-attachments/assets/db8d12d7-ecd4-4d72-9b10-58250a7764cc" />

After. the salary column has the same place
<img width="1465" height="806" alt="Screenshot 2026-07-30 at 14 56 44" src="https://github.com/user-attachments/assets/b700f1cb-7495-43aa-82b9-87e55f71928b" />
<img width="1376" height="818" alt="Screenshot 2026-07-30 at 14 57 18" src="https://github.com/user-attachments/assets/ede6c57f-1ad5-49b7-b609-123433db7c62" />


## Implementation details

- fix: `cellHint` can return an optional `hintPosition: "left" | "right"`, propagated through `EditableCellProps["hint"]`
- fix: `NonEditableCell` and `DisabledCell` use `hint?.hintPosition ?? "right"` instead of a hardcoded `"right"`, so existing columns (e.g. Backfill) are unaffected unless they opt in
- test: cover the `hintPosition: "left"` override in `NonEditableCell` and `DisabledCell` unit tests

[FCT-59350]: https://factorialmakers.atlassian.net/browse/FCT-59350?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ