### PR TITLE
fix(F0AvatarIcon): solid dark-mode background & align radius

### DIFF
--- a/packages/react/src/components/avatars/F0Avatar/__stories__/F0Avatar.stories.tsx
+++ b/packages/react/src/components/avatars/F0Avatar/__stories__/F0Avatar.stories.tsx
@@ -269,27 +269,22 @@ const TYPE_ROWS: {
   {
     label: "Person",
     sizes: avatarSizes,
-    avatar: {
-      type: "person",
-      firstName: "John",
-      lastName: "Doe",
-      "aria-label": "John Doe",
-    },
+    avatar: { type: "person", firstName: "John", lastName: "Doe" },
   },
   {
     label: "Team",
     sizes: avatarSizes,
-    avatar: { type: "team", name: "Engineering Team", "aria-label": "Team" },
+    avatar: { type: "team", name: "Engineering Team" },
   },
   {
     label: "Company",
     sizes: avatarSizes,
-    avatar: { type: "company", name: "Factorial HR", "aria-label": "Company" },
+    avatar: { type: "company", name: "Factorial HR" },
   },
   {
     label: "Flag",
     sizes: avatarSizes,
-    avatar: { type: "flag", flag: "es", "aria-label": "Spain" },
+    avatar: { type: "flag", flag: "es" },
   },
   {
     label: "File",
@@ -297,18 +292,17 @@ const TYPE_ROWS: {
     avatar: {
       type: "file",
       file: { name: "report.pdf", type: "application/pdf" },
-      "aria-label": "report.pdf",
     },
   },
   {
     label: "Emoji",
     sizes: avatarEmojiSizes,
-    avatar: { type: "emoji", emoji: "🎉", "aria-label": "Party" },
+    avatar: { type: "emoji", emoji: "🎉" },
   },
   {
     label: "Icon",
     sizes: avatarIconSizes,
-    avatar: { type: "icon", icon: Calendar, "aria-label": "Calendar" },
+    avatar: { type: "icon", icon: Calendar },
   },
 ]
 

--- a/packages/react/src/components/avatars/F0Avatar/__stories__/F0Avatar.stories.tsx
+++ b/packages/react/src/components/avatars/F0Avatar/__stories__/F0Avatar.stories.tsx
@@ -8,9 +8,13 @@ import { dataTestIdArgs } from "@/lib/data-testid/__stories__/args"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 import { internalAvatarSizes } from "@/ui/Avatar"
 
-import { avatarSizes } from "../../internal/BaseAvatar"
+import { avatarEmojiSizes } from "../../F0AvatarEmoji/F0AvatarEmoji"
+import { avatarFileSizes } from "../../F0AvatarFile/types"
+import { avatarIconSizes } from "../../F0AvatarIcon/F0AvatarIcon"
+import { AvatarSize, avatarSizes } from "../../internal/BaseAvatar"
 import { getBaseAvatarArgTypes } from "../../internal/BaseAvatar/__stories__/utils"
 import { F0Avatar } from "../F0Avatar"
+import { AvatarVariant } from "../types"
 
 const meta = {
   component: F0Avatar,
@@ -254,54 +258,140 @@ export const AllTypes: Story = {
   },
 }
 
+// Every F0Avatar type paired with the sizes it actually supports. File, Emoji
+// and Icon expose narrower size scales than the base xs-2xl range, so the matrix
+// only renders each type at its available sizes (blank cells otherwise).
+const TYPE_ROWS: {
+  label: string
+  sizes: readonly AvatarSize[]
+  avatar: AvatarVariant
+}[] = [
+  {
+    label: "Person",
+    sizes: avatarSizes,
+    avatar: {
+      type: "person",
+      firstName: "John",
+      lastName: "Doe",
+      "aria-label": "John Doe",
+    },
+  },
+  {
+    label: "Team",
+    sizes: avatarSizes,
+    avatar: { type: "team", name: "Engineering Team", "aria-label": "Team" },
+  },
+  {
+    label: "Company",
+    sizes: avatarSizes,
+    avatar: { type: "company", name: "Factorial HR", "aria-label": "Company" },
+  },
+  {
+    label: "Flag",
+    sizes: avatarSizes,
+    avatar: { type: "flag", flag: "es", "aria-label": "Spain" },
+  },
+  {
+    label: "File",
+    sizes: avatarFileSizes,
+    avatar: {
+      type: "file",
+      file: { name: "report.pdf", type: "application/pdf" },
+      "aria-label": "report.pdf",
+    },
+  },
+  {
+    label: "Emoji",
+    sizes: avatarEmojiSizes,
+    avatar: { type: "emoji", emoji: "🎉", "aria-label": "Party" },
+  },
+  {
+    label: "Icon",
+    sizes: avatarIconSizes,
+    avatar: { type: "icon", icon: Calendar, "aria-label": "Calendar" },
+  },
+]
+
 export const Snapshot: Story = {
   parameters: withSnapshot({}),
   render: () => (
-    <div className="flex w-fit flex-col gap-4">
-      <h3 className="text-lg font-semibold">Avatars with Badges</h3>
-      <div className="flex flex-row gap-4">
-        <div className="flex flex-col items-center gap-2">
-          <span className="text-sm font-medium">Module Badge</span>
-          <F0Avatar
-            size="lg"
-            avatar={{
-              type: "person",
-              firstName: "John",
-              lastName: "Doe",
-              badge: {
-                type: "module",
-                module: "time-tracking",
-              },
-            }}
-          />
+    <div className="flex w-fit flex-col gap-8">
+      <div className="flex w-fit flex-col gap-4">
+        <h3 className="text-lg font-semibold">
+          All types · all available sizes
+        </h3>
+        {/* Size header */}
+        <div className="flex flex-row items-end gap-4">
+          <span className="w-16" />
+          {SIZES.map((size) => (
+            <span
+              key={size}
+              className="w-20 text-center text-sm font-medium text-f1-foreground-secondary"
+            >
+              {size}
+            </span>
+          ))}
         </div>
-        <div className="flex flex-col items-center gap-2">
-          <span className="text-sm font-medium">Success Badge</span>
-          <F0Avatar
-            size="lg"
-            avatar={{
-              type: "team",
-              name: "Engineering Team",
-              badge: {
-                type: "positive",
-                icon: Check,
-              },
-            }}
-          />
-        </div>
-        <div className="flex flex-col items-center gap-2">
-          <span className="text-sm font-medium">Warning Badge</span>
-          <F0Avatar
-            size="lg"
-            avatar={{
-              type: "company",
-              name: "Factorial HR",
-              badge: {
-                type: "warning",
-                icon: Warning,
-              },
-            }}
-          />
+        {TYPE_ROWS.map(({ label, sizes, avatar }) => (
+          <div key={label} className="flex flex-row items-center gap-4">
+            <span className="w-16 text-sm font-medium">{label}</span>
+            {SIZES.map((size) => (
+              <div key={size} className="flex w-20 justify-center">
+                {(sizes as readonly AvatarSize[]).includes(size) ? (
+                  <F0Avatar size={size} avatar={avatar} />
+                ) : null}
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+
+      <div className="flex w-fit flex-col gap-4">
+        <h3 className="text-lg font-semibold">Avatars with Badges</h3>
+        <div className="flex flex-row gap-4">
+          <div className="flex flex-col items-center gap-2">
+            <span className="text-sm font-medium">Module Badge</span>
+            <F0Avatar
+              size="lg"
+              avatar={{
+                type: "person",
+                firstName: "John",
+                lastName: "Doe",
+                badge: {
+                  type: "module",
+                  module: "time-tracking",
+                },
+              }}
+            />
+          </div>
+          <div className="flex flex-col items-center gap-2">
+            <span className="text-sm font-medium">Success Badge</span>
+            <F0Avatar
+              size="lg"
+              avatar={{
+                type: "team",
+                name: "Engineering Team",
+                badge: {
+                  type: "positive",
+                  icon: Check,
+                },
+              }}
+            />
+          </div>
+          <div className="flex flex-col items-center gap-2">
+            <span className="text-sm font-medium">Warning Badge</span>
+            <F0Avatar
+              size="lg"
+              avatar={{
+                type: "company",
+                name: "Factorial HR",
+                badge: {
+                  type: "warning",
+                  icon: Warning,
+                },
+              }}
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/packages/react/src/components/avatars/F0AvatarDate/F0AvatarDate.tsx
+++ b/packages/react/src/components/avatars/F0AvatarDate/F0AvatarDate.tsx
@@ -16,7 +16,7 @@ export const F0AvatarDate = ({
 
   return (
     <div
-      className="flex h-10 w-10 flex-col items-center justify-center rounded border border-solid border-f1-border-secondary bg-f1-background-inverse-secondary dark:bg-f1-background-tertiary"
+      className="flex h-10 w-10 flex-col items-center justify-center rounded-md border border-solid border-f1-border-secondary bg-f1-background-inverse-secondary dark:bg-f1-background-tertiary"
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledby}
     >

--- a/packages/react/src/components/avatars/F0AvatarEmoji/F0AvatarEmoji.tsx
+++ b/packages/react/src/components/avatars/F0AvatarEmoji/F0AvatarEmoji.tsx
@@ -13,7 +13,7 @@ const sizes = {
   sm: "w-6 h-6 rounded-sm",
   md: "w-8 h-8 rounded",
   lg: "w-10 h-10 rounded-md",
-  xl: "w-14 h-14 rounded-lg",
+  xl: "w-14 h-14 rounded-xl",
 }
 
 const imageSizes: Record<

--- a/packages/react/src/components/avatars/F0AvatarIcon/F0AvatarIcon.tsx
+++ b/packages/react/src/components/avatars/F0AvatarIcon/F0AvatarIcon.tsx
@@ -13,8 +13,8 @@ export type F0AvatarIconProps = {
 
 const sizes = {
   sm: "size-6 rounded-sm",
-  md: "size-8 rounded-md",
-  lg: "size-10 rounded-lg",
+  md: "size-8 rounded",
+  lg: "size-10 rounded-md",
 }
 
 export const F0AvatarIcon = ({
@@ -27,7 +27,7 @@ export const F0AvatarIcon = ({
   return (
     <div
       className={cn(
-        "flex aspect-square items-center justify-center border border-solid border-f1-border-secondary bg-f1-background dark:bg-f1-background-inverse-secondary",
+        "flex aspect-square items-center justify-center border border-solid border-f1-border-secondary bg-f1-background",
         sizes[size]
       )}
       aria-label={ariaLabel}

--- a/packages/react/src/components/avatars/__tests__/avatarRadius.test.tsx
+++ b/packages/react/src/components/avatars/__tests__/avatarRadius.test.tsx
@@ -1,0 +1,109 @@
+import { ReactElement } from "react"
+import { describe, expect, it } from "vitest"
+
+import { Placeholder } from "@/icons/app"
+import { zeroRender } from "@/testing/test-utils"
+
+import { F0AvatarCompany } from "../F0AvatarCompany"
+import { F0AvatarDate } from "../F0AvatarDate"
+import { F0AvatarEmoji } from "../F0AvatarEmoji"
+import { F0AvatarFile } from "../F0AvatarFile"
+import { F0AvatarFlag } from "../F0AvatarFlag"
+import { F0AvatarIcon } from "../F0AvatarIcon"
+import { F0AvatarTeam } from "../F0AvatarTeam"
+import { AvatarSize, avatarSizes } from "../internal/BaseAvatar"
+
+/**
+ * Canonical `size -> border-radius` token for square avatars. This is the scale
+ * defined once in `ui/Avatar` (`avatarVariants`, src/ui/Avatar/Avatar.tsx) and
+ * shared by every BaseAvatar-based type. The standalone avatars (Icon, Emoji,
+ * Date) hardcode their own size maps, so they can silently drift out of sync —
+ * this test is the guard that keeps every type rounding its box identically at a
+ * given size, so they look the same when swapped into a shared slot (e.g. F0Card).
+ */
+const CANONICAL_RADIUS = {
+  xs: "rounded-xs",
+  sm: "rounded-sm",
+  md: "rounded",
+  lg: "rounded-md",
+  xl: "rounded-xl",
+  "2xl": "rounded-2xl",
+} as const satisfies Record<AvatarSize, string>
+
+/**
+ * The avatar's outermost box carries the radius class. Icon/Emoji/Date render an
+ * outer <div> with `border-f1-border-secondary`; the ui/Avatar-based types (File,
+ * Flag, Company, Team) render a Radix root tagged `data-a11y-color-contrast-ignore`.
+ * jsdom does not evaluate Tailwind, so we assert on the class token, not a pixel.
+ */
+const getAvatarBox = (container: HTMLElement): HTMLElement => {
+  const box = container.querySelector<HTMLElement>(
+    "[class*='border-f1-border-secondary'], [data-a11y-color-contrast-ignore]"
+  )
+  if (!box) throw new Error("Could not locate the avatar box element")
+  return box
+}
+
+type AvatarCase = {
+  name: string
+  sizes: AvatarSize[]
+  render: (size: AvatarSize) => ReactElement
+}
+
+const makeCase = <S extends AvatarSize>(
+  name: string,
+  sizes: readonly S[],
+  render: (size: S) => ReactElement
+): AvatarCase => ({
+  name,
+  sizes: [...sizes],
+  render: (size) => render(size as S),
+})
+
+const cases: AvatarCase[] = [
+  makeCase("F0AvatarIcon", ["sm", "md", "lg"] as const, (size) => (
+    <F0AvatarIcon icon={Placeholder} size={size} aria-label="icon" />
+  )),
+  makeCase("F0AvatarEmoji", ["sm", "md", "lg", "xl"] as const, (size) => (
+    <F0AvatarEmoji emoji="😀" size={size} aria-label="emoji" />
+  )),
+  makeCase("F0AvatarFile", ["xs", "sm", "md", "lg"] as const, (size) => (
+    <F0AvatarFile
+      file={{ name: "document.pdf", type: "application/pdf" }}
+      size={size}
+    />
+  )),
+  makeCase("F0AvatarFlag", avatarSizes, (size) => (
+    <F0AvatarFlag flag="ES" size={size} />
+  )),
+  makeCase("F0AvatarCompany", avatarSizes, (size) => (
+    <F0AvatarCompany name="Acme Inc" size={size} />
+  )),
+  makeCase("F0AvatarTeam", avatarSizes, (size) => (
+    <F0AvatarTeam name="Platform Team" size={size} />
+  )),
+]
+
+describe("avatar corner radius is in sync across avatar types", () => {
+  describe.each(cases)("$name", ({ sizes, render }) => {
+    it.each(sizes)("uses the canonical radius at size '%s'", (size) => {
+      const { container } = zeroRender(render(size))
+
+      const box = getAvatarBox(container)
+
+      expect(box.classList.contains(CANONICAL_RADIUS[size])).toBe(true)
+    })
+  })
+
+  // F0AvatarDate has no size prop: it renders at a fixed 40px box, which is the
+  // `lg` step of the scale, so it must use the same radius as every other `lg`.
+  it("F0AvatarDate (fixed 40px) matches the 'lg' radius", () => {
+    const { container } = zeroRender(
+      <F0AvatarDate date={new Date("2026-07-30T00:00:00Z")} />
+    )
+
+    const box = getAvatarBox(container)
+
+    expect(box.classList.contains(CANONICAL_RADIUS.lg)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Description

In dark mode the icon avatar rendered a washed-out, semi-transparent white square because the `dark:` background override resolved to the `white-60` token (`f1-background-inverse-secondary`). This drops the override so the component relies on `bg-f1-background` (neutral-0), which is opaque in both themes and keeps the solid background that #4069 restored. It also aligns the corner-radius scale with `F0AvatarEmoji` so icon avatars match the rest of the avatar family when they share a slot (e.g. `F0Card`).

## Implementation details

- fix: use `bg-f1-background` (opaque in both themes) instead of the semi-transparent `dark:bg-f1-background-inverse-secondary`, fixing the washed-out dark-mode background

  <details>
  <summary>Why not <code>dark:bg-f1-background-tertiary</code>?</summary>

  Every other `f1-background-*` variant (`-tertiary`, `-inverse-secondary`) carries alpha, so it would re-introduce the non-solid look #4069 fixed — just in dark mode. Only `bg-f1-background` (neutral-0) is fully opaque in both light (`white.100`) and dark (`grey.100`).
  </details>

- fix: align the radius scale with `F0AvatarEmoji` (`md` `rounded-md`→`rounded`, `lg` `rounded-lg`→`rounded-md`)

  <details>
  <summary>Why?</summary>

  `F0AvatarIcon`'s radii ran one step rounder than `F0AvatarEmoji`'s at every size ≥ md. In `F0Card`'s `WithIconAndImage` both resolve to size `lg`, so an emoji rendered `rounded-md` while an icon in the same slot rendered `rounded-lg`. Aligning the base component keeps standalone and other consumers consistent too.
  </details>