### PR TITLE
fix(F0DataChart): round the true outer stack segment, not a fixed series

### DIFF
--- a/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
@@ -137,6 +137,27 @@ export const StackedNegativeValues: Story = {
 }
 
 /**
+ * All values are positive, but not every series has data in every category —
+ * e.g. "Involuntary exits" is 0 for most offices. The outer-most non-zero
+ * segment of each bar is rounded, whichever series that happens to be for
+ * that category, instead of always the last series in the array.
+ */
+export const StackedWithMissingCategories: Story = {
+  render: (args) => <F0DataChart {...args} />,
+  args: {
+    type: "bar",
+    stacked: true,
+    categories: ["Barcelona", "Paris", "Berlin", "London", "Remote"],
+    series: [
+      { name: "Working from home", data: [14, 13, 0, 0, 0] },
+      { name: "Paid — Vacation", data: [12, 10, 25, 28, 26] },
+      { name: "Paid — Compensation", data: [0, 2, 0, 0, 0] },
+      { name: "Involuntary exits", data: [0, 2, 2, 0, 0] },
+    ],
+  },
+}
+
+/**
  * Each bar has a `target` value — the gap between the actual value and the
  * target is rendered as a faded "ghost" bar above the solid one.
  */

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -214,4 +214,25 @@ describe("BarChart — corner rounding", () => {
     expect(getBorderRadii(2)).toEqual([0])
     expect(getBorderRadii(3)).toEqual([[0, 0, 4, 4]])
   })
+
+  it("rounds the true outer segment of an all-positive stack, even when the last series is 0 for that category", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        stacked
+        categories={["Q1", "Q2"]}
+        series={[
+          { name: "Hires", data: [10, 8] },
+          { name: "Internal moves", data: [5, 4] },
+          { name: "Exits", data: [3, 0] },
+        ]}
+      />
+    )
+
+    // Q1: "Exits" (last series) is the outer segment → rounded, others flat
+    // Q2: "Exits" is 0, so "Internal moves" is the true outer segment
+    expect(getBorderRadii(0)).toEqual([0, 0])
+    expect(getBorderRadii(1)).toEqual([0, [4, 4, 0, 0]])
+    expect(getBorderRadii(2)).toEqual([[4, 4, 0, 0], 0])
+  })
 })

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -71,27 +71,33 @@ type BorderRadiusResolver = (
 ) => number[] | number
 
 /**
- * Builds a per-bar corner radius resolver, needed only when some value is
- * negative: the series-level radius can't express two directions at once.
+ * Builds a per-bar corner radius resolver.
  *
- * ECharts stacks positive and negative values away from the zero line in
- * opposite directions, so a stacked category has up to two outer segments —
- * the last series contributing a positive value and the last one contributing
- * a negative value — and only those two get rounded.
+ * Non-stacked charts only need this when some value is negative: the
+ * series-level radius can't express two directions at once. All-positive
+ * (or all-negative) non-stacked charts keep the plain series-level radius.
+ *
+ * Stacked charts always need it, even when every value is positive: ECharts
+ * stacks positive and negative values away from the zero line in opposite
+ * directions, so a category has up to two outer segments — the last series
+ * contributing a positive value and the last one contributing a negative
+ * value — and only those two get rounded. Which series that is can differ
+ * per category (e.g. the nominally "last" series is 0 for one category, so
+ * an earlier series is the one actually touching the outer edge there), so
+ * this can't be reduced to a single fixed series index.
  */
 function buildBorderRadiusResolver(
   series: F0DataChartBarSeries[],
   isVertical: boolean,
   stacked: boolean
 ): BorderRadiusResolver | undefined {
-  const hasNegativeValues = series.some((s) =>
-    s.data.some((point) => getValue(point) < 0)
-  )
-  if (!hasNegativeValues) {
-    return undefined
-  }
-
   if (!stacked) {
+    const hasNegativeValues = series.some((s) =>
+      s.data.some((point) => getValue(point) < 0)
+    )
+    if (!hasNegativeValues) {
+      return undefined
+    }
     return (_seriesIndex, _dataIndex, value) =>
       barCornerRadius(isVertical, value < 0)
   }
@@ -132,7 +138,6 @@ function buildSeriesEntries(
   isVertical: boolean,
   showLabels: boolean,
   stacked: boolean,
-  isLastSeries: boolean,
   labelColor: string,
   resolveBorderRadius: BorderRadiusResolver | undefined
 ): echarts.BarSeriesOption[] {
@@ -171,11 +176,11 @@ function buildSeriesEntries(
   // Round only the far end (away from the zero line):
   // - Vertical: top corners rounded, bottom flat against x-axis
   // - Horizontal: right corners rounded, left flat against y-axis
-  // Negative bars grow the other way, so `resolveBorderRadius` overrides this
-  // per data point.
+  // This series-level default only applies when `resolveBorderRadius` is
+  // undefined (non-stacked, all-positive charts) — everything else
+  // (negatives, or any stacked chart) is overridden per data point below,
+  // since the direction and the outer-most segment can vary per category.
   const borderRadius = barCornerRadius(isVertical, false)
-  // Stacked series that aren't the last one get no rounding (sandwiched)
-  const effectiveBorderRadius = stacked && !isLastSeries ? 0 : borderRadius
 
   const mainSeries: echarts.BarSeriesOption = {
     name: series.name,
@@ -184,7 +189,7 @@ function buildSeriesEntries(
     stack: stackId,
     itemStyle: {
       color,
-      borderRadius: effectiveBorderRadius,
+      borderRadius,
     },
     label: {
       show: showLabels,
@@ -339,7 +344,6 @@ export function useBarChartOptions(
         isVertical,
         showLabels,
         stacked,
-        i === series.length - 1,
         theme.colors.foregroundSecondary,
         resolveBorderRadius
       )


### PR DESCRIPTION
## Description

Follow-up to #4871. That PR fixed corner rounding for stacked bars with **negative** values, but left the original bug in place for **all-positive** stacks: the rounded corner was still hardcoded to whichever series is last in the `series` array, instead of whichever segment is actually the outer-most non-zero one in each category.

If that last series is `0` for a given category (a common case: not every series has data in every category), the segment that's actually visually on top stays square.

## Screenshots (if applicable)

Repro'd in the new `StackedWithMissingCategories` story (`F0DataChart/Bar`) — an absences-by-office chart where "Working from home" / "Paid — Compensation" / "Involuntary exits" are 0 for most offices, so "Paid — Vacation" is the true top segment for most bars but isn't the last series.

## Implementation details

`buildBorderRadiusResolver` already computes, per category, which series is the outer-most positive contributor and which is the outer-most negative one (`outerPositive` / `outerNegative` maps) — added in #4871 to fix negative-value rounding. But it only ran that logic when the chart had at least one negative value:

```ts
const hasNegativeValues = series.some((s) => s.data.some((point) => getValue(point) < 0))
if (!hasNegativeValues) {
  return undefined
}
```

For an all-positive stack, this bailed out to the old series-level radius, gated on `isLastSeries` (fixed array position) — the exact bug this PR fixes.

- Moved the `hasNegativeValues` bail-out so it only applies to **non-stacked** charts (where a single series-level radius is genuinely sufficient when nothing is negative).
- Stacked charts now always build the per-category `outerPositive`/`outerNegative` resolver, regardless of sign — the "outer" segment can shift between categories independently of whether any value is negative.
- Removed the now-dead `isLastSeries` parameter and the `stacked && !isLastSeries ? 0 : borderRadius` fallback from `buildSeriesEntries`: since stacked charts always get a per-point resolver now, the series-level radius is never read for stacked bars — every point carries an explicit `itemStyle.borderRadius`.
- Non-stacked, all-positive charts are unaffected (still plain-number data, series-level radius, no behavior change).

### Tests

Added a case in `BarChart.test.tsx` covering an all-positive stack where the nominal last series (`"Exits"`) is `0` for one category, asserting the earlier series becomes the rounded one for that category while the last series is still rounded where it does have data. Full `F0DataChart` suite: 101 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)