### PR TITLE
chore: release main

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "packages/react": "4.72.0",
+  "packages/react": "4.72.1",
   "packages/react-native": "0.59.0",
   "packages/core": "1.56.0"
 }

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [4.72.1](https://github.com/factorialco/f0/compare/f0-react-v4.72.0...f0-react-v4.72.1) (2026-07-31)
+
+
+### Bug Fixes
+
+* **icons:** remove non-scaling-stroke to fix thin strokes on Retina ([#4944](https://github.com/factorialco/f0/issues/4944)) ([96311fe](https://github.com/factorialco/f0/commit/96311fe86f9901d6feaa62a51b4f26c098e35f81))
+
 ## [4.72.0](https://github.com/factorialco/f0/compare/f0-react-v4.71.0...f0-react-v4.72.0) (2026-07-31)
 
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@factorialco/f0-react",
-  "version": "4.72.0",
+  "version": "4.72.1",
   "private": false,
   "files": [
     "assets",


### PR DESCRIPTION
🤖 F0 React package stable release 🚀
---


<details><summary>f0-react: 4.72.1</summary>

## [4.72.1](https://github.com/factorialco/f0/compare/f0-react-v4.72.0...f0-react-v4.72.1) (2026-07-31)


### Bug Fixes

* **icons:** remove non-scaling-stroke to fix thin strokes on Retina ([#4944](https://github.com/factorialco/f0/issues/4944)) ([96311fe](https://github.com/factorialco/f0/commit/96311fe86f9901d6feaa62a51b4f26c098e35f81))
</details>

---
This PR was generated with [Release Please](https://github.com/googleapis/release-please). See [documentation](https://github.com/googleapis/release-please#release-please).