### PR TITLE
feat(F0CanvasCard): add icon avatar variant

### DIFF
--- a/packages/react/src/kits/ai/canvas/F0CanvasCard/F0CanvasCard.tsx
+++ b/packages/react/src/kits/ai/canvas/F0CanvasCard/F0CanvasCard.tsx
@@ -4,6 +4,7 @@ import {
 } from "@/components/avatars/F0AvatarModule"
 import { F0AvatarFile } from "@/components/avatars/F0AvatarFile"
 import type { FileDef } from "@/components/avatars/F0AvatarFile/types"
+import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon"
 import { F0Button } from "@/components/F0Button"
 import type { IconType } from "@/components/F0Icon"
 import { OneEllipsis } from "@/lib/OneEllipsis"
@@ -13,6 +14,7 @@ import { cn } from "@/lib/utils"
 type CanvasCardAvatar =
   | { type: "module"; module: ModuleId }
   | { type: "file"; file: FileDef }
+  | { type: "icon"; icon: IconType }
 
 type CanvasCardAction =
   | {
@@ -35,7 +37,7 @@ type CanvasCardAction =
  * @removeIn 5.0.0
  */
 export type F0CanvasCardProps = {
-  /** Avatar to display: a module icon or a file-type badge */
+  /** Avatar to display: a module icon, a file-type badge, or a plain icon */
   avatar?: CanvasCardAvatar
   /** Primary title */
   title: string
@@ -93,6 +95,9 @@ export function F0CanvasCard({
         )}
         {avatar?.type === "file" && (
           <F0AvatarFile file={avatar.file} size="lg" />
+        )}
+        {avatar?.type === "icon" && (
+          <F0AvatarIcon icon={avatar.icon} size="md" />
         )}
         <div className="flex min-w-0 flex-1 flex-col">
           <OneEllipsis className="text-lg font-semibold text-f1-foreground">

--- a/packages/react/src/kits/ai/canvas/F0CanvasCard/__stories__/F0CanvasCard.stories.tsx
+++ b/packages/react/src/kits/ai/canvas/F0CanvasCard/__stories__/F0CanvasCard.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { fn } from "storybook/test"
 
-import { Download } from "@/icons/app"
+import { BarGraph, Download } from "@/icons/app"
 
 import { F0CanvasCard } from "../F0CanvasCard"
 
@@ -86,6 +86,16 @@ export const FileAvatarNoDescription: Story = {
   args: {
     avatar: { type: "file", file: { name: "headcount_q1.pdf", type: "pdf" } },
     title: "Headcount report Q1",
+    isActive: false,
+    action: openAction,
+  },
+}
+
+export const IconAvatar: Story = {
+  args: {
+    avatar: { type: "icon", icon: BarGraph },
+    title: "Headcount Overview",
+    description: "Employee distribution by department",
     isActive: false,
     action: openAction,
   },

--- a/packages/react/src/kits/ai/canvas/F0CanvasCard/__stories__/F0CanvasCard.stories.tsx
+++ b/packages/react/src/kits/ai/canvas/F0CanvasCard/__stories__/F0CanvasCard.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 import { fn } from "storybook/test"
 
-import { BarGraph, Download } from "@/icons/app"
+import { Download, Table } from "@/icons/app"
 
 import { F0CanvasCard } from "../F0CanvasCard"
 
@@ -93,7 +93,7 @@ export const FileAvatarNoDescription: Story = {
 
 export const IconAvatar: Story = {
   args: {
-    avatar: { type: "icon", icon: BarGraph },
+    avatar: { type: "icon", icon: Table },
     title: "Headcount Overview",
     description: "Employee distribution by department",
     isActive: false,

--- a/packages/react/src/kits/ai/canvas/F0CanvasCard/__tests__/F0CanvasCard.test.tsx
+++ b/packages/react/src/kits/ai/canvas/F0CanvasCard/__tests__/F0CanvasCard.test.tsx
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest"
 import "@testing-library/jest-dom/vitest"
 import { zeroRender as render, screen, userEvent } from "@/testing/test-utils"
 
-import { Download } from "@/icons/app"
+import { BarGraph, Download } from "@/icons/app"
 
 import { F0CanvasCard } from "../F0CanvasCard"
 
@@ -99,6 +99,17 @@ describe("F0CanvasCard", () => {
     )
 
     expect(screen.getByText("PDF")).toBeInTheDocument()
+  })
+
+  it("renders icon avatar", () => {
+    const { container } = render(
+      <F0CanvasCard
+        {...defaultProps}
+        avatar={{ type: "icon", icon: BarGraph }}
+      />
+    )
+
+    expect(container.querySelector("svg")).toBeInTheDocument()
   })
 
   it("does not render description line when description is omitted", () => {


### PR DESCRIPTION
## Description

Adds a third avatar variant to `F0CanvasCard`: `{ type: "icon", icon: IconType }`, rendered with `F0AvatarIcon` at `md` (32px, same box as the module avatar). The card previously only accepted `module` and `file` avatars, so canvas entities that aren't tied to a Factorial module had no neutral avatar option.

`F0CanvasCard` is deprecated in favor of `F0CardHorizontal`, but existing consumers still render it; this is a small additive bridge that mirrors the `icon` variant already supported by `F0CardHorizontal`'s `CardAvatarVariant`, keeping the eventual migration 1:1.

## Screenshots (if applicable)

See the new `IconAvatar` story in Storybook (`AI/F0CanvasCard`).

## Implementation details

- feat: add `{ type: "icon", icon: IconType }` to `CanvasCardAvatar` and render it with `F0AvatarIcon` size `md`
- test: unit test covering the icon avatar rendering
- docs: `IconAvatar` story added to the existing F0CanvasCard stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)