### PR TITLE
fix(SectionHeader): draw the separator with a 3px/4px dash

### DIFF
--- a/packages/react/src/patterns/SectionHeader/__tests__/SectionHeader.test.tsx
+++ b/packages/react/src/patterns/SectionHeader/__tests__/SectionHeader.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest"
+
+import { zeroRender as render, screen } from "@/testing/test-utils"
+
+import { SectionHeader } from "../index"
+
+/**
+ * The separator's dash is a design decision, not a browser default: 3px on,
+ * 4px off. `border-style: dashed` cannot express that, so the rule is painted
+ * as a repeating gradient and these tests pin the pattern down.
+ */
+describe("SectionHeader", () => {
+  const dashPattern = "transparent_3px,transparent_7px"
+
+  const section = () =>
+    screen.getByRole("heading", { level: 2 }).closest("div")?.parentElement
+      ?.parentElement
+
+  it("draws a top separator as a 3px-on/4px-off dashed rule", () => {
+    render(
+      <SectionHeader title="Personal" description="Details" separator="top" />
+    )
+
+    const className = section()?.className ?? ""
+    expect(className).toContain("repeating-linear-gradient")
+    expect(className).toContain(dashPattern)
+    expect(className).toContain("bg-left-top")
+  })
+
+  it("anchors a bottom separator to the bottom edge with the same dash", () => {
+    render(
+      <SectionHeader
+        title="Personal"
+        description="Details"
+        separator="bottom"
+      />
+    )
+
+    const className = section()?.className ?? ""
+    expect(className).toContain(dashPattern)
+    expect(className).toContain("bg-left-bottom")
+  })
+
+  it("paints no rule when no separator is asked for", () => {
+    render(<SectionHeader title="Personal" description="Details" />)
+
+    expect(section()?.className ?? "").not.toContain(
+      "repeating-linear-gradient"
+    )
+  })
+})

--- a/packages/react/src/patterns/SectionHeader/index.tsx
+++ b/packages/react/src/patterns/SectionHeader/index.tsx
@@ -29,6 +29,19 @@ type Props = {
   separator?: "top" | "bottom"
 }
 
+/**
+ * `border-style: dashed` leaves the dash length to the browser, which draws a
+ * 1px-on, 1px-off hairline. The rule is painted as a repeating gradient
+ * instead, so the dash is 3px on / 4px off, the same rhythm `Separator` uses.
+ *
+ * `bg-origin-border` puts the gradient's box at the border edge, so the rule
+ * lands exactly where the colored border used to, and the transparent 1px
+ * border stays on to reserve that space: a section with a separator and one
+ * without still line up.
+ */
+const dashedRule =
+  "bg-repeat-x bg-origin-border [background-image:repeating-linear-gradient(to_right,theme(colors.f1.border.DEFAULT)_0,theme(colors.f1.border.DEFAULT)_3px,transparent_3px,transparent_7px)] [background-size:7px_1px]"
+
 const _SectionHeader = ({
   title,
   description,
@@ -40,10 +53,10 @@ const _SectionHeader = ({
   return (
     <div
       className={cn(
-        "flex flex-col justify-between gap-4 border border-dashed border-transparent px-6 pb-5 pt-5 first:pb-0 first:pt-0 md:flex-row md:gap-2",
+        "flex flex-col justify-between gap-4 border border-transparent px-6 pb-5 pt-5 first:pb-0 first:pt-0 md:flex-row md:gap-2",
         layout === "standard" && "-mx-[23px]",
-        separator === "top" && "border-t-f1-border first:pt-5",
-        separator === "bottom" && "border-b-f1-border first:pb-5"
+        separator === "top" && cn(dashedRule, "bg-left-top first:pt-5"),
+        separator === "bottom" && cn(dashedRule, "bg-left-bottom first:pb-5")
       )}
     >
       <div className="flex grow flex-col gap-3">


### PR DESCRIPTION
## Description

`SectionHeader`'s separator was a `border-style: dashed` top border, which leaves the dash length up to the browser: Chrome draws a 1px-on, 1px-off hairline. The design system's dashed rule is **3px on, 4px off**, which CSS `border-style` cannot express at all.

The rule is now painted as a repeating gradient with that dash, matching the rhythm `ui/separator.tsx` already uses.

## Type of change

- [x] Bug fix

## Implementation details

`packages/react/src/patterns/SectionHeader/index.tsx`

- `separator="top"` / `separator="bottom"` no longer colour the border. They set a `repeating-linear-gradient` background sized `7px 1px` and repeated on X, anchored with `bg-left-top` / `bg-left-bottom`.
- `bg-origin-border` puts the gradient's positioning box at the border edge, so the rule lands on exactly the same pixel row the coloured border occupied. No layout shift.
- The transparent 1px border stays on, since it is what reserves the rule's space: a section with a separator and one without still line up. `border-dashed` is dropped from it, because with every side transparent it was drawing nothing and only misled the reader about where the rule comes from.
- The colour still resolves through the token, `theme(colors.f1.border.DEFAULT)`, so light/dark keep working.

Also adds `__tests__/SectionHeader.test.tsx`, which pins the dash pattern and the edge each separator anchors to. The component had no tests before.

## Verification

- `tsc --noEmit` clean.
- `oxlint` and `oxfmt` clean.
- Unit tests: 3 new pass; the 109 existing tests across `F0Form/components`, `SurveyFormBuilder` and `ResourceHeader` (the suites that render `SectionHeader`) still pass.
- Compiled the real file through this repo's Tailwind config to confirm every arbitrary class emits CSS. Worth noting: `theme(colors.f1.border)` silently emits nothing here, `.DEFAULT` is required.

## Screenshots

Not attached; the change is a 1px dash pattern that does not read at screenshot scale. The pattern is asserted in tests instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
