### PR TITLE
feat(F0DataChart): bar labels by default and stacked bar polish

### DIFF
--- a/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
@@ -521,10 +521,17 @@ export const CategoryAxisBoundaries: Story = {
                 <span className="text-xs text-f1-foreground-secondary">
                   {label}
                 </span>
-                <div
-                  className={`${widthClass} h-[240px] rounded-md border border-solid border-f1-border-secondary bg-f1-background p-3`}
-                >
-                  <F0DataChart {...boundaryProps(orientation)} />
+                {/*
+                 * The sized box carries no border or padding of its own. The
+                 * chart measures its container, and `box-sizing: border-box`
+                 * means any inset would shift the effective width off the
+                 * boundary being demonstrated — a padded 220px box measures as
+                 * `sm`. The frame lives on the wrapper instead.
+                 */}
+                <div className="w-fit rounded-md border border-solid border-f1-border-secondary bg-f1-background">
+                  <div className={`${widthClass} h-[240px]`}>
+                    <F0DataChart {...boundaryProps(orientation)} />
+                  </div>
                 </div>
               </div>
             ))}

--- a/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
@@ -454,10 +454,10 @@ export const ResponsiveSnapshotMatrix: Story = {
 
 /**
  * Same matrix as `ResponsiveSnapshotMatrix` but rendered with
- * `orientation: "horizontal"`. The category axis lives on Y instead of X, and
- * unlike the vertical case it survives the medium breakpoint: each label names
- * the row beside it, so hiding them would leave a stack of anonymous bars.
- * Both axes are visible from `md` up; `sm` still drops all chrome.
+ * `orientation: "horizontal"`. The category axis lives on Y instead of X; as in
+ * the vertical case it survives the medium breakpoint, since the categories are
+ * the subjects being compared. Both axes are visible from `md` up; `sm` still
+ * drops all chrome.
  */
 const responsivePropsHorizontal = (
   column: "low" | "normal" | "large"
@@ -474,13 +474,13 @@ export const ResponsiveSnapshotMatrixHorizontal: Story = {
 // ---------------------------------------------------------------------------
 // Category-axis boundary widths
 //
-// Horizontal bars keep their category axis at `md`, where every other chart
-// family hides it (see `resolveResponsiveDisplay`). The deviation is deliberate
-// — a row label names the bar beside it — but it costs plot width: the labels
-// take `min(80, width * 0.2)`, so bars in a 220–519px container are up to 20%
-// shorter than they were. This story renders one pixel either side of both band
-// edges so Chromatic diffs that trade-off instead of leaving it to prose. The
-// vertical column is the control: it still gains its axis only at `lg`.
+// Bar charts keep their category axis at `md` in both orientations, where every
+// other chart family hides it (see `resolveResponsiveDisplay`). The deviation is
+// deliberate — the categories are the subjects being compared — but it costs
+// plot area: horizontal labels take `min(80, width * 0.2)` of the width,
+// vertical ones a row of height. This story renders one pixel either side of
+// both band edges so Chromatic diffs that trade-off instead of leaving it to
+// prose, and shows what the smart axis layout does with the space it gets.
 // ---------------------------------------------------------------------------
 
 const CATEGORY_AXIS_BOUNDARY_WIDTHS = [
@@ -501,9 +501,10 @@ const boundaryProps = (
 })
 
 /**
- * The exact widths at which the category axis appears, per orientation.
- * Horizontal gains it at 220px (`sm` → `md`); vertical not until 520px
- * (`md` → `lg`). Paired with the boundary assertions in `BarChart.test.tsx`.
+ * The exact widths at which the category axis appears. Both orientations gain
+ * it at 220px (`sm` → `md`) and keep it across 519/520px, so the only visible
+ * step is between the first two columns. Paired with the boundary assertions in
+ * `BarChart.test.tsx`.
  */
 export const CategoryAxisBoundaries: Story = {
   parameters: withSnapshot({}),

--- a/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
@@ -454,9 +454,10 @@ export const ResponsiveSnapshotMatrix: Story = {
 
 /**
  * Same matrix as `ResponsiveSnapshotMatrix` but rendered with
- * `orientation: "horizontal"`. The category axis lives on Y instead of X, so
- * at the medium breakpoint it's the Y axis (categories) that gets hidden and
- * the X axis (values) that stays visible — the inverse of the vertical case.
+ * `orientation: "horizontal"`. The category axis lives on Y instead of X, and
+ * unlike the vertical case it survives the medium breakpoint: each label names
+ * the row beside it, so hiding them would leave a stack of anonymous bars.
+ * Both axes are visible from `md` up; `sm` still drops all chrome.
  */
 const responsivePropsHorizontal = (
   column: "low" | "normal" | "large"

--- a/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Bar.stories.tsx
@@ -471,6 +471,70 @@ export const ResponsiveSnapshotMatrixHorizontal: Story = {
   render: () => <ResponsiveSnapshot getProps={responsivePropsHorizontal} />,
 }
 
+// ---------------------------------------------------------------------------
+// Category-axis boundary widths
+//
+// Horizontal bars keep their category axis at `md`, where every other chart
+// family hides it (see `resolveResponsiveDisplay`). The deviation is deliberate
+// — a row label names the bar beside it — but it costs plot width: the labels
+// take `min(80, width * 0.2)`, so bars in a 220–519px container are up to 20%
+// shorter than they were. This story renders one pixel either side of both band
+// edges so Chromatic diffs that trade-off instead of leaving it to prose. The
+// vertical column is the control: it still gains its axis only at `lg`.
+// ---------------------------------------------------------------------------
+
+const CATEGORY_AXIS_BOUNDARY_WIDTHS = [
+  { label: "219px — last sm", widthClass: "w-[219px]" },
+  { label: "220px — first md", widthClass: "w-[220px]" },
+  { label: "519px — last md", widthClass: "w-[519px]" },
+  { label: "520px — first lg", widthClass: "w-[520px]" },
+] as const
+
+const boundaryProps = (
+  orientation: "vertical" | "horizontal"
+): F0DataChartProps => ({
+  type: "bar",
+  orientation,
+  categories: ["Engineering", "Design", "Product", "Sales"],
+  series: [{ name: "Headcount", data: [145, 89, 67, 90] }],
+  showLegend: false,
+})
+
+/**
+ * The exact widths at which the category axis appears, per orientation.
+ * Horizontal gains it at 220px (`sm` → `md`); vertical not until 520px
+ * (`md` → `lg`). Paired with the boundary assertions in `BarChart.test.tsx`.
+ */
+export const CategoryAxisBoundaries: Story = {
+  parameters: withSnapshot({}),
+  decorators: [(Story) => <Story />],
+  render: () => (
+    <div className="flex w-fit flex-col gap-8 p-6">
+      {(["horizontal", "vertical"] as const).map((orientation) => (
+        <div key={orientation} className="flex flex-col gap-3">
+          <span className="text-xs font-medium uppercase tracking-wide text-f1-foreground-secondary">
+            {orientation}
+          </span>
+          <div className="flex flex-row items-start gap-4">
+            {CATEGORY_AXIS_BOUNDARY_WIDTHS.map(({ label, widthClass }) => (
+              <div key={label} className="flex flex-col gap-2">
+                <span className="text-xs text-f1-foreground-secondary">
+                  {label}
+                </span>
+                <div
+                  className={`${widthClass} h-[240px] rounded-md border border-solid border-f1-border-secondary bg-f1-background p-3`}
+                >
+                  <F0DataChart {...boundaryProps(orientation)} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+}
+
 /**
  * Many series with long names — the legend paginates with arrow controls
  * while the chart area stays the same size.

--- a/packages/react/src/kits/F0DataChart/__stories__/F0DataChart.mdx
+++ b/packages/react/src/kits/F0DataChart/__stories__/F0DataChart.mdx
@@ -118,7 +118,7 @@ Bar labels use `valueFormatter`, with configurable size and collision handling:
 
 ### Precise tooltip values
 
-Use `tooltipValueFormatter` when the axis and labels should stay compact while the hover tooltip retains the precise value.
+Tooltips use `valueFormatter` like the rest of the chart. Add `tooltipValueFormatter` when the axis and labels must stay compact but the tooltip should carry the exact figure. The Customization section below covers how the two divide the work.
 
 <Canvas of={BarStories.PreciseTooltip} />
 
@@ -319,16 +319,23 @@ import {
 
 ### Value & Category Formatters
 
-All chart types support `valueFormatter` to customize how numbers are displayed in axes, labels, and tooltips. Bar and line charts also support `categoryFormatter` for axis labels.
+Every chart type takes `valueFormatter` for its numbers — axis ticks, labels, and the hover tooltip. One formatter is all most charts need: the tooltip reads the value the way the rest of the chart does, so a unit or a currency can't go missing on hover. Bar and line charts also support `categoryFormatter` for axis labels.
+
+`tooltipValueFormatter` overrides it for the tooltip alone. Reach for it when the axis has to stay compact but the tooltip should be exact:
 
 ```tsx
 <F0DataChart
-  type="bar"
-  valueFormatter={(v) => `${v / 1_000_000}M €`}
+  type="line"
+  valueFormatter={(v) => `€${(v / 1_000_000).toFixed(1)}M`} // axis: "€4.0M"
+  tooltipValueFormatter={(v) => `€${v.toLocaleString()}`} // tooltip: "€4,000,000"
   categoryFormatter={(v) => v.slice(0, 3)}
   // ...
 />
 ```
+
+With neither, values render as a plain localized number.
+
+<Canvas of={LineStories.CustomFormatters} />
 
 ### ECharts Escape Hatch
 

--- a/packages/react/src/kits/F0DataChart/__stories__/Line.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Line.stories.tsx
@@ -165,7 +165,15 @@ export const WithDots: Story = {
 // Formatting & minimal variants
 // ---------------------------------------------------------------------------
 
-/** Custom value + category formatters for currency / abbreviated month names. */
+/**
+ * Custom value + category formatters for currency / abbreviated month names.
+ *
+ * `valueFormatter` writes the axis, where space is tight, so it compacts
+ * millions to `4M €` — and the tooltip would read the same way, since a tooltip
+ * uses that formatter unless told otherwise. Here it is told otherwise: hover a
+ * point and it reads `4,000,000 €`, from `tooltipValueFormatter`, because the
+ * card has room for the exact figure.
+ */
 export const CustomFormatters: Story = {
   render: (args) => <F0DataChart {...args} />,
   args: {
@@ -186,6 +194,7 @@ export const CustomFormatters: Story = {
       },
     ],
     valueFormatter: (v) => `${v / 1_000_000}M €`,
+    tooltipValueFormatter: (v) => `${v.toLocaleString("en-US")} €`,
     categoryFormatter: (v) => v.slice(0, 3),
   },
 }

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -170,14 +170,15 @@ describe("BarChart — responsive breakpoints", () => {
     expect(option.yAxis.axisLabel.show).toBe(false)
   })
 
-  it("shows legend and the value axis but hides the category axis at the medium breakpoint", () => {
+  it("shows legend and both axes at the medium breakpoint", () => {
     containerSize.width = 320
     render(<F0DataChart {...verticalProps} />)
 
     const option = getLatestOption()
     expect(option.legend?.show).toBe(true)
-    // X = category (hidden at md), Y = value (shown at md)
-    expect(option.xAxis.axisLabel.show).toBe(false)
+    // Bars keep their categories wherever they keep any chrome — X = category,
+    // Y = value. Crowding is handled by the smart axis layout, not by hiding.
+    expect(option.xAxis.axisLabel.show).toBe(true)
     expect(option.yAxis.axisLabel.show).toBe(true)
   })
 
@@ -197,9 +198,9 @@ describe("BarChart — responsive breakpoints", () => {
 
     const option = getLatestOption()
     expect(option.legend?.show).toBe(true)
-    // Horizontal bars: X = value axis, Y = category axis. Each category label
-    // names the row beside it, so dropping them at md would leave a stack of
-    // anonymous bars — unlike vertical bars, where they crowd each other.
+    // Horizontal bars: X = value axis, Y = category axis. Both orientations
+    // keep their categories at md; dropping them would leave a stack of
+    // anonymous bars the value axis can't explain.
     expect(option.xAxis.axisLabel.show).toBe(true)
     expect(option.yAxis.axisLabel.show).toBe(true)
   })
@@ -214,14 +215,14 @@ describe("BarChart — responsive breakpoints", () => {
     expect(option.yAxis.axisLabel.show).toBe(false)
   })
 
-  it("keeps hiding the category axis on vertical bars at the medium breakpoint", () => {
-    containerSize.width = 320
+  it("still hides the category axis on vertical bars at the small breakpoint", () => {
+    containerSize.width = 180
     render(<F0DataChart {...verticalProps} />)
 
     const option = getLatestOption()
-    // X = category. The md exception is horizontal-only.
+    // `sm` is the only size that drops the categories, in either orientation.
     expect(option.xAxis.axisLabel.show).toBe(false)
-    expect(option.yAxis.axisLabel.show).toBe(true)
+    expect(option.yAxis.axisLabel.show).toBe(false)
   })
 
   it("inverts the category axis on horizontal bars so rows read top-to-bottom in data order", () => {
@@ -242,13 +243,13 @@ describe("BarChart — responsive breakpoints", () => {
 })
 
 // ---------------------------------------------------------------------------
-// Horizontal bars deviate from the shared matrix: they keep the category axis
+// Bars deviate from the shared matrix: both orientations keep the category axis
 // at `md`, where every other chart family hides it (see
-// `resolveResponsiveDisplay`). That deviation costs plot width — the category
-// labels take `min(80, width * 0.2)` — so these pin the exact width the
-// behavior changes at, one pixel either side of both band edges. A breakpoint
-// tweak that moves the flip has to fail here rather than quietly reflow every
-// horizontal chart in a chat card.
+// `resolveResponsiveDisplay`). That deviation costs plot area — horizontal
+// labels take `min(80, width * 0.2)` of the width, vertical ones a row of
+// height — so these pin the exact width the behavior changes at, one pixel
+// either side of both band edges. A breakpoint tweak that moves the flip has to
+// fail here rather than quietly reflow every bar chart in a chat card.
 // ---------------------------------------------------------------------------
 
 describe("BarChart — category axis at the breakpoint boundaries", () => {
@@ -271,29 +272,21 @@ describe("BarChart — category axis at the breakpoint boundaries", () => {
       : option.yAxis.axisLabel.show
   }
 
-  it("hides the horizontal category axis at the last sm width (219px)", () => {
-    expect(categoryAxisShownAt(SM_MAX_WIDTH - 1, "horizontal")).toBe(false)
-  })
+  for (const orientation of ["horizontal", "vertical"] as const) {
+    it(`hides the ${orientation} category axis at the last sm width (219px)`, () => {
+      expect(categoryAxisShownAt(SM_MAX_WIDTH - 1, orientation)).toBe(false)
+    })
 
-  it("shows the horizontal category axis from the first md width (220px)", () => {
-    expect(categoryAxisShownAt(SM_MAX_WIDTH, "horizontal")).toBe(true)
-  })
+    it(`shows the ${orientation} category axis from the first md width (220px)`, () => {
+      expect(categoryAxisShownAt(SM_MAX_WIDTH, orientation)).toBe(true)
+    })
 
-  it("keeps the horizontal category axis across the md → lg edge (519/520px)", () => {
-    // Already visible at md, so crossing into lg must not toggle anything.
-    expect(categoryAxisShownAt(MD_MAX_WIDTH - 1, "horizontal")).toBe(true)
-    expect(categoryAxisShownAt(MD_MAX_WIDTH, "horizontal")).toBe(true)
-  })
-
-  it("keeps the vertical category axis hidden across the whole md band", () => {
-    // The deviation is horizontal-only: vertical still flips at lg alone.
-    expect(categoryAxisShownAt(SM_MAX_WIDTH, "vertical")).toBe(false)
-    expect(categoryAxisShownAt(MD_MAX_WIDTH - 1, "vertical")).toBe(false)
-  })
-
-  it("shows the vertical category axis from the first lg width (520px)", () => {
-    expect(categoryAxisShownAt(MD_MAX_WIDTH, "vertical")).toBe(true)
-  })
+    it(`keeps the ${orientation} category axis across the md → lg edge (519/520px)`, () => {
+      // Already visible at md, so crossing into lg must not toggle anything.
+      expect(categoryAxisShownAt(MD_MAX_WIDTH - 1, orientation)).toBe(true)
+      expect(categoryAxisShownAt(MD_MAX_WIDTH, orientation)).toBe(true)
+    })
+  }
 })
 
 describe("BarChart — corner rounding", () => {

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -951,11 +951,11 @@ describe("BarChart — hideOverflowingLabels", () => {
 })
 
 // ---------------------------------------------------------------------------
-// tooltipValueFormatter — the tooltip can show precise values while the
-// axis/labels stay compact.
+// Item tooltip — bar charts describe the hovered bar/segment: precise value,
+// change vs. the previous category, and (multi-series) share of the total.
 // ---------------------------------------------------------------------------
 
-describe("BarChart — tooltipValueFormatter", () => {
+describe("BarChart — item tooltip", () => {
   function getTooltipFormatter() {
     const call = setOptionMock.mock.calls.at(-1)
     if (!call) throw new Error("setOption was never called")
@@ -973,31 +973,42 @@ describe("BarChart — tooltipValueFormatter", () => {
         tooltipValueFormatter={(v) => v.toLocaleString("en-US")}
       />
     )
-    const html = getTooltipFormatter()?.([
-      { axisValueLabel: "A", seriesName: "S", value: 107505, marker: "" },
-    ])
+    const html = getTooltipFormatter()?.({
+      name: "A",
+      seriesName: "S",
+      value: 107505,
+      dataIndex: 0,
+    })
     expect(html).toContain("107,505") // precise, grouped
     expect(html).not.toContain("K") // not the compact form
     expect(getLatestOption().aria?.enabled).toBe(true)
     expect(getLatestOption().aria?.label?.description).toContain("107,505")
   })
 
-  it("falls back to valueFormatter when no tooltipValueFormatter is given", () => {
+  // The tooltip reads the number the way the axis does, so a unit written by
+  // `valueFormatter` (a currency, a "%") is not silently dropped on hover.
+  it("falls back to the axis formatter when no tooltipValueFormatter is given", () => {
     render(
       <F0DataChart
         type="bar"
         categories={["A"]}
-        series={[{ name: "S", data: [107505] }]}
-        valueFormatter={(v) => `${Math.round(v / 1000)}K`}
+        series={[{ name: "S", data: [107505.8632] }]}
+        valueFormatter={(v) =>
+          `€${v.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+        }
       />
     )
-    const html = getTooltipFormatter()?.([
-      { axisValueLabel: "A", seriesName: "S", value: 107505, marker: "" },
-    ])
-    expect(html).toContain("108K")
+    const html = getTooltipFormatter()?.({
+      name: "A",
+      seriesName: "S",
+      value: 107505.8632,
+      dataIndex: 0,
+    })
+    expect(html).toContain("€107,505.86")
+    expect(html).not.toContain("107505.8632") // no raw float precision
   })
 
-  it("formats and escapes actual and target values in target tooltips", () => {
+  it("formats and escapes values in target tooltips, and hides ghost series", () => {
     render(
       <F0DataChart
         type="bar"
@@ -1014,50 +1025,209 @@ describe("BarChart — tooltipValueFormatter", () => {
       />
     )
 
-    const html = getTooltipFormatter()?.([
-      {
-        axisValueLabel: "<script>category</script>",
-        seriesName: "<strong>Revenue</strong>",
-        value: 107505,
-        dataIndex: 0,
-        marker: '<span class="trusted-marker"></span>',
-      },
-    ])
+    const formatter = getTooltipFormatter()
+    const html = formatter?.({
+      name: "<script>category</script>",
+      seriesName: "<strong>Revenue</strong>",
+      value: 107505,
+      dataIndex: 0,
+      marker: '<span class="trusted-marker"></span>',
+    })
 
+    // ECharts' own coloured dot is trusted HTML and survives unescaped.
     expect(html).toContain('<span class="trusted-marker"></span>')
     expect(html).toContain("&lt;script&gt;category&lt;/script&gt;")
     expect(html).toContain("&lt;strong&gt;Revenue&lt;/strong&gt;")
     expect(html).toContain("&lt;em&gt;107,505&lt;/em&gt;")
-    expect(html).toContain("&lt;em&gt;125,000&lt;/em&gt;")
+    expect(html).toContain("&lt;em&gt;125,000&lt;/em&gt;") // target row
     expect(html).not.toContain("<script>")
+    // Hovering the ghost gradient bar renders no tooltip.
+    expect(
+      formatter?.({
+        seriesName: "<strong>Revenue</strong> (target)",
+        value: 17495,
+        dataIndex: 0,
+      })
+    ).toBe("")
   })
 
-  it("escapes the ordinary tooltip while preserving ECharts marker HTML", () => {
+  it("shows share of total only for multi-series charts", () => {
     render(
       <F0DataChart
         type="bar"
-        categories={["<script>category</script>"]}
-        series={[{ name: "<strong>Revenue</strong>", data: [107505] }]}
-        tooltipValueFormatter={(value) =>
-          `<em>${value.toLocaleString("en-US")}</em>`
-        }
+        categories={["A", "B"]}
+        series={[
+          { name: "S1", data: [30, 10] },
+          { name: "S2", data: [70, 90] },
+        ]}
       />
     )
+    const html = getTooltipFormatter()?.({
+      name: "A",
+      seriesName: "S1",
+      value: 30,
+      dataIndex: 0,
+    })
+    expect(html).toContain("30.0%")
+    expect(html).toContain("of total")
+    expect(html).toContain((100).toLocaleString())
+  })
 
-    const html = getTooltipFormatter()?.([
-      {
-        axisValueLabel: "<script>category</script>",
-        seriesName: "<strong>Revenue</strong>",
-        value: 107505,
-        marker: '<span class="trusted-marker"></span>',
-      },
-    ])
+  it("hides share of total for single-series charts", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        categories={["A"]}
+        series={[{ name: "S", data: [100] }]}
+      />
+    )
+    const html = getTooltipFormatter()?.({
+      name: "A",
+      seriesName: "S",
+      value: 100,
+      dataIndex: 0,
+    })
+    expect(html).not.toContain("of total")
+    expect(html).not.toContain("total<")
+  })
 
-    expect(html).toContain('<span class="trusted-marker"></span>')
-    expect(html).toContain("&lt;script&gt;category&lt;/script&gt;")
-    expect(html).toContain("&lt;strong&gt;Revenue&lt;/strong&gt;")
-    expect(html).toContain("&lt;em&gt;107,505&lt;/em&gt;")
-    expect(html).not.toContain("<script>")
+  // A stacked chart mixing gains with losses has no total its parts add up
+  // to: the net sum is smaller than the segments it is made of, so a share of
+  // it can exceed 100% (or blow up entirely near cancellation).
+  it("omits share and total when the category mixes positive and negative values", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        stacked
+        categories={["Q1", "Q2"]}
+        series={[
+          { name: "Hires", data: [24, 18] },
+          { name: "Internal moves", data: [6, 4] },
+          { name: "Voluntary exits", data: [-8, -12] },
+          { name: "Involuntary exits", data: [-3, -2] },
+        ]}
+      />
+    )
+    const html = getTooltipFormatter()?.({
+      name: "Q1",
+      seriesName: "Hires",
+      value: 24,
+      dataIndex: 0,
+    })
+    // 24 / (24 + 6 - 8 - 3) would have read 126.3%, and the misleading net
+    // total goes with it — both rows carry the word "total".
+    expect(html).toContain((24).toLocaleString())
+    expect(html).not.toContain("total")
+    expect(html).not.toContain("126.3%")
+    expect(html).not.toContain((19).toLocaleString())
+  })
+
+  it("omits share and total when positive and negative series cancel out", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        stacked
+        categories={["Q1"]}
+        series={[
+          { name: "Hires", data: [1000] },
+          { name: "Exits", data: [-999.9] },
+        ]}
+      />
+    )
+    const html = getTooltipFormatter()?.({
+      name: "Q1",
+      seriesName: "Hires",
+      value: 1000,
+      dataIndex: 0,
+    })
+    // A net of 0.1 would have turned 1000 into 1,000,000% of total.
+    expect(html).not.toContain("total")
+    expect(html).not.toContain("%</strong>")
+  })
+
+  it("keeps share and total when every series is negative", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        stacked
+        categories={["Q1"]}
+        series={[
+          { name: "Voluntary exits", data: [-8] },
+          { name: "Involuntary exits", data: [-2] },
+        ]}
+      />
+    )
+    const html = getTooltipFormatter()?.({
+      name: "Q1",
+      seriesName: "Voluntary exits",
+      value: -8,
+      dataIndex: 0,
+    })
+    // Both sides share a sign, so the ratio still reads as a positive share.
+    expect(html).toContain("80.0%")
+    expect(html).toContain("of total")
+    expect(html).toContain((-10).toLocaleString())
+  })
+
+  it("treats a series that runs short of the categories as zero there", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        stacked
+        categories={["A", "B"]}
+        series={[
+          { name: "S1", data: [30, 40] },
+          { name: "S2", data: [70] }, // no value for "B"
+        ]}
+      />
+    )
+    const html = getTooltipFormatter()?.({
+      name: "B",
+      seriesName: "S1",
+      value: 40,
+      dataIndex: 1,
+    })
+    expect(html).toContain("100.0%")
+    expect(html).not.toContain("NaN")
+  })
+
+  it("omits the share but keeps the total when every value is zero", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        stacked
+        categories={["Q1"]}
+        series={[
+          { name: "Hires", data: [0] },
+          { name: "Exits", data: [0] },
+        ]}
+      />
+    )
+    const html = getTooltipFormatter()?.({
+      name: "Q1",
+      seriesName: "Hires",
+      value: 0,
+      dataIndex: 0,
+    })
+    // No division by zero, and "0 total" is still true.
+    expect(html).not.toContain("of total")
+    expect(html).not.toContain("Infinity")
+    expect(html).not.toContain("NaN")
+    expect(html).toContain("total")
+  })
+
+  it("never compares a bar with the previous category — that is a line-chart concept", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        categories={["A", "B"]}
+        series={[{ name: "S", data: [100, 125] }]}
+      />
+    )
+    const formatter = getTooltipFormatter()
+    expect(
+      formatter?.({ name: "B", seriesName: "S", value: 125, dataIndex: 1 })
+    ).not.toContain("from previous")
   })
 
   it("bounds the accessible description for large datasets", () => {
@@ -1082,6 +1252,23 @@ describe("BarChart — tooltipValueFormatter", () => {
     expect(description).toContain("Category 20: 20")
     expect(description).toContain("5 more values")
     expect(description).not.toContain("Category 21")
+  })
+
+  it("lets a caller's own echartsOptions.tooltip win over the built-in one", () => {
+    const ownFormatter = () => "custom tooltip"
+    render(
+      <F0DataChart
+        type="bar"
+        categories={["A"]}
+        series={[{ name: "S", data: [1] }]}
+        echartsOptions={{
+          tooltip: { trigger: "axis", formatter: ownFormatter },
+        }}
+      />
+    )
+
+    const tooltip = getTooltipFormatter()
+    expect(tooltip).toBe(ownFormatter)
   })
 })
 

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -1,5 +1,6 @@
 import {
   afterAll,
+  afterEach,
   beforeAll,
   beforeEach,
   describe,
@@ -123,6 +124,19 @@ function getAnimationOptions() {
     stateAnimation?: { duration?: number; easing?: string }
   }
 }
+
+/** Drive `useReducedMotion()` — the setup default has no query matching. */
+const setReducedMotion = (matches: boolean) =>
+  vi.stubGlobal("matchMedia", (query: string) => ({
+    matches: matches && query.includes("prefers-reduced-motion"),
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }))
 
 /** Corner radii of every bar in a series, `undefined` for plain-number data */
 function getBorderRadii(seriesIndex: number) {
@@ -597,6 +611,43 @@ describe("BarChart — stacked segment polish", () => {
 
     const options = getAnimationOptions()
     expect(options.stateAnimation).toBeUndefined()
+  })
+
+  describe("reduced motion", () => {
+    afterEach(() => {
+      // Restore the setup default (motion allowed) for the rest of the suite.
+      setReducedMotion(false)
+    })
+
+    it("drops the cross-fade to zero duration", () => {
+      setReducedMotion(true)
+      render(<F0DataChart {...base} stacked />)
+
+      // The highlight itself stays — hovering still isolates the series, it
+      // just arrives instantly instead of fading.
+      expect(getAnimationOptions().stateAnimation?.duration).toBe(0)
+      expect(getMainSeries()[0]?.emphasis?.focus).toBe("series")
+      expect(getMainSeries()[0]?.blur?.itemStyle?.opacity).toBe(0.4)
+    })
+
+    it("overrides a consumer-provided cross-fade duration", () => {
+      setReducedMotion(true)
+      render(
+        <F0DataChart
+          {...base}
+          stacked
+          echartsOptions={{
+            stateAnimation: { duration: 120, easing: "linear" },
+          }}
+        />
+      )
+
+      // The preference is the user's, so it wins over the consumer's duration.
+      expect(getAnimationOptions().stateAnimation).toEqual({
+        duration: 0,
+        easing: "linear",
+      })
+    })
   })
 })
 

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -176,15 +176,37 @@ describe("BarChart — responsive breakpoints", () => {
     expect(option.yAxis.axisLabel.show).toBe(true)
   })
 
-  it("respects orientation: in horizontal bars the category axis lives on Y", () => {
-    containerSize.width = 320 // medium breakpoint → category axis hidden
+  it("keeps the category axis on horizontal bars at the medium breakpoint", () => {
+    containerSize.width = 320
     render(<F0DataChart {...verticalProps} orientation="horizontal" />)
 
     const option = getLatestOption()
     expect(option.legend?.show).toBe(true)
-    // Horizontal bars: X = value axis (shown at md), Y = category axis (hidden at md)
+    // Horizontal bars: X = value axis, Y = category axis. Each category label
+    // names the row beside it, so dropping them at md would leave a stack of
+    // anonymous bars — unlike vertical bars, where they crowd each other.
     expect(option.xAxis.axisLabel.show).toBe(true)
+    expect(option.yAxis.axisLabel.show).toBe(true)
+  })
+
+  it("still hides the category axis on horizontal bars at the small breakpoint", () => {
+    containerSize.width = 180
+    render(<F0DataChart {...verticalProps} orientation="horizontal" />)
+
+    const option = getLatestOption()
+    expect(option.legend).toBeUndefined()
+    expect(option.xAxis.axisLabel.show).toBe(false)
     expect(option.yAxis.axisLabel.show).toBe(false)
+  })
+
+  it("keeps hiding the category axis on vertical bars at the medium breakpoint", () => {
+    containerSize.width = 320
+    render(<F0DataChart {...verticalProps} />)
+
+    const option = getLatestOption()
+    // X = category. The md exception is horizontal-only.
+    expect(option.xAxis.axisLabel.show).toBe(false)
+    expect(option.yAxis.axisLabel.show).toBe(true)
   })
 
   it("inverts the category axis on horizontal bars so rows read top-to-bottom in data order", () => {

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -11,6 +11,7 @@ import "@testing-library/jest-dom/vitest"
 import { zeroRender as render } from "@/testing/test-utils"
 
 import { F0DataChart } from "../F0DataChart"
+import { resolveChartTheme } from "../utils/theme"
 
 // ---------------------------------------------------------------------------
 // Same ECharts mock + container size mock as LineChart.test.tsx so the two
@@ -96,11 +97,31 @@ function getMainSeries() {
           fontSize?: number
           formatter?: (params: { value: number }) => string
         }
-        emphasis?: { label?: { color?: string; show?: boolean } }
+        itemStyle?: { borderColor?: string; borderWidth?: number }
+        emphasis?: {
+          label?: { color?: string; show?: boolean }
+          focus?: string
+        }
+        blur?: {
+          itemStyle?: { opacity?: number }
+          label?: { opacity?: number }
+        }
         labelLayout?: (p: LabelLayoutParams) => { fontSize?: number }
       }[]
     }
   ).series
+}
+
+/** Root-level animation keys that drive the hover blur cross-fade */
+function getAnimationOptions() {
+  const call = setOptionMock.mock.calls.at(-1)
+  if (!call) throw new Error("setOption was never called")
+  return call[0] as {
+    animation?: boolean
+    animationDuration?: number
+    animationDurationUpdate?: number
+    stateAnimation?: { duration?: number; easing?: string }
+  }
 }
 
 /** Corner radii of every bar in a series, `undefined` for plain-number data */
@@ -427,6 +448,118 @@ describe("BarChart — label placement", () => {
     expect(mainSeries?.label?.color).toBe("#ffffff")
     expect(mainSeries?.emphasis?.label?.color).toBe("#ffffff")
     expect(mainSeries?.data?.[1]?.label).toBeUndefined()
+  })
+})
+
+describe("BarChart — stacked segment polish", () => {
+  const base = {
+    type: "bar" as const,
+    categories: ["A", "B"],
+    series: [
+      { name: "X", data: [1, 2] },
+      { name: "Y", data: [3, 4] },
+    ],
+  }
+
+  /** The chart resolves its own light-mode theme in jsdom (no `.dark` ancestor). */
+  const themeBackground = resolveChartTheme(null).colors.background
+
+  it("separates stacked segments with a hairline in the theme background", () => {
+    render(<F0DataChart {...base} stacked />)
+
+    const itemStyle = getMainSeries()[0]?.itemStyle
+    expect(itemStyle?.borderColor).toBe(themeBackground)
+    // Both neighbours stroke the shared edge and the strokes overlap, so 0.5
+    // renders as a ~0.5px separation rather than 1px.
+    expect(itemStyle?.borderWidth).toBe(0.5)
+  })
+
+  it("leaves non-stacked bars without a separator border", () => {
+    render(<F0DataChart {...base} />)
+
+    const itemStyle = getMainSeries()[0]?.itemStyle
+    expect(itemStyle?.borderColor).toBeUndefined()
+    expect(itemStyle?.borderWidth).toBeUndefined()
+  })
+
+  it("isolates the hovered series and fades the rest to 40%", () => {
+    render(<F0DataChart {...base} stacked />)
+
+    const series = getMainSeries()
+    for (const entry of series) {
+      expect(entry?.emphasis?.focus).toBe("series")
+      expect(entry?.blur?.itemStyle?.opacity).toBe(0.4)
+      expect(entry?.blur?.label?.opacity).toBe(0.4)
+    }
+  })
+
+  it("does not blur or focus when the bars are not stacked", () => {
+    render(<F0DataChart {...base} />)
+
+    const mainSeries = getMainSeries()[0]
+    expect(mainSeries?.emphasis?.focus).toBeUndefined()
+    expect(mainSeries?.blur).toBeUndefined()
+  })
+
+  it("fades the target ghost with its stack instead of the echarts default", () => {
+    render(
+      <F0DataChart
+        {...base}
+        stacked
+        series={[{ name: "X", data: [{ value: 1, target: 5 }] }]}
+        categories={["A"]}
+      />
+    )
+
+    // [main, target] — the ghost is a separate series, so `focus: "series"`
+    // blurs it too; it must dim to the same 40%.
+    const target = getMainSeries()[1]
+    expect(target?.blur?.itemStyle?.opacity).toBe(0.4)
+  })
+
+  it("runs the blur cross-fade without animating entrance or updates", () => {
+    render(<F0DataChart {...base} stacked />)
+
+    const options = getAnimationOptions()
+    // The engine must be on for state transitions, but entrance and update
+    // animations stay at zero so only the blur fade is visible.
+    expect(options.animation).toBe(true)
+    expect(options.animationDuration).toBe(0)
+    expect(options.animationDurationUpdate).toBe(0)
+    expect(options.stateAnimation).toEqual({
+      duration: 500,
+      easing: "cubicOut",
+    })
+  })
+
+  it("defers to consumer-provided animation options", () => {
+    render(
+      <F0DataChart
+        {...base}
+        stacked
+        echartsOptions={{
+          animationDuration: 900,
+          stateAnimation: { duration: 120, easing: "linear" },
+        }}
+      />
+    )
+
+    const options = getAnimationOptions()
+    expect(options.animationDuration).toBe(900)
+    expect(options.stateAnimation).toEqual({
+      duration: 120,
+      easing: "linear",
+    })
+    // Untouched keys still get their stacked defaults.
+    expect(options.animation).toBe(true)
+    expect(options.animationDurationUpdate).toBe(0)
+  })
+
+  it("leaves non-stacked charts' animation options alone", () => {
+    render(<F0DataChart {...base} />)
+
+    const options = getAnimationOptions()
+    expect(options.stateAnimation).toBeUndefined()
   })
 })
 

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -12,6 +12,7 @@ import "@testing-library/jest-dom/vitest"
 import { zeroRender as render } from "@/testing/test-utils"
 
 import { F0DataChart } from "../F0DataChart"
+import { MD_MAX_WIDTH, SM_MAX_WIDTH } from "../utils/responsive"
 import { resolveChartTheme } from "../utils/theme"
 
 // ---------------------------------------------------------------------------
@@ -237,6 +238,61 @@ describe("BarChart — responsive breakpoints", () => {
     const option = getLatestOption()
     expect(option.xAxis.inverse).toBeUndefined()
     expect(option.yAxis.inverse).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Horizontal bars deviate from the shared matrix: they keep the category axis
+// at `md`, where every other chart family hides it (see
+// `resolveResponsiveDisplay`). That deviation costs plot width — the category
+// labels take `min(80, width * 0.2)` — so these pin the exact width the
+// behavior changes at, one pixel either side of both band edges. A breakpoint
+// tweak that moves the flip has to fail here rather than quietly reflow every
+// horizontal chart in a chat card.
+// ---------------------------------------------------------------------------
+
+describe("BarChart — category axis at the breakpoint boundaries", () => {
+  const props = {
+    type: "bar" as const,
+    categories: ["Jan", "Feb", "Mar"],
+    series: [{ name: "A", data: [1, 2, 3] }],
+  }
+
+  /** Category-axis visibility at `width`. Horizontal keeps categories on Y. */
+  function categoryAxisShownAt(
+    width: number,
+    orientation: "vertical" | "horizontal"
+  ) {
+    containerSize.width = width
+    render(<F0DataChart {...props} orientation={orientation} />)
+    const option = getLatestOption()
+    return orientation === "vertical"
+      ? option.xAxis.axisLabel.show
+      : option.yAxis.axisLabel.show
+  }
+
+  it("hides the horizontal category axis at the last sm width (219px)", () => {
+    expect(categoryAxisShownAt(SM_MAX_WIDTH - 1, "horizontal")).toBe(false)
+  })
+
+  it("shows the horizontal category axis from the first md width (220px)", () => {
+    expect(categoryAxisShownAt(SM_MAX_WIDTH, "horizontal")).toBe(true)
+  })
+
+  it("keeps the horizontal category axis across the md → lg edge (519/520px)", () => {
+    // Already visible at md, so crossing into lg must not toggle anything.
+    expect(categoryAxisShownAt(MD_MAX_WIDTH - 1, "horizontal")).toBe(true)
+    expect(categoryAxisShownAt(MD_MAX_WIDTH, "horizontal")).toBe(true)
+  })
+
+  it("keeps the vertical category axis hidden across the whole md band", () => {
+    // The deviation is horizontal-only: vertical still flips at lg alone.
+    expect(categoryAxisShownAt(SM_MAX_WIDTH, "vertical")).toBe(false)
+    expect(categoryAxisShownAt(MD_MAX_WIDTH - 1, "vertical")).toBe(false)
+  })
+
+  it("shows the vertical category axis from the first lg width (520px)", () => {
+    expect(categoryAxisShownAt(MD_MAX_WIDTH, "vertical")).toBe(true)
   })
 })
 

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -404,7 +404,7 @@ describe("BarChart — label placement", () => {
     expect(getMainSeries()[0]?.label?.fontSize).toBe(11)
   })
 
-  it("chooses contrast-safe label colours for per-bar fills", () => {
+  it("keeps inside labels white on every fill, including light ones", () => {
     render(
       <F0DataChart
         {...base}
@@ -421,11 +421,12 @@ describe("BarChart — label placement", () => {
       />
     )
 
-    const data = getMainSeries()[0]?.data
-    expect(data?.[0]?.label?.color).toBe("#ffffff")
-    expect(data?.[1]?.label?.color).toBe("#000000")
-    expect(data?.[0]?.emphasis?.label?.color).toBe("#ffffff")
-    expect(data?.[1]?.emphasis?.label?.color).toBe("#000000")
+    const mainSeries = getMainSeries()[0]
+    // A per-bar colour override no longer carries its own label colour: the
+    // series-level white applies to dark indigo and light yellow alike.
+    expect(mainSeries?.label?.color).toBe("#ffffff")
+    expect(mainSeries?.emphasis?.label?.color).toBe("#ffffff")
+    expect(mainSeries?.data?.[1]?.label).toBeUndefined()
   })
 })
 

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -461,7 +461,10 @@ describe("BarChart — stacked segment polish", () => {
     ],
   }
 
-  /** The chart resolves its own light-mode theme in jsdom (no `.dark` ancestor). */
+  /**
+   * Nothing in the jsdom tree paints a background, so the container lookup
+   * falls back to the light-mode page token.
+   */
   const themeBackground = resolveChartTheme(null).colors.background
 
   it("separates stacked segments with a hairline in the theme background", () => {
@@ -469,9 +472,21 @@ describe("BarChart — stacked segment polish", () => {
 
     const itemStyle = getMainSeries()[0]?.itemStyle
     expect(itemStyle?.borderColor).toBe(themeBackground)
-    // Both neighbours stroke the shared edge and the strokes overlap, so 0.5
-    // renders as a ~0.5px separation rather than 1px.
+    // Both neighbours stroke the shared edge and canvas strokes are centered on
+    // it, so the two cover the same band rather than adding up: 0.5 reads as a
+    // hairline, not a 1px gap.
     expect(itemStyle?.borderWidth).toBe(0.5)
+  })
+
+  it("paints the separator in the nearest surface colour, not the page colour", () => {
+    render(
+      <div style={{ backgroundColor: "rgb(1, 2, 3)" }}>
+        <F0DataChart {...base} stacked />
+      </div>
+    )
+
+    // A chart on a tinted card / modal must blend into that surface.
+    expect(getMainSeries()[0]?.itemStyle?.borderColor).toBe("rgb(1, 2, 3)")
   })
 
   it("leaves non-stacked bars without a separator border", () => {

--- a/packages/react/src/kits/F0DataChart/__tests__/FunnelChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/FunnelChart.test.tsx
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import "@testing-library/jest-dom/vitest"
+import { zeroRender as render } from "@/testing/test-utils"
+
+import { F0DataChart } from "../F0DataChart"
+
+const setOptionMock = vi.fn()
+
+vi.mock("echarts", () => ({
+  init: vi.fn(() => ({
+    setOption: setOptionMock,
+    resize: vi.fn(),
+    dispose: vi.fn(),
+    getDom: vi.fn(() => document.createElement("div")),
+    on: vi.fn(),
+    off: vi.fn(),
+  })),
+  use: vi.fn(),
+  getInstanceByDom: vi.fn(),
+  graphic: {
+    LinearGradient: vi.fn(function LinearGradient(this: object) {
+      return this
+    }),
+  },
+}))
+
+vi.mock("echarts/components", () => ({
+  AriaComponent: {},
+}))
+
+const containerSize = { width: 800, height: 320 }
+
+vi.mock("../utils/useContainerSize", () => ({
+  useContainerSize: () => containerSize,
+}))
+
+function getLatestOption() {
+  const call = setOptionMock.mock.calls.at(-1)
+  if (!call) throw new Error("setOption was never called")
+  return call[0] as {
+    tooltip?: { formatter?: (params: unknown) => string }
+  }
+}
+
+/** Run the tooltip formatter the way ECharts would on hover. */
+function hover(params: unknown) {
+  const formatter = getLatestOption().tooltip?.formatter
+  if (!formatter) throw new Error("the chart built no tooltip formatter")
+  return formatter(params)
+}
+
+const funnelProps = {
+  type: "funnel" as const,
+  series: {
+    name: "Hiring",
+    data: [
+      { name: "Applied", value: 1200 },
+      { name: "Screened", value: 480 },
+      { name: "Interviewed", value: 120 },
+      { name: "Hired", value: 24 },
+    ],
+  },
+}
+
+beforeEach(() => {
+  setOptionMock.mockClear()
+  containerSize.width = 800
+  containerSize.height = 320
+})
+
+// The formatter runs inside ECharts on hover, so it only gets exercised by
+// calling it with the params ECharts passes.
+describe("FunnelChart — tooltip", () => {
+  it("shows the stage and its value, with no conversion rows by default", () => {
+    render(<F0DataChart {...funnelProps} />)
+
+    const html = hover({
+      name: "Screened",
+      value: 480,
+      marker: '<span class="trusted-marker"></span>',
+    })
+    expect(html).toContain('<span class="trusted-marker"></span>')
+    expect(html).toContain("Screened")
+    expect(html).toContain((480).toLocaleString())
+    expect(html).not.toContain("of total")
+  })
+
+  it("adds share-of-first and step-over-step rows when showConversion is set", () => {
+    render(<F0DataChart {...funnelProps} showConversion />)
+
+    const html = hover({ name: "Interviewed", value: 120 })
+    expect(html).toContain("10.0%") // 120 of the 1,200 that applied
+    expect(html).toContain("of total")
+    expect(html).toContain("25.0%") // 120 of the 480 screened
+    expect(html).toContain("from Screened")
+  })
+
+  it("omits the step row on the first stage, which has nothing before it", () => {
+    render(<F0DataChart {...funnelProps} showConversion />)
+
+    const html = hover({ name: "Applied", value: 1200 })
+    expect(html).toContain("100%")
+    expect(html).toContain("of total")
+    expect(html).not.toContain("from ")
+  })
+
+  it("reads the previous stage from rendered order, not array order", () => {
+    render(<F0DataChart {...funnelProps} sort="ascending" showConversion />)
+
+    // Ascending renders Hired → Interviewed → Screened → Applied, so the stage
+    // before "Screened" is "Interviewed", and 100% is the smallest stage.
+    const html = hover({ name: "Screened", value: 480 })
+    expect(html).toContain("from Interviewed")
+    expect(html).toContain("400.0%") // 480 over the 120 interviewed
+  })
+
+  it("keeps the value alone when a stage has nothing to convert from", () => {
+    render(
+      <F0DataChart
+        type="funnel"
+        showConversion
+        series={{
+          name: "Hiring",
+          data: [
+            { name: "Applied", value: 0 },
+            { name: "Hired", value: 0 },
+          ],
+        }}
+      />
+    )
+
+    const html = hover({ name: "Applied", value: 0 })
+    expect(html).toContain((0).toLocaleString())
+    expect(html).not.toContain("of total")
+    expect(html).not.toContain("NaN")
+    expect(html).not.toContain("Infinity")
+  })
+
+  it("escapes the stage name it names in a conversion row", () => {
+    render(
+      <F0DataChart
+        type="funnel"
+        showConversion
+        tooltipValueFormatter={(v) => `${v} people`}
+        series={{
+          name: "Hiring",
+          data: [
+            { name: "<script>x</script>", value: 100 },
+            { name: "Hired", value: 25 },
+          ],
+        }}
+      />
+    )
+
+    const html = hover({ name: "Hired", value: 25 })
+    expect(html).toContain("25 people")
+    // The previous stage's name lands in a label — escaped like any other text.
+    expect(html).toContain("&lt;script&gt;")
+    expect(html).not.toContain("<script>")
+  })
+
+  it("reads the value the way the stage labels do", () => {
+    render(
+      <F0DataChart {...funnelProps} valueFormatter={(v) => `${v} people`} />
+    )
+
+    expect(hover({ name: "Screened", value: 480 })).toContain("480 people")
+  })
+
+  it("lets tooltipValueFormatter set the tooltip number", () => {
+    render(
+      <F0DataChart
+        {...funnelProps}
+        valueFormatter={(v) => `${v / 1000}k`}
+        tooltipValueFormatter={(v) => `${v.toLocaleString("en-US")} people`}
+      />
+    )
+
+    expect(hover({ name: "Screened", value: 480 })).toContain("480 people")
+  })
+
+  it("survives params with no name or value", () => {
+    render(<F0DataChart {...funnelProps} showConversion />)
+
+    const html = hover({})
+    expect(html).toContain((0).toLocaleString())
+    expect(html).not.toContain("of total") // unknown stage, no position to use
+    expect(html).not.toContain("undefined")
+  })
+})

--- a/packages/react/src/kits/F0DataChart/__tests__/GaugeChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/GaugeChart.test.tsx
@@ -41,10 +41,18 @@ function getLatestOption() {
     series: Array<{
       title?: { show?: boolean; fontSize?: number }
       detail?: { show?: boolean; fontSize?: number }
-      progress?: { width?: number }
+      progress?: { width?: number; itemStyle?: { color?: string } }
       axisLine?: { lineStyle?: { width?: number } }
     }>
+    tooltip?: { formatter?: (params: unknown) => string }
   }
+}
+
+/** Run the tooltip formatter the way ECharts would on hover. */
+function hover(params: unknown) {
+  const formatter = getLatestOption().tooltip?.formatter
+  if (!formatter) throw new Error("the chart built no tooltip formatter")
+  return formatter(params)
 }
 
 const gaugeProps = {
@@ -88,5 +96,70 @@ describe("GaugeChart — responsive breakpoints", () => {
     expect(option.series[0].title?.show).toBe(true)
     expect(option.series[0].detail?.fontSize).toBe(32)
     expect(option.series[0].progress?.width).toBe(18)
+  })
+})
+
+// The formatter runs inside ECharts on hover, so it only gets exercised by
+// calling it with the params ECharts passes.
+describe("GaugeChart — tooltip", () => {
+  it("shows the name, the value and its share of the range", () => {
+    render(<F0DataChart {...gaugeProps} min={0} max={200} />)
+
+    const html = hover({ name: "Engagement", value: 72 })
+    expect(html).toContain("Engagement")
+    expect(html).toContain((72).toLocaleString())
+    expect(html).toContain("36.0%")
+    expect(html).toContain("of range")
+  })
+
+  it("marks the dot with the arc's own colour, not the palette entry", () => {
+    render(<F0DataChart {...gaugeProps} color="viridian" />)
+
+    const painted = getLatestOption().series[0].progress?.itemStyle?.color
+    expect(painted).toBeTruthy()
+    expect(hover({ name: "Engagement", value: 72 })).toContain(
+      `background-color:${painted}`
+    )
+  })
+
+  it("escapes the name and reads the value the way the ring does", () => {
+    render(
+      <F0DataChart
+        {...gaugeProps}
+        name="<script>x</script>"
+        value={7200}
+        max={10000}
+        valueFormatter={(v) => `${v / 100}%`}
+      />
+    )
+
+    const html = hover({ name: "<script>x</script>", value: 7200 })
+    expect(html).toContain("72%")
+    expect(html).toContain("&lt;script&gt;")
+    expect(html).not.toContain("<script>")
+  })
+
+  it("lets tooltipValueFormatter set the tooltip number", () => {
+    render(
+      <F0DataChart
+        {...gaugeProps}
+        valueFormatter={(v) => `${v}%`}
+        tooltipValueFormatter={(v) => `${v} of 100 points`}
+      />
+    )
+
+    expect(hover({ name: "Engagement", value: 72 })).toContain(
+      "72 of 100 points"
+    )
+  })
+
+  it("survives a missing value and a zero-width range", () => {
+    render(<F0DataChart {...gaugeProps} min={50} max={50} />)
+
+    const html = hover({ name: "Engagement" })
+    expect(html).toContain((0).toLocaleString())
+    expect(html).not.toContain("of range") // no range to be a share of
+    expect(html).not.toContain("NaN")
+    expect(html).not.toContain("Infinity")
   })
 })

--- a/packages/react/src/kits/F0DataChart/__tests__/HeatmapChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/HeatmapChart.test.tsx
@@ -52,7 +52,15 @@ function getLatestOption() {
       label?: { show?: boolean }
       itemStyle?: SeriesItemStyle
     }>
+    tooltip?: { formatter?: (params: unknown) => string }
   }
+}
+
+/** Run the tooltip formatter the way ECharts would on hover. */
+function hover(params: unknown) {
+  const formatter = getLatestOption().tooltip?.formatter
+  if (!formatter) throw new Error("the chart built no tooltip formatter")
+  return formatter(params)
 }
 
 const heatmapProps = {
@@ -141,5 +149,74 @@ describe("HeatmapChart — cell appearance", () => {
     const option = getLatestOption()
     expect(option.xAxis.axisLine.show).toBe(false)
     expect(option.yAxis.axisLine.show).toBe(false)
+  })
+})
+
+// The formatter runs inside ECharts on hover, so it only gets exercised by
+// calling it with the params ECharts passes.
+describe("HeatmapChart — tooltip", () => {
+  it("names both dimensions of the hovered cell and shows its value", () => {
+    containerSize.width = 720
+    render(<F0DataChart {...heatmapProps} />)
+
+    const html = hover({
+      value: [1, 1, 4],
+      marker: '<span class="trusted-marker"></span>',
+    })
+    expect(html).toContain('<span class="trusted-marker"></span>')
+    expect(html).toContain("Afternoon") // y category
+    expect(html).toContain("Tue") // x category
+    expect(html).toContain((4).toLocaleString())
+  })
+
+  it("escapes category names and reads the value the way the cells do", () => {
+    containerSize.width = 720
+    render(
+      <F0DataChart
+        {...heatmapProps}
+        xCategories={["<script>x</script>", "Tue", "Wed"]}
+        showLabels
+        valueFormatter={(v) => `${v}h`}
+      />
+    )
+
+    const html = hover({ value: [0, 0, 5] })
+    expect(html).toContain("5h")
+    expect(html).toContain("&lt;script&gt;")
+    expect(html).not.toContain("<script>")
+  })
+
+  it("lets tooltipValueFormatter set the tooltip number", () => {
+    containerSize.width = 720
+    render(
+      <F0DataChart
+        {...heatmapProps}
+        showLabels
+        tooltipValueFormatter={(v) => `${v} hours`}
+      />
+    )
+
+    expect(hover({ value: [1, 1, 4] })).toContain("4 hours")
+  })
+
+  it("survives a cell params object with no value tuple", () => {
+    containerSize.width = 720
+    render(<F0DataChart {...heatmapProps} />)
+
+    const html = hover({})
+    // Falls back to the first cell of the grid at zero rather than throwing.
+    expect(html).toContain("Morning")
+    expect(html).toContain("Mon")
+    expect(html).toContain((0).toLocaleString())
+    expect(html).not.toContain("undefined")
+  })
+
+  it("leaves the title empty when the index is outside the categories", () => {
+    containerSize.width = 720
+    render(<F0DataChart {...heatmapProps} />)
+
+    const html = hover({ value: [9, 9, 2] })
+    expect(html).toContain((2).toLocaleString())
+    expect(html).not.toContain("undefined")
   })
 })

--- a/packages/react/src/kits/F0DataChart/__tests__/LineChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/LineChart.test.tsx
@@ -55,6 +55,9 @@ function getLatestOption() {
     legend?: { show?: boolean }
     xAxis: { axisLabel: { show: boolean } }
     yAxis: { axisLabel: { show: boolean } }
+    tooltip?: {
+      formatter?: (params: unknown) => string
+    }
   }
 }
 
@@ -155,5 +158,51 @@ describe("LineChart — responsive breakpoints", () => {
     expect(option.legend?.show).toBe(true)
     expect(option.xAxis.axisLabel.show).toBe(true)
     expect(option.yAxis.axisLabel.show).toBe(true)
+  })
+})
+
+describe("LineChart — tooltip value formatting", () => {
+  const hoverFirstPoint = () =>
+    getLatestOption().tooltip?.formatter?.([
+      { axisValue: "A", seriesName: "S", value: 107505, dataIndex: 0 },
+    ])
+
+  it("falls back to the axis formatter when no tooltipValueFormatter is given", () => {
+    render(
+      <F0DataChart
+        type="line"
+        categories={["A"]}
+        series={[{ name: "S", data: [107505] }]}
+        valueFormatter={(v) => `${Math.round(v / 1000)}K €`}
+      />
+    )
+
+    expect(hoverFirstPoint()).toContain("108K €")
+  })
+
+  it("uses a plain localized number when neither formatter is given", () => {
+    render(
+      <F0DataChart
+        type="line"
+        categories={["A"]}
+        series={[{ name: "S", data: [107505] }]}
+      />
+    )
+
+    expect(hoverFirstPoint()).toContain((107505).toLocaleString())
+  })
+
+  it("lets tooltipValueFormatter keep a unit the axis formatter would drop", () => {
+    render(
+      <F0DataChart
+        type="line"
+        categories={["A"]}
+        series={[{ name: "S", data: [107505] }]}
+        valueFormatter={(v) => `${Math.round(v / 1000)}K`}
+        tooltipValueFormatter={(v) => `${v.toLocaleString("en-US")} €`}
+      />
+    )
+
+    expect(hoverFirstPoint()).toContain("107,505 €")
   })
 })

--- a/packages/react/src/kits/F0DataChart/__tests__/PieChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/PieChart.test.tsx
@@ -44,7 +44,15 @@ function getLatestOption() {
       labelLine?: { show?: boolean }
       radius?: [string, string]
     }>
+    tooltip?: { formatter?: (params: unknown) => string }
   }
+}
+
+/** Run the tooltip formatter the way ECharts would on hover. */
+function hover(params: unknown) {
+  const formatter = getLatestOption().tooltip?.formatter
+  if (!formatter) throw new Error("the chart built no tooltip formatter")
+  return formatter(params)
 }
 
 const pieProps = {
@@ -100,5 +108,55 @@ describe("PieChart — responsive breakpoints", () => {
 
     const option = getLatestOption()
     expect(option.legend).toBeUndefined()
+  })
+})
+
+// The formatter runs inside ECharts on hover, so it only gets exercised by
+// calling it with the params ECharts passes.
+describe("PieChart — tooltip", () => {
+  it("shows the slice, its value, its share and the whole", () => {
+    render(<F0DataChart {...pieProps} />)
+
+    const html = hover({
+      name: "Engineering",
+      value: 45,
+      percent: 53.6,
+      marker: '<span class="trusted-marker"></span>',
+    })
+    expect(html).toContain('<span class="trusted-marker"></span>')
+    expect(html).toContain("Engineering")
+    expect(html).toContain((45).toLocaleString())
+    expect(html).toContain("53.6%")
+    expect(html).toContain("of total")
+    expect(html).toContain((85).toLocaleString()) // 45 + 18 + 22
+  })
+
+  it("reads the slice value and the total the way the labels do", () => {
+    render(<F0DataChart {...pieProps} valueFormatter={(v) => `${v} FTE`} />)
+
+    const html = hover({ name: "Design", value: 18, percent: 21.2 })
+    expect(html).toContain("18 FTE")
+    expect(html).toContain("85 FTE") // the total row too
+  })
+
+  it("lets tooltipValueFormatter set both the slice value and the total", () => {
+    render(
+      <F0DataChart {...pieProps} tooltipValueFormatter={(v) => `${v} FTE`} />
+    )
+
+    const html = hover({ name: "Design", value: 18, percent: 21.2 })
+    expect(html).toContain("18 FTE")
+    expect(html).toContain("85 FTE") // the total row too
+  })
+
+  it("escapes the slice name and keeps a missing value at zero", () => {
+    render(<F0DataChart {...pieProps} />)
+
+    const html = hover({ name: "<script>x</script>" })
+    expect(html).toContain("&lt;script&gt;")
+    expect(html).not.toContain("<script>")
+    expect(html).toContain((0).toLocaleString())
+    expect(html).toContain("0.0%") // ECharts sent no percent
+    expect(html).not.toContain("NaN")
   })
 })

--- a/packages/react/src/kits/F0DataChart/__tests__/RadarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/RadarChart.test.tsx
@@ -42,7 +42,15 @@ function getLatestOption() {
     radar: {
       axisName?: { show?: boolean; width?: number }
     }
+    tooltip?: { formatter?: (params: unknown) => string }
   }
+}
+
+/** Run the tooltip formatter the way ECharts would on hover. */
+function hover(params: unknown) {
+  const formatter = getLatestOption().tooltip?.formatter
+  if (!formatter) throw new Error("the chart built no tooltip formatter")
+  return formatter(params)
 }
 
 const radarProps = {
@@ -87,5 +95,68 @@ describe("RadarChart — responsive breakpoints", () => {
     const option = getLatestOption()
     expect(option.legend?.show).toBe(true)
     expect(option.radar.axisName?.width).toBe(96)
+  })
+})
+
+// The formatter runs inside ECharts on hover, so it only gets exercised by
+// calling it with the params ECharts passes.
+describe("RadarChart — tooltip", () => {
+  it("lists every indicator as a row under the series name", () => {
+    render(<F0DataChart {...radarProps} />)
+
+    const html = hover({
+      name: "Team A",
+      value: [85, 70, 90],
+      marker: '<span class="trusted-marker"></span>',
+    })
+    expect(html).toContain('<span class="trusted-marker"></span>')
+    expect(html).toContain("Team A")
+    expect(html).toContain("Performance")
+    expect(html).toContain("Engagement")
+    expect(html).toContain("Retention")
+    expect(html).toContain((85).toLocaleString())
+    expect(html).toContain((70).toLocaleString())
+    expect(html).toContain((90).toLocaleString())
+    // A radar point carries every indicator at once — no single headline value.
+    expect(html).not.toContain("font-size: 20px")
+  })
+
+  it("reads every indicator the way the vertex labels do", () => {
+    render(<F0DataChart {...radarProps} valueFormatter={(v) => `${v} pts`} />)
+
+    const html = hover({ name: "Team A", value: [85, 70, 90] })
+    expect(html).toContain("85 pts")
+    expect(html).toContain("70 pts")
+  })
+
+  it("lets tooltipValueFormatter set every indicator row", () => {
+    render(
+      <F0DataChart
+        {...radarProps}
+        tooltipValueFormatter={(v) => `${v} / 100`}
+      />
+    )
+
+    const html = hover({ name: "Team A", value: [85, 70, 90] })
+    expect(html).toContain("85 / 100")
+    expect(html).toContain("70 / 100")
+    expect(html).toContain("90 / 100")
+  })
+
+  it("escapes the series name and fills indicators the point omits", () => {
+    render(
+      <F0DataChart
+        {...radarProps}
+        series={[{ name: "<b>A</b>", data: [85] }]}
+      />
+    )
+
+    const html = hover({ name: "<b>A</b>", value: [85] })
+    expect(html).toContain("&lt;b&gt;A&lt;/b&gt;")
+    expect(html).not.toContain("<b>")
+    // Two indicators had no value: they read 0 rather than disappearing.
+    expect(html).toContain("Retention")
+    expect(html).not.toContain("undefined")
+    expect(html).not.toContain("NaN")
   })
 })

--- a/packages/react/src/kits/F0DataChart/__tests__/options.test.ts
+++ b/packages/react/src/kits/F0DataChart/__tests__/options.test.ts
@@ -3,8 +3,13 @@ import { describe, expect, it } from "vitest"
 import {
   computeCategoryAxisLayout,
   computeLabelInterval,
+  deltaRow,
   escapeTooltipText,
+  renderMarker,
+  renderValueTooltip,
+  tooltipValueFormat,
 } from "../utils/options"
+import { resolveChartTheme } from "../utils/theme"
 
 describe("escapeTooltipText", () => {
   it("escapes HTML-significant characters in consumer-provided text", () => {
@@ -99,5 +104,134 @@ describe("computeCategoryAxisLayout", () => {
     const layout = computeCategoryAxisLayout(50, 100, true)
     expect(layout).toBeDefined()
     expect(layout!.labelWidth).toBeGreaterThanOrEqual(24)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Shared tooltip renderer — every chart type funnels through this.
+// ---------------------------------------------------------------------------
+
+describe("renderValueTooltip", () => {
+  const theme = resolveChartTheme()
+
+  it("renders marker, title, subtitle, value and rows", () => {
+    const html = renderValueTooltip(
+      {
+        marker: '<span class="dot"></span>',
+        title: "Variable pay",
+        subtitle: "Q2",
+        value: "22,000",
+        rows: [{ value: "14.1%", label: "of total" }],
+      },
+      theme
+    )
+    expect(html).toContain('<span class="dot"></span>') // trusted, unescaped
+    expect(html).toContain("Variable pay")
+    expect(html).toContain("Q2")
+    expect(html).toContain("22,000")
+    expect(html).toContain("14.1%")
+    expect(html).toContain("of total")
+    expect(html).toContain("min-width: 130px")
+  })
+
+  it("escapes everything except the ECharts marker", () => {
+    const html = renderValueTooltip(
+      {
+        marker: '<span class="dot"></span>',
+        title: "<script>x</script>",
+        subtitle: "<b>c</b>",
+        value: "<em>1</em>",
+        rows: [{ value: "<i>2</i>", label: "<u>l</u>" }],
+      },
+      theme
+    )
+    expect(html).toContain('<span class="dot"></span>')
+    expect(html).not.toContain("<script>")
+    expect(html).not.toContain("<b>")
+    expect(html).not.toContain("<em>")
+    expect(html).not.toContain("<i>")
+  })
+
+  it("omits sections that were not provided and drops falsy rows", () => {
+    const html = renderValueTooltip(
+      { title: "Only a title", rows: [undefined, false] },
+      theme
+    )
+    expect(html).toContain("Only a title")
+    expect(html).not.toContain("font-size: 20px") // no headline value
+    expect(html).not.toContain("<strong")
+  })
+})
+
+describe("deltaRow", () => {
+  const theme = resolveChartTheme()
+
+  it("signs and colors an increase", () => {
+    const row = deltaRow(125, 100, "from previous", theme)
+    expect(row?.value).toBe("+25.0%")
+    expect(row?.color).toBe(theme.colors.positive)
+  })
+
+  it("colors a decrease and keeps the minus sign", () => {
+    const row = deltaRow(75, 100, "from previous", theme)
+    expect(row?.value).toBe("-25.0%")
+    expect(row?.color).toBe(theme.colors.critical)
+  })
+
+  it("returns nothing without a usable baseline", () => {
+    expect(deltaRow(10, undefined, "l", theme)).toBeUndefined()
+    expect(deltaRow(10, 0, "l", theme)).toBeUndefined()
+    expect(deltaRow(Number.NaN, 10, "l", theme)).toBeUndefined()
+  })
+
+  it("falls back to the primary foreground when the theme omits delta colors", () => {
+    const bare = {
+      ...theme,
+      colors: { ...theme.colors, positive: undefined, critical: undefined },
+    }
+    const html = renderValueTooltip(
+      { value: "125", rows: [deltaRow(125, 100, "from previous", bare)] },
+      bare
+    )
+    expect(html).toContain(`color: ${theme.colors.foreground}`)
+  })
+})
+
+describe("renderMarker", () => {
+  it("builds a dot in the requested color", () => {
+    expect(renderMarker("#0d9488")).toContain("background-color:#0d9488")
+  })
+
+  it("strips characters that would break out of the style attribute", () => {
+    expect(renderMarker('red"><script>alert(1)</script>')).not.toContain(
+      "<script>"
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The one place every chart type resolves its tooltip number.
+// ---------------------------------------------------------------------------
+
+describe("tooltipValueFormat", () => {
+  it("reads the value the way the axis and labels do", () => {
+    // Without this a chart whose axis says "€46,390.86" hovered as
+    // "46390.863" — currency gone, raw float precision exposed.
+    const axis = (v: number) =>
+      `€${v.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+    expect(tooltipValueFormat(undefined, axis)(46390.8632)).toBe("€46,390.86")
+  })
+
+  it("lets tooltipValueFormatter win, for a compact axis with an exact tooltip", () => {
+    const compactAxis = (v: number) => `${Math.round(v / 1000)}k`
+    const exact = (v: number) => v.toLocaleString("en-US")
+    expect(tooltipValueFormat(exact, compactAxis)(107505)).toBe("107,505")
+  })
+
+  it("falls back to a plain localized number when neither is given", () => {
+    expect(tooltipValueFormat()(107505)).toBe((107505).toLocaleString())
+    expect(tooltipValueFormat(undefined, undefined)(0)).toBe(
+      (0).toLocaleString()
+    )
   })
 })

--- a/packages/react/src/kits/F0DataChart/__tests__/theme.test.ts
+++ b/packages/react/src/kits/F0DataChart/__tests__/theme.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it } from "vitest"
+
+import { resolveChartTheme } from "../utils/theme"
+
+// ---------------------------------------------------------------------------
+// `containerBackground` — the surface a chart actually sits on, used when the
+// chart paints its own background (e.g. the hairline between stacked segments).
+// ---------------------------------------------------------------------------
+
+function mount(...backgrounds: (string | undefined)[]) {
+  let parent: HTMLElement = document.body
+  for (const background of backgrounds) {
+    const element = document.createElement("div")
+    if (background !== undefined) {
+      element.style.backgroundColor = background
+    }
+    parent.appendChild(element)
+    parent = element
+  }
+  return parent
+}
+
+afterEach(() => {
+  document.body.replaceChildren()
+})
+
+describe("resolveChartTheme — containerBackground", () => {
+  it("falls back to the page token when nothing paints a background", () => {
+    const theme = resolveChartTheme(mount(undefined, undefined))
+    expect(theme.colors.containerBackground).toBe(theme.colors.background)
+  })
+
+  it("falls back to the page token when no element is given", () => {
+    const theme = resolveChartTheme(null)
+    expect(theme.colors.containerBackground).toBe(theme.colors.background)
+  })
+
+  it("uses the element's own background when it has one", () => {
+    const theme = resolveChartTheme(mount("rgb(10, 20, 30)"))
+    expect(theme.colors.containerBackground).toBe("rgb(10, 20, 30)")
+  })
+
+  it("walks up to the nearest ancestor that paints one", () => {
+    const theme = resolveChartTheme(mount("rgb(10, 20, 30)", undefined))
+    expect(theme.colors.containerBackground).toBe("rgb(10, 20, 30)")
+  })
+
+  it("stops at the nearest surface rather than the outermost one", () => {
+    // A tinted card inside a page wrapper — the card wins.
+    const theme = resolveChartTheme(
+      mount("rgb(1, 1, 1)", "rgb(2, 2, 2)", undefined)
+    )
+    expect(theme.colors.containerBackground).toBe("rgb(2, 2, 2)")
+  })
+
+  it("skips fully transparent backgrounds", () => {
+    const theme = resolveChartTheme(
+      mount("rgb(10, 20, 30)", "rgba(0, 0, 0, 0)")
+    )
+    expect(theme.colors.containerBackground).toBe("rgb(10, 20, 30)")
+  })
+
+  it("takes a translucent surface at face value", () => {
+    // Blending against what sits beneath is overkill for a hairline.
+    const theme = resolveChartTheme(mount("rgba(10, 20, 30, 0.5)"))
+    expect(theme.colors.containerBackground).toBe("rgba(10, 20, 30, 0.5)")
+  })
+
+  it("leaves the page-level background token untouched", () => {
+    const theme = resolveChartTheme(mount("rgb(10, 20, 30)"))
+    expect(theme.colors.background).not.toBe("rgb(10, 20, 30)")
+  })
+})

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -1,6 +1,8 @@
 import * as echarts from "echarts"
 import { type RefObject, useMemo } from "react"
 
+import { useReducedMotion } from "@/lib/a11y"
+
 import type {
   F0DataChartBarDataPoint,
   F0DataChartBarProps,
@@ -52,7 +54,10 @@ const STACK_GAP_BORDER_WIDTH = 0.5
 /** Opacity of the series that are *not* hovered, while one series has focus. */
 const BLUR_OPACITY = 0.4
 
-/** Cross-fade duration (ms) in and out of the hover blur state. */
+/**
+ * Cross-fade duration (ms) in and out of the hover blur state. Drops to 0 when
+ * the user prefers reduced motion.
+ */
 const STATE_ANIMATION_DURATION = 500
 
 function resolveGridRightSpace(
@@ -454,6 +459,7 @@ export function useBarChartOptions(
   const theme = useChartTheme(containerRef)
   const { width: containerWidth, height: containerHeight } =
     useContainerSize(containerRef)
+  const prefersReducedMotion = useReducedMotion()
 
   return useMemo(() => {
     const isVertical = orientation === "vertical"
@@ -688,15 +694,22 @@ export function useBarChartOptions(
     // This runs after `buildBaseChartOptions` merged the consumer's
     // `echartsOptions`, so each key defers to an explicitly-provided value —
     // same convention as the `userGridRight` guard below.
+    //
+    // `prefers-reduced-motion` zeroes the duration rather than dropping the
+    // state: the hover highlight still isolates the series, it just arrives
+    // instantly. The preference belongs to the user, not the consumer, so it
+    // also flattens an explicitly-provided `stateAnimation` duration.
     if (stacked) {
       options.animation = echartsOptions?.animation ?? true
       options.animationDuration = echartsOptions?.animationDuration ?? 0
       options.animationDurationUpdate =
         echartsOptions?.animationDurationUpdate ?? 0
-      options.stateAnimation = echartsOptions?.stateAnimation ?? {
-        duration: STATE_ANIMATION_DURATION,
-        easing: "cubicOut",
-      }
+      options.stateAnimation = prefersReducedMotion
+        ? { ...echartsOptions?.stateAnimation, duration: 0 }
+        : (echartsOptions?.stateAnimation ?? {
+            duration: STATE_ANIMATION_DURATION,
+            easing: "cubicOut",
+          })
     }
 
     // Non-stacked horizontal bars render labels BESIDE the bar end, so the
@@ -733,5 +746,6 @@ export function useBarChartOptions(
     containerWidth,
     containerHeight,
     size,
+    prefersReducedMotion,
   ])
 }

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -406,27 +406,28 @@ function buildSeriesEntries(
 export type BarChartSize = ChartResponsiveSize
 
 /**
- * Maps a discrete `size` to which chrome (legend, axes) is rendered. The
- * matrix mirrors `LineChart.resolveResponsiveDisplay` so the two chart
- * families behave the same at every breakpoint, with one bar-only exception
- * at `md`:
+ * Maps a discrete `size` to which chrome (legend, axes) is rendered:
  *
  * - `sm` → just the bars, no axes, no legend
- * - `md` → bars + legend + value axis; the category axis shows for horizontal
- *   bars only
- * - `lg` → bars + legend + both axes (with smart truncation on the category axis)
+ * - `md` / `lg` → bars + legend + both axes (with smart truncation on the
+ *   category axis)
  *
- * Horizontal bars carry their categories on the left, one label per row beside
- * the bar it names. Dropping them leaves a stack of anonymous bars that the
- * value axis alone can't explain, and they cost at most 20% of the width
- * (`yAxisMaxLabelWidth`) rather than competing with each other. Vertical bars
- * keep the plain `md` rule: their categories run along the bottom, where they
- * crowd each other well before the plot runs out of room.
+ * Bars deviate from `LineChart.resolveResponsiveDisplay`, which keeps the
+ * category axis for `lg` alone. A bar chart's categories are its subjects — a
+ * plot without them is a set of lengths with nothing to compare, which the
+ * value axis can't rescue. So bars show them wherever there is room for any
+ * chrome at all, and `sm` is the only size that drops them.
+ *
+ * Crowding is handled rather than avoided: `computeCategoryAxisLayout` runs
+ * whenever the axis is shown, fitting every label with ellipsis truncation and
+ * only skipping labels when even a 3-char stub won't fit. The cost is plot
+ * area — horizontal labels take `min(80, width * 0.2)` of the width, vertical
+ * ones a row of height.
  */
-function resolveResponsiveDisplay(size: BarChartSize, isVertical: boolean) {
+function resolveResponsiveDisplay(size: BarChartSize) {
   return {
     showLegend: size !== "sm",
-    showCategoryAxis: size === "lg" || (size === "md" && !isVertical),
+    showCategoryAxis: size !== "sm",
     showValueAxis: size !== "sm",
   }
 }
@@ -472,7 +473,7 @@ export function useBarChartOptions(
       containerWidth
     )
 
-    const responsive = resolveResponsiveDisplay(size, isVertical)
+    const responsive = resolveResponsiveDisplay(size)
     // The user-provided `showLegend` prop can still force the legend off,
     // but it can never override the `sm` rule.
     const effectiveShowLegend = responsive.showLegend && showLegend

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -402,17 +402,26 @@ export type BarChartSize = ChartResponsiveSize
 
 /**
  * Maps a discrete `size` to which chrome (legend, axes) is rendered. The
- * matrix is identical to `LineChart.resolveResponsiveDisplay` so the two
- * chart families behave the same at every breakpoint:
+ * matrix mirrors `LineChart.resolveResponsiveDisplay` so the two chart
+ * families behave the same at every breakpoint, with one bar-only exception
+ * at `md`:
  *
  * - `sm` → just the bars, no axes, no legend
- * - `md` → bars + legend + value axis, no category axis
+ * - `md` → bars + legend + value axis; the category axis shows for horizontal
+ *   bars only
  * - `lg` → bars + legend + both axes (with smart truncation on the category axis)
+ *
+ * Horizontal bars carry their categories on the left, one label per row beside
+ * the bar it names. Dropping them leaves a stack of anonymous bars that the
+ * value axis alone can't explain, and they cost at most 20% of the width
+ * (`yAxisMaxLabelWidth`) rather than competing with each other. Vertical bars
+ * keep the plain `md` rule: their categories run along the bottom, where they
+ * crowd each other well before the plot runs out of room.
  */
-function resolveResponsiveDisplay(size: BarChartSize) {
+function resolveResponsiveDisplay(size: BarChartSize, isVertical: boolean) {
   return {
     showLegend: size !== "sm",
-    showCategoryAxis: size === "lg",
+    showCategoryAxis: size === "lg" || (size === "md" && !isVertical),
     showValueAxis: size !== "sm",
   }
 }
@@ -457,7 +466,7 @@ export function useBarChartOptions(
       containerWidth
     )
 
-    const responsive = resolveResponsiveDisplay(size)
+    const responsive = resolveResponsiveDisplay(size, isVertical)
     // The user-provided `showLegend` prop can still force the legend off,
     // but it can never override the `sm` rule.
     const effectiveShowLegend = responsive.showLegend && showLegend

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -40,9 +40,12 @@ const ARIA_MAX_VALUES_PER_SERIES = 20
 const INSIDE_LABEL_COLOR = "#ffffff"
 
 /**
- * Stroke width (px) of the hairline separating stacked segments. Adjacent
- * segments both stroke the shared edge and the strokes are centered on it, so
- * they overlap rather than add: the visible separation is ~0.5 CSS px.
+ * Stroke width (px) of the hairline separating stacked segments.
+ *
+ * Adjacent segments both stroke the shared edge and canvas strokes are centered
+ * on the path, so the two cover the same band rather than adding to it: the
+ * visible separation equals this width, not twice it. 0.5 is deliberate — it
+ * renders as a hairline at 1x and a crisp single device pixel at 2x.
  */
 const STACK_GAP_BORDER_WIDTH = 0.5
 
@@ -543,7 +546,7 @@ export function useBarChartOptions(
         showLabels,
         stacked,
         theme.colors.foregroundSecondary,
-        theme.colors.background,
+        theme.colors.containerBackground,
         resolvedLabelFontSize,
         resolveBorderRadius,
         labelLayout,

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -2,6 +2,7 @@ import * as echarts from "echarts"
 import { type RefObject, useMemo } from "react"
 
 import { useReducedMotion } from "@/lib/a11y"
+import { useI18n } from "@/lib/providers/i18n"
 
 import type {
   F0DataChartBarDataPoint,
@@ -10,7 +11,12 @@ import type {
 } from "../../types"
 
 import { paletteColor, resolveChartColorToken } from "../../utils/colors"
-import { buildBaseChartOptions, escapeTooltipText } from "../../utils/options"
+import {
+  buildBaseChartOptions,
+  buildItemTooltip,
+  renderValueTooltip,
+  tooltipValueFormat,
+} from "../../utils/options"
 import type { ChartResponsiveSize } from "../../utils/responsive"
 import { useChartTheme } from "../../utils/useChartTheme"
 import { useContainerSize } from "../../utils/useContainerSize"
@@ -458,6 +464,7 @@ export function useBarChartOptions(
   size: BarChartSize
 ): echarts.EChartsOption {
   const theme = useChartTheme(containerRef)
+  const i18n = useI18n()
   const { width: containerWidth, height: containerHeight } =
     useContainerSize(containerRef)
   const prefersReducedMotion = useReducedMotion()
@@ -582,48 +589,14 @@ export function useBarChartOptions(
       }
     }
 
-    const hasAnyTargets = targetMap.size > 0
-
-    // Tooltip values use their own formatter when provided (precise numbers),
-    // otherwise fall back to the shared value formatter.
+    // Aria descriptions use their own formatter when provided (precise
+    // numbers), otherwise fall back to the shared value formatter.
     const tooltipValue = tooltipValueFormatter ?? valueFormatter
 
-    const tooltipFormatter = hasAnyTargets
-      ? (params: unknown) => {
-          if (!Array.isArray(params)) return ""
-          const filtered = params.filter(
-            (p: { seriesName?: string }) =>
-              !String(p.seriesName ?? "").endsWith(" (target)")
-          )
-          if (filtered.length === 0) return ""
-
-          const header = `<div style="margin-bottom: 4px; font-weight: 500">${escapeTooltipText(filtered[0].axisValueLabel ?? filtered[0].name ?? "")}</div>`
-          const items = filtered
-            .map(
-              (p: {
-                marker?: string
-                seriesName?: string
-                value?: number
-                dataIndex?: number
-              }) => {
-                const val = Number(p.value)
-                const formattedValue = tooltipValue
-                  ? tooltipValue(val)
-                  : String(val)
-                const targets = targetMap.get(String(p.seriesName ?? ""))
-                const target = targets?.[p.dataIndex ?? 0]
-                const targetHtml =
-                  target !== undefined
-                    ? ` <span style="opacity: 0.6">/ ${escapeTooltipText(tooltipValue ? tooltipValue(target) : String(target))}</span>`
-                    : ""
-                return `<div>${String(p.marker ?? "")} ${escapeTooltipText(p.seriesName ?? "")} <strong>${escapeTooltipText(formattedValue)}</strong>${targetHtml}</div>`
-              }
-            )
-            .join("")
-
-          return `${header}${items}`
-        }
-      : undefined
+    const formatTooltipValue = tooltipValueFormat(
+      tooltipValueFormatter,
+      valueFormatter
+    )
 
     const options = buildBaseChartOptions({
       categories,
@@ -639,8 +612,6 @@ export function useBarChartOptions(
       showValueAxis,
       valueFormatter,
       categoryFormatter,
-      tooltipFilterSeries: (name) => name.endsWith(" (target)"),
-      tooltipFormatter,
       tooltipValueFormatter,
       valueAxisSplitNumber,
       echartsOptions,
@@ -713,6 +684,81 @@ export function useBarChartOptions(
           })
     }
 
+    // Bar charts use an item-triggered tooltip about the hovered bar or
+    // segment (pairing with the stacked series highlight) instead of the axis
+    // tooltip listing every series: value large, then — with several
+    // same-signed series — the hovered value's share of the category total,
+    // that total, and the target when there is one.
+    //
+    // `buildBaseChartOptions` has already merged `echartsOptions`, so a caller
+    // that passed its own tooltip keeps it: only build ours when it didn't.
+    if (echartsOptions?.tooltip === undefined) {
+      options.tooltip = buildItemTooltip({
+        theme,
+        formatter: (params: unknown) => {
+          const p = params as {
+            seriesName?: string
+            name?: string
+            value?: number
+            dataIndex?: number
+            marker?: string
+          }
+          const seriesName = String(p.seriesName ?? "")
+          if (seriesName.endsWith(" (target)")) return ""
+
+          const value = Number(p.value)
+          const dataIndex = p.dataIndex ?? 0
+          const target = targetMap.get(seriesName)?.[dataIndex]
+          // Share-of-total context only means something with several series
+          // pushing the same way: a single-series bar is always 100% of its own
+          // category, and a category mixing gains with losses has no "total"
+          // the parts add up to — 24 hires against a net of 19 would read as
+          // 126.3%, and near-cancellation makes that ratio arbitrarily large.
+          // Signed categories therefore show the value alone.
+          const categoryValues = series.map((s) => {
+            // A series can be shorter than `categories`.
+            const point = s.data[dataIndex]
+            return point === undefined ? 0 : getValue(point) || 0
+          })
+          const hasMixedSigns =
+            categoryValues.some((v) => v > 0) &&
+            categoryValues.some((v) => v < 0)
+          const total = categoryValues.reduce((sum, v) => sum + v, 0)
+          const showTotal = series.length > 1 && !hasMixedSigns
+
+          // No "from previous" row here: bar categories are not necessarily a
+          // sequence (locations, departments), so comparing a bar with the one
+          // to its left is only meaningful on a trend — i.e. a line chart.
+          return renderValueTooltip(
+            {
+              marker: p.marker,
+              title: seriesName,
+              subtitle: String(p.name ?? ""),
+              value: formatTooltipValue(value),
+              rows: [
+                showTotal &&
+                  total !== 0 && {
+                    // Same sign on both sides, so the ratio is positive even
+                    // when the whole category is negative.
+                    value: `${((value / total) * 100).toFixed(1)}%`,
+                    label: i18n.dataChart.tooltip.ofTotal,
+                  },
+                showTotal && {
+                  value: formatTooltipValue(total),
+                  label: i18n.dataChart.tooltip.total,
+                },
+                target !== undefined && {
+                  value: formatTooltipValue(target),
+                  label: i18n.dataChart.tooltip.target,
+                },
+              ],
+            },
+            theme
+          )
+        },
+      })
+    }
+
     // Non-stacked horizontal bars render labels BESIDE the bar end, so the
     // grid reserves room for them on the right. Stacked labels sit inside
     // their segments — no reservation needed, the plot keeps its full width.
@@ -744,6 +790,7 @@ export function useBarChartOptions(
     valueAxisSplitNumber,
     echartsOptions,
     theme,
+    i18n,
     containerWidth,
     containerHeight,
     size,

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -555,7 +555,7 @@ export function useBarChartOptions(
         showLabels,
         stacked,
         theme.colors.foregroundSecondary,
-        theme.colors.containerBackground,
+        theme.colors.containerBackground ?? theme.colors.background,
         resolvedLabelFontSize,
         resolveBorderRadius,
         labelLayout,

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -39,6 +39,19 @@ const ARIA_MAX_VALUES_PER_SERIES = 20
  */
 const INSIDE_LABEL_COLOR = "#ffffff"
 
+/**
+ * Stroke width (px) of the hairline separating stacked segments. Adjacent
+ * segments both stroke the shared edge and the strokes are centered on it, so
+ * they overlap rather than add: the visible separation is ~0.5 CSS px.
+ */
+const STACK_GAP_BORDER_WIDTH = 0.5
+
+/** Opacity of the series that are *not* hovered, while one series has focus. */
+const BLUR_OPACITY = 0.4
+
+/** Cross-fade duration (ms) in and out of the hover blur state. */
+const STATE_ANIMATION_DURATION = 500
+
 function resolveGridRightSpace(
   right: number | string | undefined,
   containerWidth: number
@@ -255,11 +268,9 @@ function buildSeriesEntries(
       borderRadius,
       // ECharts has no native gap between stacked segments — a border in the
       // container's background color is the standard way to separate them.
-      // 0.5 because adjacent segments both stroke the shared edge: the two
-      // strokes add up, and wider values read as a ~2px gap.
       ...(stacked && {
         borderColor: stackGapColor,
-        borderWidth: 0.5,
+        borderWidth: STACK_GAP_BORDER_WIDTH,
       }),
     },
     label: {
@@ -267,9 +278,9 @@ function buildSeriesEntries(
       // Stacked bars are segmented, so center the value inside its own segment;
       // single/grouped bars keep the value just outside the bar (above / beside).
       position: stacked ? "inside" : isVertical ? "top" : "right",
-      // Inside a coloured segment, choose black or white per fill so small
-      // canvas text retains WCAG AA contrast. Outside labels use the semantic
-      // secondary foreground colour from the active theme.
+      // Inside a coloured segment the label is always white (see
+      // INSIDE_LABEL_COLOR). Outside labels use the semantic secondary
+      // foreground colour from the active theme.
       color: stacked ? INSIDE_LABEL_COLOR : labelColor,
       fontWeight: "bold",
       fontSize: labelFontSize,
@@ -290,17 +301,17 @@ function buildSeriesEntries(
       // Hovering a stacked segment highlights that series across all bars by
       // sending every other series into the blur state (see `blur` below).
       ...(stacked && { focus: "series" as const }),
-      // Keep the same contrast-safe colour on hover. With labels off, add
-      // nothing here — otherwise hovering a stacked bar would reveal numbers
-      // that are meant to stay off.
+      // Keep the same colour on hover. With labels off, add nothing here —
+      // otherwise hovering a stacked bar would reveal numbers that are meant
+      // to stay off.
       ...(stacked && showLabels
         ? { label: { show: true, color: INSIDE_LABEL_COLOR } }
         : {}),
     },
     ...(stacked && {
       blur: {
-        itemStyle: { opacity: 0.4 },
-        label: { opacity: 0.4 },
+        itemStyle: { opacity: BLUR_OPACITY },
+        label: { opacity: BLUR_OPACITY },
       },
     }),
   }
@@ -370,6 +381,14 @@ function buildSeriesEntries(
     emphasis: {
       disabled: true,
     },
+    // The target ghost is a separate series, so `focus: "series"` blurs it even
+    // when its own bar is the one hovered. Match the main series' blur opacity
+    // so it fades with its stack instead of dropping to the ECharts default.
+    ...(stacked && {
+      blur: {
+        itemStyle: { opacity: BLUR_OPACITY },
+      },
+    }),
   }
 
   return [mainSeries, targetSeries]
@@ -653,11 +672,19 @@ export function useBarChartOptions(
     // `animation: false` — there to skip entrance animations — disables state
     // transitions too. Re-enable the engine with zero-duration entrance and
     // update animations so only the blur fade animates.
+    //
+    // This runs after `buildBaseChartOptions` merged the consumer's
+    // `echartsOptions`, so each key defers to an explicitly-provided value —
+    // same convention as the `userGridRight` guard below.
     if (stacked) {
-      options.animation = true
-      options.animationDuration = 0
-      options.animationDurationUpdate = 0
-      options.stateAnimation = { duration: 500, easing: "cubicOut" }
+      options.animation = echartsOptions?.animation ?? true
+      options.animationDuration = echartsOptions?.animationDuration ?? 0
+      options.animationDurationUpdate =
+        echartsOptions?.animationDurationUpdate ?? 0
+      options.stateAnimation = echartsOptions?.stateAnimation ?? {
+        duration: STATE_ANIMATION_DURATION,
+        easing: "cubicOut",
+      }
     }
 
     // Non-stacked horizontal bars render labels BESIDE the bar end, so the

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -29,34 +29,15 @@ const ARIA_MAX_SERIES = 10
 const ARIA_MAX_VALUES_PER_SERIES = 20
 
 /**
- * Pick the black/white foreground for text on a colored fill. Prefers white on
- * mid-tone fills (the strict WCAG crossover at 0.179 reads as "black too
- * eagerly" on saturated mid-tones like teal or purple); black only wins on
- * genuinely light fills (e.g. yellow), where white text would be illegible.
+ * Foreground for a value label sitting inside a colored fill.
+ *
+ * Always white: a stacked bar reads as one object, and per-segment black/white
+ * switching made a single bar look like two unrelated label styles. Every
+ * selectable series color is a shade-50 chromatic token, so white stays
+ * legible — though on the two lightest (flubber, yellow) it is a deliberate
+ * design call rather than a WCAG AA pass.
  */
-function readableLabelColor(background: string): "#000000" | "#ffffff" {
-  const hex = background.replace("#", "")
-  const normalized =
-    hex.length === 3
-      ? hex
-          .split("")
-          .map((value) => `${value}${value}`)
-          .join("")
-      : hex
-  const channels = [0, 2, 4].map((offset) => {
-    const value =
-      Number.parseInt(normalized.slice(offset, offset + 2), 16) / 255
-    return value <= 0.04045
-      ? value / 12.92
-      : Math.pow((value + 0.055) / 1.055, 2.4)
-  })
-  const luminance =
-    0.2126 * (channels[0] ?? 0) +
-    0.7152 * (channels[1] ?? 0) +
-    0.0722 * (channels[2] ?? 0)
-
-  return luminance > 0.4 ? "#000000" : "#ffffff"
-}
+const INSIDE_LABEL_COLOR = "#ffffff"
 
 function resolveGridRightSpace(
   right: number | string | undefined,
@@ -214,6 +195,7 @@ function buildSeriesEntries(
   showLabels: boolean,
   stacked: boolean,
   labelColor: string,
+  stackGapColor: string,
   labelFontSize: number,
   resolveBorderRadius: BorderRadiusResolver | undefined,
   labelLayout?: echarts.BarSeriesOption["labelLayout"],
@@ -240,10 +222,6 @@ function buildSeriesEntries(
     if (pointColor === undefined && pointBorderRadius === undefined) {
       return value
     }
-    // Inside a stacked segment with a per-bar colour override, the label must
-    // recompute its contrast colour against that override, not the series fill.
-    const contrastColor =
-      pointColor !== undefined ? readableLabelColor(pointColor) : undefined
     return {
       value,
       itemStyle: {
@@ -252,12 +230,9 @@ function buildSeriesEntries(
           borderRadius: pointBorderRadius,
         }),
       },
-      ...(stacked && contrastColor !== undefined
-        ? {
-            label: { color: contrastColor },
-            emphasis: { label: { color: contrastColor } },
-          }
-        : {}),
+      // Inside labels are white regardless of the fill, so a per-bar colour
+      // override needs no label colour of its own — the series-level one
+      // already applies.
     }
   })
 
@@ -278,6 +253,14 @@ function buildSeriesEntries(
     itemStyle: {
       color,
       borderRadius,
+      // ECharts has no native gap between stacked segments — a border in the
+      // container's background color is the standard way to separate them.
+      // 0.5 because adjacent segments both stroke the shared edge: the two
+      // strokes add up, and wider values read as a ~2px gap.
+      ...(stacked && {
+        borderColor: stackGapColor,
+        borderWidth: 0.5,
+      }),
     },
     label: {
       show: showLabels,
@@ -287,7 +270,7 @@ function buildSeriesEntries(
       // Inside a coloured segment, choose black or white per fill so small
       // canvas text retains WCAG AA contrast. Outside labels use the semantic
       // secondary foreground colour from the active theme.
-      color: stacked ? readableLabelColor(color) : labelColor,
+      color: stacked ? INSIDE_LABEL_COLOR : labelColor,
       fontWeight: "bold",
       fontSize: labelFontSize,
       overflow: "truncate",
@@ -304,13 +287,22 @@ function buildSeriesEntries(
         shadowOffsetX: 0,
         shadowColor: "transparent",
       },
+      // Hovering a stacked segment highlights that series across all bars by
+      // sending every other series into the blur state (see `blur` below).
+      ...(stacked && { focus: "series" as const }),
       // Keep the same contrast-safe colour on hover. With labels off, add
       // nothing here — otherwise hovering a stacked bar would reveal numbers
       // that are meant to stay off.
       ...(stacked && showLabels
-        ? { label: { show: true, color: readableLabelColor(color) } }
+        ? { label: { show: true, color: INSIDE_LABEL_COLOR } }
         : {}),
     },
+    ...(stacked && {
+      blur: {
+        itemStyle: { opacity: 0.4 },
+        label: { opacity: 0.4 },
+      },
+    }),
   }
 
   if (!hasTargetData) {
@@ -532,6 +524,7 @@ export function useBarChartOptions(
         showLabels,
         stacked,
         theme.colors.foregroundSecondary,
+        theme.colors.background,
         resolvedLabelFontSize,
         resolveBorderRadius,
         labelLayout,
@@ -652,6 +645,19 @@ export function useBarChartOptions(
         enabled: true,
         description: ariaDescriptions.join(" "),
       },
+    }
+
+    // Fade in/out of the hover blur state (see `blur` on the series). Two
+    // requirements: `stateAnimation` is only honored at the option root (the
+    // series-level one in the types is ignored), and the base options'
+    // `animation: false` — there to skip entrance animations — disables state
+    // transitions too. Re-enable the engine with zero-duration entrance and
+    // update animations so only the blur fade animates.
+    if (stacked) {
+      options.animation = true
+      options.animationDuration = 0
+      options.animationDurationUpdate = 0
+      options.stateAnimation = { duration: 500, easing: "cubicOut" }
     }
 
     // Non-stacked horizontal bars render labels BESIDE the bar end, so the

--- a/packages/react/src/kits/F0DataChart/components/FunnelChart/useFunnelChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/FunnelChart/useFunnelChartOptions.ts
@@ -2,6 +2,8 @@ import type * as echarts from "echarts"
 
 import { type RefObject, useMemo } from "react"
 
+import { useI18n } from "@/lib/providers/i18n"
+
 import type { F0DataChartFunnelProps } from "../../types"
 
 import {
@@ -12,8 +14,10 @@ import { formatPercent } from "../../utils/formatters"
 import {
   buildGrid,
   buildItemTooltip,
+  renderValueTooltip,
   buildLegend,
   DEFAULT_EMPHASIS,
+  tooltipValueFormat,
 } from "../../utils/options"
 import { useChartTheme } from "../../utils/useChartTheme"
 import { useContainerSize } from "../../utils/useContainerSize"
@@ -30,10 +34,12 @@ export function useFunnelChartOptions(
     showConversion = false,
     colorScale = true,
     valueFormatter,
+    tooltipValueFormatter,
     echartsOptions,
   }: F0DataChartFunnelProps
 ): echarts.EChartsOption {
   const theme = useChartTheme(containerRef)
+  const i18n = useI18n()
   const { width: containerWidth } = useContainerSize(containerRef)
 
   return useMemo(() => {
@@ -114,7 +120,10 @@ export function useFunnelChartOptions(
       },
     }
 
-    const { colors } = theme
+    const formatTooltipValue = tooltipValueFormat(
+      tooltipValueFormatter,
+      valueFormatter
+    )
 
     const buildTooltipFormatter = () => {
       // Use sorted order for step-over-step conversion
@@ -137,28 +146,37 @@ export function useFunnelChartOptions(
           value?: number
         }
         const val = Number(p.value ?? 0)
-        const formattedValue = valueFormatter
-          ? valueFormatter(val)
-          : String(val)
+        const formattedValue = formatTooltipValue(val)
         const name = String(p.name ?? "")
         const sortedIndex = sortedIndexMap.get(name)
 
-        let conversionHtml = ""
+        const conversionRows = []
         if (showConversion && firstValue > 0 && sortedIndex !== undefined) {
-          const overallPct = formatPercent(val, firstValue)
-          conversionHtml = `<div style="margin-top: 4px; color: ${colors.foregroundTertiary}; font-size: 11px">Overall: ${overallPct}</div>`
+          conversionRows.push({
+            value: formatPercent(val, firstValue),
+            label: i18n.dataChart.tooltip.ofTotal,
+          })
 
-          const prevIndex = sortedIndex - 1
-          if (prevIndex >= 0) {
-            const prevData = sorted[prevIndex]
-            if (prevData && prevData.value > 0) {
-              const stepPct = formatPercent(val, prevData.value)
-              conversionHtml += `<div style="color: ${colors.foregroundTertiary}; font-size: 11px">From ${prevData.name}: ${stepPct}</div>`
-            }
+          const prevData = sortedIndex > 0 ? sorted[sortedIndex - 1] : undefined
+          if (prevData && prevData.value > 0) {
+            conversionRows.push({
+              value: formatPercent(val, prevData.value),
+              label: i18n.t("dataChart.tooltip.fromStage", {
+                stage: prevData.name,
+              }),
+            })
           }
         }
 
-        return `<div>${String(p.marker ?? "")} <strong>${name}</strong></div><div style="margin-top: 2px">${formattedValue}</div>${conversionHtml}`
+        return renderValueTooltip(
+          {
+            marker: p.marker,
+            title: name,
+            value: formattedValue,
+            rows: conversionRows,
+          },
+          theme
+        )
       }
     }
 
@@ -197,8 +215,10 @@ export function useFunnelChartOptions(
     showConversion,
     colorScale,
     valueFormatter,
+    tooltipValueFormatter,
     echartsOptions,
     theme,
+    i18n,
     containerWidth,
   ])
 }

--- a/packages/react/src/kits/F0DataChart/components/GaugeChart/useGaugeChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/GaugeChart/useGaugeChartOptions.ts
@@ -2,10 +2,17 @@ import type * as echarts from "echarts"
 
 import { type RefObject, useMemo } from "react"
 
+import { useI18n } from "@/lib/providers/i18n"
+
 import type { F0DataChartGaugeProps } from "../../types"
 
 import { paletteColor, resolveChartColorToken } from "../../utils/colors"
-import { buildItemTooltip } from "../../utils/options"
+import {
+  buildItemTooltip,
+  renderMarker,
+  renderValueTooltip,
+  tooltipValueFormat,
+} from "../../utils/options"
 import type { ChartResponsiveSize } from "../../utils/responsive"
 import { useChartTheme } from "../../utils/useChartTheme"
 
@@ -54,11 +61,13 @@ export function useGaugeChartOptions(
     color,
     showValue = true,
     valueFormatter,
+    tooltipValueFormatter,
     echartsOptions,
   }: F0DataChartGaugeProps,
   size: GaugeChartSize
 ): echarts.EChartsOption {
   const theme = useChartTheme(containerRef)
+  const i18n = useI18n()
 
   return useMemo(() => {
     const resolvedColor = color
@@ -131,16 +140,30 @@ export function useGaugeChartOptions(
         theme,
         formatter: (params: unknown) => {
           const p = params as {
-            marker?: string
             name?: string
             value?: number
           }
           const val = Number(p.value ?? 0)
-          const formattedValue = valueFormatter
-            ? valueFormatter(val)
-            : String(val)
-          const label = p.name ? `<strong>${String(p.name)}</strong><br/>` : ""
-          return `${label}${formattedValue}`
+          const span = max - min
+          return renderValueTooltip(
+            {
+              // ECharts' own marker for a gauge uses the palette, not the
+              // colour the arc is actually painted with.
+              marker: renderMarker(resolvedColor),
+              title: p.name ? String(p.name) : undefined,
+              value: tooltipValueFormat(
+                tooltipValueFormatter,
+                valueFormatter
+              )(val),
+              rows: [
+                span > 0 && {
+                  value: `${(((val - min) / span) * 100).toFixed(1)}%`,
+                  label: i18n.dataChart.tooltip.ofRange,
+                },
+              ],
+            },
+            theme
+          )
         },
       }),
     }
@@ -158,8 +181,10 @@ export function useGaugeChartOptions(
     color,
     showValue,
     valueFormatter,
+    tooltipValueFormatter,
     echartsOptions,
     theme,
+    i18n,
     size,
   ])
 }

--- a/packages/react/src/kits/F0DataChart/components/HeatmapChart/useHeatmapChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/HeatmapChart/useHeatmapChartOptions.ts
@@ -5,7 +5,12 @@ import { type RefObject, useMemo } from "react"
 import type { F0DataChartHeatmapProps } from "../../types"
 
 import { lerpColor, paletteColor } from "../../utils/colors"
-import { buildCategoryAxis, buildItemTooltip } from "../../utils/options"
+import {
+  buildCategoryAxis,
+  buildItemTooltip,
+  renderValueTooltip,
+  tooltipValueFormat,
+} from "../../utils/options"
 import type { ChartResponsiveSize } from "../../utils/responsive"
 import { useChartTheme } from "../../utils/useChartTheme"
 import { useContainerSize } from "../../utils/useContainerSize"
@@ -55,6 +60,7 @@ export function useHeatmapChartOptions(
     showLabels = false,
     showVisualMap = false,
     valueFormatter,
+    tooltipValueFormatter,
     echartsOptions,
   }: F0DataChartHeatmapProps,
   size: HeatmapChartSize
@@ -198,12 +204,18 @@ export function useHeatmapChartOptions(
             value?: [number, number, number]
           }
           const [xIdx, yIdx, val] = p.value ?? [0, 0, 0]
-          const xLabel = xCategories[xIdx] ?? ""
-          const yLabel = yCategories[yIdx] ?? ""
-          const formattedValue = valueFormatter
-            ? valueFormatter(val)
-            : String(val)
-          return `<div style="margin-bottom: 4px; font-weight: 500">${yLabel} · ${xLabel}</div><div>${String(p.marker ?? "")} <strong>${formattedValue}</strong></div>`
+          return renderValueTooltip(
+            {
+              marker: p.marker,
+              title: yCategories[yIdx] ?? "",
+              subtitle: xCategories[xIdx] ?? "",
+              value: tooltipValueFormat(
+                tooltipValueFormatter,
+                valueFormatter
+              )(val),
+            },
+            theme
+          )
         },
       }),
     }
@@ -222,6 +234,7 @@ export function useHeatmapChartOptions(
     showLabels,
     showVisualMap,
     valueFormatter,
+    tooltipValueFormatter,
     echartsOptions,
     theme,
     width,

--- a/packages/react/src/kits/F0DataChart/components/LineChart/useLineChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/LineChart/useLineChartOptions.ts
@@ -1,6 +1,8 @@
 import * as echarts from "echarts"
 import { type RefObject, useMemo } from "react"
 
+import { useI18n } from "@/lib/providers/i18n"
+
 import type {
   F0DataChartLineDataPoint,
   F0DataChartLineProps,
@@ -9,7 +11,12 @@ import type {
 } from "../../types"
 
 import { paletteColor, resolveChartColorToken } from "../../utils/colors"
-import { buildBaseChartOptions } from "../../utils/options"
+import {
+  buildBaseChartOptions,
+  deltaRow,
+  renderValueTooltip,
+  tooltipValueFormat,
+} from "../../utils/options"
 import type { ChartResponsiveSize } from "../../utils/responsive"
 import { useChartTheme } from "../../utils/useChartTheme"
 import { useContainerSize } from "../../utils/useContainerSize"
@@ -146,12 +153,14 @@ export function useLineChartOptions(
     showGrid = true,
     showLabels = false,
     valueFormatter,
+    tooltipValueFormatter,
     categoryFormatter,
     echartsOptions,
   }: F0DataChartLineProps,
   size: LineChartSize
 ): echarts.EChartsOption {
   const theme = useChartTheme(containerRef)
+  const i18n = useI18n()
   const { width: containerWidth, height: containerHeight } =
     useContainerSize(containerRef)
 
@@ -186,6 +195,68 @@ export function useLineChartOptions(
 
     const legendData = series.map((s) => s.name)
 
+    const formatTooltipValue = tooltipValueFormat(
+      tooltipValueFormatter,
+      valueFormatter
+    )
+
+    // Lines keep the axis trigger — a line is too thin to hover reliably —
+    // but render the shared tooltip card. With one series that is the same
+    // card every other chart type shows; with several, the category heads
+    // the card and each series becomes a row.
+    const tooltipFormatter = (params: unknown) => {
+      if (!Array.isArray(params) || params.length === 0) return ""
+      const points = params as {
+        seriesName?: string
+        axisValueLabel?: string
+        name?: string
+        value?: number
+        dataIndex?: number
+        marker?: string
+      }[]
+      const first = points[0]
+      const category = String(first?.axisValueLabel ?? first?.name ?? "")
+
+      if (points.length === 1 && first) {
+        const value = Number(first.value)
+        const dataIndex = first.dataIndex ?? 0
+        const hovered = series.find((s) => s.name === first.seriesName)
+        const previous =
+          dataIndex > 0 && hovered
+            ? getValue(hovered.data[dataIndex - 1])
+            : undefined
+        return renderValueTooltip(
+          {
+            marker: first.marker,
+            title: String(first.seriesName ?? ""),
+            subtitle: category,
+            value: formatTooltipValue(value),
+            rows: [
+              deltaRow(
+                value,
+                previous,
+                i18n.dataChart.tooltip.fromPrevious,
+                theme
+              ),
+            ],
+          },
+          theme
+        )
+      }
+
+      return renderValueTooltip(
+        {
+          title: category,
+          rows: points.map((point) => ({
+            marker: point.marker,
+            value: formatTooltipValue(Number(point.value)),
+            label: String(point.seriesName ?? ""),
+          })),
+        },
+        theme
+      )
+    }
+
     return buildBaseChartOptions({
       categories,
       theme,
@@ -197,6 +268,7 @@ export function useLineChartOptions(
       showCategoryAxis,
       showValueAxis,
       valueFormatter,
+      tooltipFormatter,
       categoryFormatter,
       echartsOptions,
       containerWidth,
@@ -213,9 +285,11 @@ export function useLineChartOptions(
     showGrid,
     showLabels,
     valueFormatter,
+    tooltipValueFormatter,
     categoryFormatter,
     echartsOptions,
     theme,
+    i18n,
     containerWidth,
     containerHeight,
     size,

--- a/packages/react/src/kits/F0DataChart/components/PieChart/usePieChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/PieChart/usePieChartOptions.ts
@@ -2,6 +2,8 @@ import type * as echarts from "echarts"
 
 import { type RefObject, useMemo } from "react"
 
+import { useI18n } from "@/lib/providers/i18n"
+
 import type { F0DataChartPieProps } from "../../types"
 
 import {
@@ -12,6 +14,8 @@ import {
   buildItemTooltip,
   buildLegend,
   DEFAULT_EMPHASIS,
+  renderValueTooltip,
+  tooltipValueFormat,
 } from "../../utils/options"
 import type { ChartResponsiveSize } from "../../utils/responsive"
 import { useChartTheme } from "../../utils/useChartTheme"
@@ -44,11 +48,13 @@ export function usePieChartOptions(
     showLabels = true,
     showPercentage = false,
     valueFormatter,
+    tooltipValueFormatter,
     echartsOptions,
   }: F0DataChartPieProps,
   size: PieChartSize
 ): echarts.EChartsOption {
   const theme = useChartTheme(containerRef)
+  const i18n = useI18n()
   const { width: containerWidth } = useContainerSize(containerRef)
 
   return useMemo(() => {
@@ -56,6 +62,11 @@ export function usePieChartOptions(
     const resolvedSeriesColor = series.color
       ? resolveChartColorToken(series.color)
       : undefined
+
+    const formatTooltipValue = tooltipValueFormat(
+      tooltipValueFormatter,
+      valueFormatter
+    )
 
     const responsive = resolveResponsiveDisplay(size)
     // The user prop can still force chrome OFF, but never ON at sm/md.
@@ -165,11 +176,25 @@ export function usePieChartOptions(
             percent?: number
           }
           const val = Number(p.value ?? 0)
-          const formattedValue = valueFormatter
-            ? valueFormatter(val)
-            : String(val)
-          const pct = (p.percent ?? 0).toFixed(1)
-          return `<div>${String(p.marker ?? "")} <strong>${String(p.name ?? "")}</strong></div><div style="margin-top: 2px">${formattedValue} (${pct}%)</div>`
+          const total = dataPoints.reduce((sum, point) => sum + point.value, 0)
+          return renderValueTooltip(
+            {
+              marker: p.marker,
+              title: String(p.name ?? ""),
+              value: formatTooltipValue(val),
+              rows: [
+                {
+                  value: `${(p.percent ?? 0).toFixed(1)}%`,
+                  label: i18n.dataChart.tooltip.ofTotal,
+                },
+                {
+                  value: formatTooltipValue(total),
+                  label: i18n.dataChart.tooltip.total,
+                },
+              ],
+            },
+            theme
+          )
         },
       }),
       emphasis: DEFAULT_EMPHASIS,
@@ -187,8 +212,10 @@ export function usePieChartOptions(
     showLabels,
     showPercentage,
     valueFormatter,
+    tooltipValueFormatter,
     echartsOptions,
     theme,
+    i18n,
     containerWidth,
     size,
   ])

--- a/packages/react/src/kits/F0DataChart/components/RadarChart/useRadarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/RadarChart/useRadarChartOptions.ts
@@ -7,8 +7,10 @@ import type { F0DataChartRadarProps } from "../../types"
 import { paletteColor, resolveChartColorToken } from "../../utils/colors"
 import {
   buildItemTooltip,
+  renderValueTooltip,
   buildLegend,
   DEFAULT_EMPHASIS,
+  tooltipValueFormat,
 } from "../../utils/options"
 import type { ChartResponsiveSize } from "../../utils/responsive"
 import { useChartTheme } from "../../utils/useChartTheme"
@@ -44,6 +46,7 @@ export function useRadarChartOptions(
     showLegend = true,
     showLabels = false,
     valueFormatter,
+    tooltipValueFormatter,
     echartsOptions,
   }: F0DataChartRadarProps,
   size: RadarChartSize
@@ -55,6 +58,10 @@ export function useRadarChartOptions(
     const responsive = resolveResponsiveDisplay(size)
     const effectiveShowLegend = responsive.showLegend && showLegend
     const { showIndicatorNames, nameWidth } = responsive
+    const formatTooltipValue = tooltipValueFormat(
+      tooltipValueFormatter,
+      valueFormatter
+    )
 
     // Auto-calculate max for each indicator if not provided
     const radarIndicators = indicators.map((ind, i) => {
@@ -158,17 +165,19 @@ export function useRadarChartOptions(
             value?: number[]
           }
           const values = p.value ?? []
-          const header = `<div style="margin-bottom: 4px">${String(p.marker ?? "")} <strong>${String(p.name ?? "")}</strong></div>`
-          const items = indicators
-            .map((ind, i) => {
-              const val = values[i] ?? 0
-              const formattedVal = valueFormatter
-                ? valueFormatter(val)
-                : String(val)
-              return `<div>${ind.name}: <strong>${formattedVal}</strong></div>`
-            })
-            .join("")
-          return `${header}${items}`
+          // A radar point carries every indicator at once, so there is no
+          // single headline value — the indicators are the rows.
+          return renderValueTooltip(
+            {
+              marker: p.marker,
+              title: String(p.name ?? ""),
+              rows: indicators.map((indicator, i) => ({
+                value: formatTooltipValue(values[i] ?? 0),
+                label: indicator.name,
+              })),
+            },
+            theme
+          )
         },
       }),
       emphasis: DEFAULT_EMPHASIS,
@@ -186,6 +195,7 @@ export function useRadarChartOptions(
     showLegend,
     showLabels,
     valueFormatter,
+    tooltipValueFormatter,
     echartsOptions,
     theme,
     containerSize,

--- a/packages/react/src/kits/F0DataChart/types.ts
+++ b/packages/react/src/kits/F0DataChart/types.ts
@@ -180,8 +180,10 @@ export interface F0DataChartBarProps extends F0DataChartBaseProps {
   labelFontSize?: number
   /**
    * Formatter for the values shown in the hover tooltip. Defaults to
-   * {@link F0DataChartBaseProps.valueFormatter}; set it to show precise values
-   * (e.g. "107,505") while the axis and labels stay compact ("107.5K").
+   * {@link F0DataChartBaseProps.valueFormatter}, so a unit or a currency on the
+   * axis reads the same on hover, then to a plain localized number. Set it when
+   * the axis has to stay compact ("107.5K") but the tooltip should be exact
+   * ("107,505").
    */
   tooltipValueFormatter?: (value: number) => string
 }
@@ -204,6 +206,14 @@ export interface F0DataChartLineProps extends F0DataChartBaseProps {
   showArea?: boolean
   /** Show data point dots on the lines. @default false */
   showDots?: boolean
+  /**
+   * Formatter for the values shown in the hover tooltip. Defaults to
+   * {@link F0DataChartBaseProps.valueFormatter}, so a unit or a currency on the
+   * axis reads the same on hover, then to a plain localized number. Set it when
+   * the axis has to stay compact ("107.5K") but the tooltip should be exact
+   * ("107,505").
+   */
+  tooltipValueFormatter?: (value: number) => string
 }
 
 // ---------------------------------------------------------------------------
@@ -270,6 +280,13 @@ export interface F0DataChartFunnelProps extends F0DataChartCommonProps {
   /** Format the value displayed in labels and tooltip */
   valueFormatter?: (value: number) => string
   /**
+   * Formatter for the value shown in the hover tooltip. Defaults to
+   * {@link valueFormatter}, so a unit or a currency on the labels reads the same
+   * on hover, then to a plain localized number. Set it when the labels have to
+   * stay compact ("107.5K") but the tooltip should be exact ("107,505").
+   */
+  tooltipValueFormatter?: (value: number) => string
+  /**
    * Map stage colors to their values using a gradient scale (light→dark).
    * When enabled, higher values get a more intense color. @default true
    */
@@ -331,6 +348,13 @@ export interface F0DataChartPieProps extends F0DataChartCommonProps {
   showPercentage?: boolean
   /** Format the value displayed in labels and tooltip */
   valueFormatter?: (value: number) => string
+  /**
+   * Formatter for the value shown in the hover tooltip. Defaults to
+   * {@link valueFormatter}, so a unit or a currency on the labels reads the same
+   * on hover, then to a plain localized number. Set it when the labels have to
+   * stay compact ("107.5K") but the tooltip should be exact ("107,505").
+   */
+  tooltipValueFormatter?: (value: number) => string
   /** Escape hatch: raw ECharts options merged (shallow) on top of the generated config */
   echartsOptions?: Partial<echarts.EChartsOption>
 }
@@ -385,6 +409,13 @@ export interface F0DataChartRadarProps extends F0DataChartCommonProps {
   showLabels?: boolean
   /** Format values in labels and tooltip */
   valueFormatter?: (value: number) => string
+  /**
+   * Formatter for the value shown in the hover tooltip. Defaults to
+   * {@link valueFormatter}, so a unit or a currency on the labels reads the same
+   * on hover, then to a plain localized number. Set it when the labels have to
+   * stay compact ("107.5K") but the tooltip should be exact ("107,505").
+   */
+  tooltipValueFormatter?: (value: number) => string
   /** Escape hatch: raw ECharts options merged (shallow) on top of the generated config */
   echartsOptions?: Partial<echarts.EChartsOption>
 }
@@ -415,6 +446,13 @@ export interface F0DataChartGaugeProps extends F0DataChartCommonProps {
   showValue?: boolean
   /** Format the value displayed */
   valueFormatter?: (value: number) => string
+  /**
+   * Formatter for the value shown in the hover tooltip. Defaults to
+   * {@link valueFormatter}, so a unit or a currency on the labels reads the same
+   * on hover, then to a plain localized number. Set it when the labels have to
+   * stay compact ("107.5K") but the tooltip should be exact ("107,505").
+   */
+  tooltipValueFormatter?: (value: number) => string
   /** Escape hatch: raw ECharts options merged (shallow) on top of the generated config */
   echartsOptions?: Partial<echarts.EChartsOption>
 }
@@ -449,6 +487,13 @@ export interface F0DataChartHeatmapProps extends F0DataChartCommonProps {
   showVisualMap?: boolean
   /** Format values in labels and tooltip */
   valueFormatter?: (value: number) => string
+  /**
+   * Formatter for the value shown in the hover tooltip. Defaults to
+   * {@link valueFormatter}, so a unit or a currency on the labels reads the same
+   * on hover, then to a plain localized number. Set it when the labels have to
+   * stay compact ("107.5K") but the tooltip should be exact ("107,505").
+   */
+  tooltipValueFormatter?: (value: number) => string
   /** Escape hatch: raw ECharts options merged (shallow) on top of the generated config */
   echartsOptions?: Partial<echarts.EChartsOption>
 }

--- a/packages/react/src/kits/F0DataChart/utils/options.ts
+++ b/packages/react/src/kits/F0DataChart/utils/options.ts
@@ -384,6 +384,130 @@ export function escapeTooltipText(value: unknown): string {
     .replace(/'/g, "&#039;")
 }
 
+// ---------------------------------------------------------------------------
+// Shared tooltip content renderer
+// ---------------------------------------------------------------------------
+
+/** Minimum tooltip width (px) so short values don't produce a cramped box. */
+const TOOLTIP_MIN_WIDTH = 130
+
+/** A context line below the headline value, e.g. "14.1% of total". */
+export interface ValueTooltipRow {
+  /** Emphasized leading text — a value, percentage, or delta. */
+  value: string
+  /** Trailing description, e.g. "of total", "target", "from previous". */
+  label: string
+  /** Color for the emphasized part. Defaults to the primary foreground. */
+  color?: string
+  /** ECharts' colored dot, for rows that stand for a series. Trusted HTML. */
+  marker?: string
+}
+
+export interface ValueTooltipContent {
+  /**
+   * ECharts' own colored dot. Trusted HTML generated per data point (it
+   * reflects per-point color overrides), so it is the one part rendered
+   * unescaped. Everything else is escaped.
+   */
+  marker?: string
+  /** Series, slice, or stage name. */
+  title?: string
+  /** Secondary line under the title — usually the category. */
+  subtitle?: string
+  /** Headline value, already formatted. Omit for tooltips that only list rows. */
+  value?: string
+  /** Context lines below the headline. Falsy entries are skipped. */
+  rows?: (ValueTooltipRow | undefined | false)[]
+}
+
+/**
+ * Render the shared F0 chart tooltip: colored dot + name, category, a large
+ * value, then context rows. Every chart type uses this so a tooltip reads the
+ * same regardless of which visualization the user is hovering.
+ */
+export function renderValueTooltip(
+  { marker, title, subtitle, value, rows = [] }: ValueTooltipContent,
+  theme: ChartTheme
+): string {
+  const secondary = `color: ${theme.colors.foregroundSecondary}; font-size: 12px`
+  const visibleRows = rows.filter((row): row is ValueTooltipRow => Boolean(row))
+
+  const html = [
+    title !== undefined
+      ? `<div style="font-weight: 600">${String(marker ?? "")}${escapeTooltipText(title)}</div>`
+      : "",
+    subtitle !== undefined
+      ? `<div style="${secondary}">${escapeTooltipText(subtitle)}</div>`
+      : "",
+    value !== undefined
+      ? `<div style="font-size: 20px; font-weight: 600; line-height: 1.2; margin-top: 6px">${escapeTooltipText(value)}</div>`
+      : "",
+    visibleRows.length > 0
+      ? `<div style="margin-top: 6px">${visibleRows
+          .map(
+            (row) =>
+              `<div style="${secondary}">${String(row.marker ?? "")}<strong style="color: ${row.color ?? theme.colors.foreground}">${escapeTooltipText(row.value)}</strong> ${escapeTooltipText(row.label)}</div>`
+          )
+          .join("")}</div>`
+      : "",
+  ].join("")
+
+  return `<div style="min-width: ${TOOLTIP_MIN_WIDTH}px">${html}</div>`
+}
+
+/**
+ * The formatter every chart type uses for the values in its tooltip.
+ *
+ * A tooltip reads the number the same way the rest of the chart does, so it
+ * takes `valueFormatter` — the one that writes the axis and the labels. That is
+ * what carries a unit across: a chart whose axis says "€46,390.86" would
+ * otherwise hover as "46390.863", dropping the currency and exposing raw
+ * float precision.
+ *
+ * `tooltipValueFormatter` overrides it, for the case where the axis has to stay
+ * compact ("125k") but the tooltip should be exact ("125,000"). With neither,
+ * the value falls back to a plain localized number.
+ */
+export function tooltipValueFormat(
+  tooltipValueFormatter?: (value: number) => string,
+  valueFormatter?: (value: number) => string
+): (value: number) => string {
+  const format = tooltipValueFormatter ?? valueFormatter
+  return (value) => (format ? format(value) : value.toLocaleString())
+}
+
+/**
+ * Build a tooltip dot in an explicit color, matching the one ECharts injects
+ * as `params.marker`. Needed where ECharts' own marker uses the palette rather
+ * than the color actually painted (e.g. the gauge arc).
+ */
+export function renderMarker(color: string): string {
+  // The color lands in a style attribute — keep it to CSS color syntax.
+  const safe = color.replace(/[^a-zA-Z0-9#(),.%\s/-]/g, "")
+  return `<span style="display:inline-block;margin-right:4px;border-radius:10px;width:10px;height:10px;background-color:${safe}"></span>`
+}
+
+/**
+ * Format a signed percentage delta ("+22.2%") and pick its semantic color.
+ * Returns `undefined` when there is nothing meaningful to compare against.
+ */
+export function deltaRow(
+  value: number,
+  previous: number | undefined,
+  label: string,
+  theme: ChartTheme
+): ValueTooltipRow | undefined {
+  if (previous === undefined || previous === 0 || !Number.isFinite(value)) {
+    return undefined
+  }
+  const change = ((value - previous) / Math.abs(previous)) * 100
+  return {
+    value: `${change >= 0 ? "+" : ""}${change.toFixed(1)}%`,
+    label,
+    color: change >= 0 ? theme.colors.positive : theme.colors.critical,
+  }
+}
+
 /**
  * Build a fully styled axis-triggered tooltip that optionally filters out
  * ghost series (e.g. target gradient bars).

--- a/packages/react/src/kits/F0DataChart/utils/responsive.ts
+++ b/packages/react/src/kits/F0DataChart/utils/responsive.ts
@@ -11,8 +11,8 @@
  * - `lg` (≥ 520px)  → dashboard cell: full chrome (legend + both axes).
  *
  * Each chart hook owns what it does with the size, so a family may deviate
- * where the layout demands it — horizontal bar charts keep their category
- * axis at `md`, since those labels name individual rows.
+ * where the layout demands it — bar charts keep their category axis at `md` in
+ * both orientations, since those labels are the subjects being compared.
  */
 export type ChartResponsiveSize = "sm" | "md" | "lg"
 

--- a/packages/react/src/kits/F0DataChart/utils/responsive.ts
+++ b/packages/react/src/kits/F0DataChart/utils/responsive.ts
@@ -9,6 +9,10 @@
  * - `sm` (< 220px)  → narrow chat card: minimal chrome.
  * - `md` (220–519px) → wide chat card: legend + value-side axes.
  * - `lg` (≥ 520px)  → dashboard cell: full chrome (legend + both axes).
+ *
+ * Each chart hook owns what it does with the size, so a family may deviate
+ * where the layout demands it — horizontal bar charts keep their category
+ * axis at `md`, since those labels name individual rows.
  */
 export type ChartResponsiveSize = "sm" | "md" | "lg"
 

--- a/packages/react/src/kits/F0DataChart/utils/theme.ts
+++ b/packages/react/src/kits/F0DataChart/utils/theme.ts
@@ -19,8 +19,15 @@ export interface ChartThemeColors {
   border: string
   /** Tooltip background color (CSS rgba string) */
   tooltipBackground: string
-  /** Chart container background — used when chart needs to know its own bg */
+  /** Page-level background token for the active mode */
   background: string
+  /**
+   * The color actually painted behind the chart — the nearest ancestor with a
+   * non-transparent background, falling back to {@link background}. Use this
+   * when a chart needs to blend into its own surface (a tinted card, a modal)
+   * rather than into the page.
+   */
+  containerBackground: string
 }
 
 /** Tooltip visual configuration */
@@ -124,6 +131,45 @@ function isDarkMode(element?: Element | null): boolean {
   return target.closest(".dark") !== null
 }
 
+/** `transparent`, `rgba(…, 0)`, or unset — this element paints no background. */
+function paintsNoBackground(color: string): boolean {
+  const value = color.trim()
+  if (value === "" || value === "transparent") return true
+  const alpha = /^rgba\(.*,\s*([\d.]+)\s*\)$/.exec(value)?.[1]
+  return alpha !== undefined && Number.parseFloat(alpha) === 0
+}
+
+/**
+ * The first non-transparent background color at or above `element`.
+ *
+ * Charts that paint their own background — the hairline between stacked bar
+ * segments, for one — need the surface they actually sit on, not the page
+ * token: a chart inside a tinted card, a modal, or a fullscreen overlay has a
+ * different backdrop from `<body>`.
+ *
+ * Falls back to `fallback` when nothing in the chain paints a background, or
+ * when there is no DOM (SSR). A translucent ancestor is taken at face value
+ * rather than blended with what sits beneath it — close enough for a hairline.
+ */
+function resolveContainerBackground(
+  element: Element | null | undefined,
+  fallback: string
+): string {
+  if (typeof window === "undefined" || !element) return fallback
+
+  let current: Element | null = element
+  while (current) {
+    const color = getComputedStyle(current)
+      .getPropertyValue("background-color")
+      .trim()
+    if (!paintsNoBackground(color)) {
+      return color
+    }
+    current = current.parentElement
+  }
+  return fallback
+}
+
 // ---------------------------------------------------------------------------
 // Theme resolver
 // ---------------------------------------------------------------------------
@@ -146,6 +192,9 @@ function isDarkMode(element?: Element | null): boolean {
  */
 export function resolveChartTheme(element?: Element | null): ChartTheme {
   const dark = isDarkMode(element)
+  const background = dark
+    ? chartColor(baseColors.grey[100])
+    : chartColor(baseColors.white[100])
 
   const colors: ChartThemeColors = {
     foreground: resolveCssColor(
@@ -176,9 +225,8 @@ export function resolveChartTheme(element?: Element | null): ChartTheme {
     tooltipBackground: dark
       ? DARK_TOOLTIP.background
       : LIGHT_TOOLTIP.background,
-    background: dark
-      ? chartColor(baseColors.grey[100])
-      : chartColor(baseColors.white[100]),
+    background,
+    containerBackground: resolveContainerBackground(element, background),
   }
 
   return {

--- a/packages/react/src/kits/F0DataChart/utils/theme.ts
+++ b/packages/react/src/kits/F0DataChart/utils/theme.ts
@@ -32,6 +32,14 @@ export interface ChartThemeColors {
    * `containerBackground ?? background`.
    */
   containerBackground?: string
+  /**
+   * Positive delta text (e.g. tooltip "+x% from previous"). Resolves from
+   * --positive-70. Optional so a hand-built theme stays valid — tooltip rows
+   * fall back to `foreground` when it is absent.
+   */
+  positive?: string
+  /** Negative delta text. Resolves from --critical-70. Optional, as `positive`. */
+  critical?: string
 }
 
 /** Tooltip visual configuration */
@@ -231,6 +239,8 @@ export function resolveChartTheme(element?: Element | null): ChartTheme {
       : LIGHT_TOOLTIP.background,
     background,
     containerBackground: resolveContainerBackground(element, background),
+    positive: resolveCssColor("--positive-70", baseColors.grass[70], element),
+    critical: resolveCssColor("--critical-70", baseColors.red[70], element),
   }
 
   return {

--- a/packages/react/src/kits/F0DataChart/utils/theme.ts
+++ b/packages/react/src/kits/F0DataChart/utils/theme.ts
@@ -26,8 +26,12 @@ export interface ChartThemeColors {
    * non-transparent background, falling back to {@link background}. Use this
    * when a chart needs to blend into its own surface (a tinted card, a modal)
    * rather than into the page.
+   *
+   * Always set by {@link resolveChartTheme}; optional only so that themes built
+   * by hand (test fixtures, consumer overrides) keep compiling — read it as
+   * `containerBackground ?? background`.
    */
-  containerBackground: string
+  containerBackground?: string
 }
 
 /** Tooltip visual configuration */

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -672,6 +672,14 @@ export const defaultTranslations = {
       title: "No data available",
       description: "Try a different date or fewer filters",
     },
+    tooltip: {
+      ofTotal: "of total",
+      total: "total",
+      target: "target",
+      ofRange: "of range",
+      fromPrevious: "from previous",
+      fromStage: "from {{stage}}",
+    },
   },
   progressSeries: {
     noData: "No data",

--- a/packages/react/src/lib/providers/i18n/i18n-provider.spec.tsx
+++ b/packages/react/src/lib/providers/i18n/i18n-provider.spec.tsx
@@ -56,6 +56,79 @@ describe("I18nProvider", () => {
     expect(screen.getByTestId("translation")).toHaveTextContent("Desar")
   })
 
+  // A dictionary written against an older f0 does not know keys added since.
+  // Components read many of them by property access, so the gaps have to close
+  // with English rather than surface as `undefined` (or throw on a subtree).
+  it("fills keys the consumer's dictionary is missing with the defaults", () => {
+    const stale = {
+      ...defaultTranslations,
+      actions: { ...defaultTranslations.actions, save: "Desar" },
+      dataChart: {
+        ...defaultTranslations.dataChart,
+        // An older dictionary predates the whole tooltip subtree.
+        tooltip: undefined,
+      },
+    } as unknown as TranslationsType
+
+    function ReadsNewKeys() {
+      const i18n = useI18n()
+      return (
+        <>
+          <div data-testid="overridden">{i18n.actions.save}</div>
+          <div data-testid="missing-subtree">
+            {i18n.dataChart.tooltip.ofTotal}
+          </div>
+          <div data-testid="via-t">
+            {i18n.t("dataChart.tooltip.fromStage", { stage: "Applied" })}
+          </div>
+        </>
+      )
+    }
+
+    render(
+      <I18nProvider translations={stale}>
+        <ReadsNewKeys />
+      </I18nProvider>
+    )
+
+    expect(screen.getByTestId("overridden")).toHaveTextContent("Desar")
+    expect(screen.getByTestId("missing-subtree")).toHaveTextContent(
+      defaultTranslations.dataChart.tooltip.ofTotal
+    )
+    expect(screen.getByTestId("via-t")).toHaveTextContent("from Applied")
+  })
+
+  it("keeps a partially translated subtree and defaults only its gaps", () => {
+    const partial = {
+      ...defaultTranslations,
+      dataChart: {
+        ...defaultTranslations.dataChart,
+        tooltip: { ofTotal: "del total" },
+      },
+    } as unknown as TranslationsType
+
+    function ReadsTooltipKeys() {
+      const i18n = useI18n()
+      return (
+        <>
+          <div data-testid="translated">{i18n.dataChart.tooltip.ofTotal}</div>
+          <div data-testid="defaulted">{i18n.dataChart.tooltip.target}</div>
+        </>
+      )
+    }
+
+    render(
+      <I18nProvider translations={partial}>
+        <ReadsTooltipKeys />
+      </I18nProvider>
+    )
+
+    expect(screen.getByTestId("translated")).toHaveTextContent("del total")
+    expect(screen.getByTestId("defaulted")).toHaveTextContent(
+      defaultTranslations.dataChart.tooltip.target
+    )
+  })
+
   it("falls back to default translations when used outside a provider", () => {
     // No provider: the hook must not throw — it degrades to the built-in
     // (English) defaults so the subtree still renders.

--- a/packages/react/src/lib/providers/i18n/i18n-provider.tsx
+++ b/packages/react/src/lib/providers/i18n/i18n-provider.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { createContext, ReactNode, useContext } from "react"
+import { createContext, ReactNode, useContext, useMemo } from "react"
 
 import {
   defaultTranslations,
@@ -37,10 +37,49 @@ const getKey = (
   return typeof current === "string" ? current : undefined
 }
 
+const isSubtree = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+/**
+ * Fill the gaps in a consumer's dictionary from the built-in (English)
+ * defaults, recursively.
+ *
+ * f0 gains translation keys as it gains features, and components read many of
+ * them by property access (`i18n.dataChart.tooltip.total`) rather than through
+ * `t`, so a dictionary written against an older version would otherwise render
+ * `undefined` — or throw on a whole missing subtree — instead of degrading to
+ * English. Arrays and non-objects are treated as leaves: the consumer's value
+ * wins outright.
+ */
+const withDefaults = <T extends Record<string, unknown>>(
+  defaults: T,
+  overrides: Record<string, unknown>
+): T => {
+  const merged: Record<string, unknown> = { ...defaults }
+
+  for (const [key, value] of Object.entries(overrides)) {
+    // An explicit `undefined` means "not translated", not "erase the default".
+    if (value === undefined) continue
+
+    const fallback = merged[key]
+    merged[key] =
+      isSubtree(value) && isSubtree(fallback)
+        ? withDefaults(fallback, value)
+        : value
+  }
+
+  return merged as T
+}
+
 export function I18nProvider({
   children,
   translations,
 }: I18nProviderProps): JSX.Element {
+  const resolved = useMemo(
+    () => withDefaults(defaultTranslations, translations),
+    [translations]
+  )
+
   /*
    * Create a function that returns a translation for a given key and replaces the arguments.
    * If the key is not found, it will return undefined.
@@ -50,7 +89,7 @@ export function I18nProvider({
     key: TranslationKey,
     args: Record<string, string | number> = {}
   ) => {
-    let translation = getKey(key, translations)
+    let translation = getKey(key, resolved)
     if (translation === undefined) {
       console.warn(`Translation key ${key} not found`)
       return key
@@ -63,7 +102,7 @@ export function I18nProvider({
     return translation
   }
   return (
-    <I18nContext.Provider value={{ ...translations, t }}>
+    <I18nContext.Provider value={{ ...resolved, t }}>
       {children}
     </I18nContext.Provider>
   )

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/chartLabelDefaults.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/chartLabelDefaults.test.ts
@@ -97,3 +97,60 @@ describe("buildChartProps — bar label default (transform path)", () => {
     ).toBeUndefined()
   })
 })
+
+// ---------------------------------------------------------------------------
+// A dashboard chart can format its tooltip separately from its axis — the pair
+// exists so the axis can compact ("€60K") while the tooltip stays exact
+// ("€46,390.86"). Both routes into the props have to carry it.
+// ---------------------------------------------------------------------------
+
+describe("buildChartProps — tooltipValueFormatter", () => {
+  const axis = (value: number) => `€${Math.round(value / 1000)}K`
+  const exact = (value: number) => `€${value.toLocaleString("en-US")}`
+
+  it("passes both formatters through on the native path", () => {
+    const props = buildChartProps(
+      chartItem({
+        type: "bar",
+        valueFormatter: axis,
+        tooltipValueFormatter: exact,
+      }),
+      barData
+    ) as {
+      valueFormatter?: (value: number) => string
+      tooltipValueFormatter?: (value: number) => string
+    }
+
+    expect(props.valueFormatter?.(60000)).toBe("€60K")
+    expect(props.tooltipValueFormatter?.(46390.8632)).toBe("€46,390.863")
+  })
+
+  it("keeps both across a cross-type transform", () => {
+    const props = buildChartProps(
+      chartItem({
+        type: "bar",
+        valueFormatter: axis,
+        tooltipValueFormatter: exact,
+      }),
+      barData,
+      "line"
+    ) as {
+      valueFormatter?: (value: number) => string
+      tooltipValueFormatter?: (value: number) => string
+    }
+
+    expect(props.valueFormatter?.(60000)).toBe("€60K")
+    expect(props.tooltipValueFormatter?.(60000)).toBe("€60,000")
+  })
+
+  it("leaves the tooltip formatter unset when the config has none", () => {
+    const props = buildChartProps(
+      chartItem({ type: "bar", valueFormatter: axis }),
+      barData,
+      "line"
+    ) as { tooltipValueFormatter?: (value: number) => string }
+
+    // Unset means F0DataChart falls back to `valueFormatter` itself.
+    expect(props.tooltipValueFormatter).toBeUndefined()
+  })
+})

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/chartLabelDefaults.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/chartLabelDefaults.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest"
+
+import { buildChartProps } from "../components/ChartItem/ChartItem"
+import type {
+  DashboardChartConfig,
+  DashboardChartData,
+  DashboardChartItem,
+} from "../types"
+import { defaultChartConfig } from "../utils/chartDataAdapter"
+
+// ---------------------------------------------------------------------------
+// Dashboard bar charts show value labels by default. These cover both routes
+// into that default — the native pass-through and the cross-type transform —
+// plus the rule that an explicitly-set `showLabels` always wins.
+// ---------------------------------------------------------------------------
+
+const barData: DashboardChartData = {
+  categories: ["A", "B"],
+  series: [{ name: "X", data: [1, 2] }],
+}
+
+function chartItem(chart: DashboardChartConfig): DashboardChartItem {
+  return {
+    id: "item",
+    title: "Item",
+    type: "chart",
+    chart,
+    fetchData: () => Promise.resolve(barData),
+  }
+}
+
+/** `showLabels` as the built props expose it — `undefined` means "not set" */
+function showLabelsOf(
+  chart: DashboardChartConfig,
+  overrideType?: DashboardChartConfig["type"]
+) {
+  const props = buildChartProps(chartItem(chart), barData, overrideType) as {
+    showLabels?: boolean
+  }
+  return props.showLabels
+}
+
+describe("defaultChartConfig", () => {
+  it("turns labels on for bar charts", () => {
+    expect(defaultChartConfig("bar")).toMatchObject({
+      type: "bar",
+      showLabels: true,
+    })
+  })
+
+  it("leaves other chart types' label defaults untouched", () => {
+    expect(defaultChartConfig("line")).not.toHaveProperty("showLabels")
+    expect(defaultChartConfig("heatmap")).not.toHaveProperty("showLabels")
+  })
+})
+
+describe("buildChartProps — bar label default (native path)", () => {
+  it("shows labels when the item config says nothing", () => {
+    expect(showLabelsOf({ type: "bar" })).toBe(true)
+  })
+
+  it("lets an explicit false win over the default", () => {
+    expect(showLabelsOf({ type: "bar", showLabels: false })).toBe(false)
+  })
+
+  it("treats an explicitly-undefined showLabels as unset, not as off", () => {
+    // A caller spreading an optional value — `{ showLabels: cfg.showLabels }` —
+    // hands us the key with an `undefined` value. It must not beat the default.
+    expect(showLabelsOf({ type: "bar", showLabels: undefined })).toBe(true)
+  })
+
+  it("does not add labels to line charts", () => {
+    expect(showLabelsOf({ type: "line" })).toBeUndefined()
+  })
+})
+
+describe("buildChartProps — bar label default (transform path)", () => {
+  it("shows labels when a line chart is transformed to bar", () => {
+    expect(showLabelsOf({ type: "line" }, "bar")).toBe(true)
+  })
+
+  it("carries an explicit false from the source config into the bar target", () => {
+    expect(showLabelsOf({ type: "line", showLabels: false }, "bar")).toBe(false)
+  })
+
+  it("ignores an explicitly-undefined showLabels on the source config", () => {
+    expect(showLabelsOf({ type: "line", showLabels: undefined }, "bar")).toBe(
+      true
+    )
+  })
+
+  it("does not drag a source config's labels onto a non-bar target", () => {
+    // Pie defaults `showLabels` to true. Transforming it to a line must use the
+    // line default, not inherit the pie's.
+    expect(
+      showLabelsOf({ type: "pie", showLabels: true }, "line")
+    ).toBeUndefined()
+  })
+})

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -161,8 +161,10 @@ function chartSkeleton(config: DashboardChartConfig) {
 /**
  * Build F0DataChart props. When `overrideType` differs from the item's
  * original chart type, the data is converted via the canonical adapter.
+ *
+ * @internal Exported for unit tests — not part of the package's public API.
  */
-function buildChartProps(
+export function buildChartProps(
   item: DashboardChartItem,
   data: DashboardChartData,
   overrideType?: DashboardChartConfig["type"],
@@ -196,7 +198,15 @@ function buildChartProps(
   if ("showLegend" in item.chart) {
     shared.showLegend = item.chart.showLegend
   }
-  if ("showLabels" in item.chart) {
+  // Only bar targets inherit the source config's `showLabels`. Other types keep
+  // their own default, so transforming a pie (labels on by default) into a line
+  // doesn't drag labels along. `undefined` is not an explicit value — letting it
+  // through would clobber the target's default with "unset".
+  if (
+    targetType === "bar" &&
+    "showLabels" in item.chart &&
+    item.chart.showLabels !== undefined
+  ) {
     shared.showLabels = item.chart.showLabels
   }
 
@@ -312,10 +322,13 @@ function buildNativeChartProps(
         categories = adapted.categories ?? []
       }
       return {
-        // Dashboard bar charts show value labels by default; an explicit
-        // `showLabels` in the item config still wins.
-        ...(chart.type === "bar" ? { showLabels: true } : {}),
         ...chart,
+        // Dashboard bar charts show value labels by default. Resolved after the
+        // spread rather than before it: `...chart` carries `showLabels` even
+        // when it is explicitly `undefined`, which would overwrite the default.
+        ...(chart.type === "bar"
+          ? { showLabels: chart.showLabels ?? true }
+          : {}),
         categories,
         series,
       } as F0DataChartProps

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -196,6 +196,9 @@ function buildChartProps(
   if ("showLegend" in item.chart) {
     shared.showLegend = item.chart.showLegend
   }
+  if ("showLabels" in item.chart) {
+    shared.showLabels = item.chart.showLabels
+  }
 
   // Build the final props by merging config + adapted data
   switch (targetType) {
@@ -308,7 +311,14 @@ function buildNativeChartProps(
         series = adapted.series
         categories = adapted.categories ?? []
       }
-      return { ...chart, categories, series } as F0DataChartProps
+      return {
+        // Dashboard bar charts show value labels by default; an explicit
+        // `showLabels` in the item config still wins.
+        ...(chart.type === "bar" ? { showLabels: true } : {}),
+        ...chart,
+        categories,
+        series,
+      } as F0DataChartProps
     }
   }
 }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -195,6 +195,12 @@ export function buildChartProps(
   if ("valueFormatter" in item.chart && item.chart.valueFormatter) {
     shared.valueFormatter = item.chart.valueFormatter
   }
+  if (
+    "tooltipValueFormatter" in item.chart &&
+    item.chart.tooltipValueFormatter
+  ) {
+    shared.tooltipValueFormatter = item.chart.tooltipValueFormatter
+  }
   if ("showLegend" in item.chart) {
     shared.showLegend = item.chart.showLegend
   }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
@@ -23,7 +23,10 @@ interface ChartConfigBase {
   showLegend?: boolean
   /** Show background grid lines. @default true */
   showGrid?: boolean
-  /** Show value labels on each data point. @default false */
+  /**
+   * Show value labels on each data point.
+   * @default true for bar charts, false otherwise
+   */
   showLabels?: boolean
   /** Format the value axis tick labels */
   valueFormatter?: (value: number) => string

--- a/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
@@ -30,6 +30,12 @@ interface ChartConfigBase {
   showLabels?: boolean
   /** Format the value axis tick labels */
   valueFormatter?: (value: number) => string
+  /**
+   * Format the value shown in the hover tooltip. Defaults to
+   * {@link valueFormatter}; set it when the axis and labels must stay compact
+   * while the tooltip carries the exact figure.
+   */
+  tooltipValueFormatter?: (value: number) => string
   /** Format category axis tick labels */
   categoryFormatter?: (value: string) => string
 }
@@ -72,6 +78,12 @@ export interface FunnelChartConfig {
   colorScale?: boolean
   /** Format the value displayed in labels and tooltip */
   valueFormatter?: (value: number) => string
+  /**
+   * Format the value shown in the hover tooltip. Defaults to
+   * {@link valueFormatter}; set it when the axis and labels must stay compact
+   * while the tooltip carries the exact figure.
+   */
+  tooltipValueFormatter?: (value: number) => string
 }
 
 export interface PieChartConfig {
@@ -86,6 +98,12 @@ export interface PieChartConfig {
   showPercentage?: boolean
   /** Format the value displayed in labels and tooltip */
   valueFormatter?: (value: number) => string
+  /**
+   * Format the value shown in the hover tooltip. Defaults to
+   * {@link valueFormatter}; set it when the axis and labels must stay compact
+   * while the tooltip carries the exact figure.
+   */
+  tooltipValueFormatter?: (value: number) => string
 }
 
 export interface RadarChartConfig {
@@ -98,6 +116,12 @@ export interface RadarChartConfig {
   showLabels?: boolean
   /** Format the value displayed in labels and tooltip */
   valueFormatter?: (value: number) => string
+  /**
+   * Format the value shown in the hover tooltip. Defaults to
+   * {@link valueFormatter}; set it when the axis and labels must stay compact
+   * while the tooltip carries the exact figure.
+   */
+  tooltipValueFormatter?: (value: number) => string
 }
 
 export interface GaugeChartConfig {
@@ -112,6 +136,12 @@ export interface GaugeChartConfig {
   showValue?: boolean
   /** Format the value displayed inside the gauge */
   valueFormatter?: (value: number) => string
+  /**
+   * Format the value shown in the hover tooltip. Defaults to
+   * {@link valueFormatter}; set it when the axis and labels must stay compact
+   * while the tooltip carries the exact figure.
+   */
+  tooltipValueFormatter?: (value: number) => string
 }
 
 export interface HeatmapChartConfig {
@@ -126,6 +156,12 @@ export interface HeatmapChartConfig {
   showVisualMap?: boolean
   /** Format the value displayed in cells and tooltip */
   valueFormatter?: (value: number) => string
+  /**
+   * Format the value shown in the hover tooltip. Defaults to
+   * {@link valueFormatter}; set it when the axis and labels must stay compact
+   * while the tooltip carries the exact figure.
+   */
+  tooltipValueFormatter?: (value: number) => string
 }
 
 /**

--- a/packages/react/src/patterns/F0AnalyticsDashboard/utils/chartDataAdapter.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/utils/chartDataAdapter.ts
@@ -396,7 +396,7 @@ export function defaultChartConfig(
 ): DashboardChartConfig {
   switch (type) {
     case "bar":
-      return { type: "bar", orientation: "vertical" }
+      return { type: "bar", orientation: "vertical", showLabels: true }
     case "line":
       return { type: "line", lineType: "linear", showArea: true }
     case "funnel":


### PR DESCRIPTION
## Description

Two related bar-chart changes. Bar charts inside `F0AnalyticsDashboard` rendered without value labels because `F0DataChart`'s `showLabels` defaults to `false`, so dashboard tiles needed per-item config to show readable values — labels are now the dashboard default. On top of that, stacked bars get visual polish: a hairline gap between segments, a hover highlight that isolates one series across every bar, and consistently white inside-labels.

**One deliberate behaviour change rides along**, called out separately below because it is a responsive-contract change rather than polish: horizontal bar charts now keep their category axis at the `md` breakpoint (220–519px), where the shared matrix previously hid it for every chart family.

## Screenshots (if applicable)

Dashboard bar charts (vertical, stacked, horizontal) now show their value labels. Stacked segments are separated by a 0.5px hairline in the colour of the surface the chart sits on, and hovering a segment fades every other series down to 40% opacity over 500ms.

https://github.com/user-attachments/assets/16e15e1e-6358-469d-8d45-1d7c50f24a24

Showing labels on MD breakpoints
**Before**
<img width="1512" height="754" alt="md-category-axis-BEFORE" src="https://github.com/user-attachments/assets/813589c7-d2ef-4c32-aa61-f13f7bb39086" />
**After**
<img width="1512" height="754" alt="md-category-axis-AFTER" src="https://github.com/user-attachments/assets/80acaaa1-2502-42c5-8f09-9cb3b3e31d3b" />

## Implementation details

- feat: default `showLabels: true` for bar charts in `buildNativeChartProps`, spread before the item config so explicit values win
- feat: include `showLabels: true` in `defaultChartConfig("bar")` so charts transformed to bar via the chart-type menu also get labels
- feat: preserve an explicitly-set `showLabels` across chart-type transforms, mirroring the existing `showLegend` handling
- feat: separate stacked segments with a `0.5px` border in the container's own background colour

  <details>
  <summary>Why a border rather than a gap?</summary>

  ECharts 6 has no native spacing between stacked segments — `barGap` and
  `barCategoryGap` only control space *between* bars, and the stack mixin
  exposes just `stack` / `stackStrategy` / `stackOrder`. A border in the
  container colour is the standard workaround. Both adjacent segments stroke
  the shared edge and canvas strokes are centred on the path, so the two cover
  the same band rather than adding to it: the separation equals the border
  width, not twice it. `0.5` is deliberate — a hairline at 1x, a crisp single
  device pixel at 2x.
  </details>

- feat: highlight the hovered series across all bars via `emphasis.focus: "series"`, dimming other series to 40% opacity, with a 500ms `stateAnimation` fade

  <details>
  <summary>Why the animation flags change</summary>

  `stateAnimation` is only honoured at the option root — the series-level one
  in the ECharts types is ignored for state transitions. It also requires the
  animation engine to be on, while the base options set `animation: false` to
  skip entrance animations. Stacked charts therefore re-enable animation with
  zero-duration entrance and update animations, so only the blur fade animates.
  </details>

- feat: always render inside-bar value labels in white

  <details>
  <summary>Contrast note</summary>

  This replaces a per-fill luminance check that flipped to black on lighter
  colours, which made one bar look like two label styles. Every selectable
  series colour is a shade-50 chromatic token, so white stays legible, but on
  the two lightest (`flubber`, `yellow`) it is below WCAG AA — a deliberate
  design call in favour of consistency.
  </details>

## Accepted behaviour change: horizontal category axis at `md`

Not label polish — a deliberate change to the shared responsive contract, kept in this PR because it is what makes labelled horizontal bars legible in a chat card. Reviewed on its own terms:

**What changed.** `resolveResponsiveDisplay` returned `showCategoryAxis: size === "lg"` for every bar chart, matching `LineChart`. It now also returns `true` for horizontal bars at `md`:

```ts
showCategoryAxis: size === "lg" || (size === "md" && !isVertical)
```

**Why.** A horizontal category label names the single row beside it. Hiding them leaves a stack of anonymous bars that the value axis alone can't explain — the reader sees four lengths and no subjects. Vertical bars keep the old rule: their categories run along the bottom competing with each other, and they crowd well before the plot runs out of room.

**What it costs.** Category labels take `min(80, width * 0.2)` (`yAxisMaxLabelWidth`), so a horizontal chart in the `md` band gives up 44px at 220px and 80px from 400px up — bars up to 20% shorter than before, in the same container. `md` is the wide-chat-card size, so this lands on existing consumers, not only the dashboard tiles this PR is about. That is the trade-off being accepted: naming the rows is worth a fifth of the bar length.

**Evidence.** The screenshots below are the new `CategoryAxisBoundaries` story rendered twice — once with the deviation reverted (before) and once as it ships (after) — so the width cost is visible rather than asserted:

| width | before | after |
| --- | --- | --- |
| 219px (`sm`) | anonymous bars | unchanged — `sm` drops all chrome |
| 220px (first `md`) | anonymous bars | row labels, truncated to the 44px cap; bars ~20% shorter |
| 519px (last `md`) | anonymous bars | full row labels; bars ~80px shorter |
| 520px (first `lg`) | full row labels | unchanged — `lg` always showed the axis |

The vertical row in each shot is the control: identical before and after, gaining its axis only at 520px.

Chromatic can't supply that pair on its own — `CategoryAxisBoundaries` is a new story, so it has no baseline and registers as *new* rather than as a diff. What it buys is forward coverage: this band previously had no image coverage at all, since the responsive matrix stories render 180/320/720 and aren't snapshotted. Boundary unit tests pin the flip to the exact pixel in both orientations, so a later breakpoint tweak fails loudly instead of silently reflowing every horizontal chart in a chat card.

## Review fixes

Applied after review — see the `fix(F0DataChart)` commits.

- fix: an explicitly-`undefined` `showLabels` no longer beats the bar default (`...chart` carries the key even when unset, so the default is resolved after the spread)
- fix: only bar targets inherit `showLabels` across a chart-type transform — pie and funnel default it to `true`, so transforming one to a line was showing labels the line default keeps off
- fix: the stacked animation block defers to consumer-provided `echartsOptions` instead of overwriting them
- fix: the target "ghost" series fades to the same 40% as its stack rather than the ECharts default
- fix: the separator uses the nearest painted ancestor background (`containerBackground`) instead of the page token, so charts on tinted cards, modals and fullscreen overlays blend correctly
- fix: the cross-fade honours `prefers-reduced-motion` via `useReducedMotion()` — the duration drops to 0, so the hover highlight still isolates the series but arrives instantly. The preference is the user's rather than the consumer's, so it also flattens an explicitly-provided `stateAnimation` duration
- test: the `md` category-axis deviation is now declared as an accepted behaviour change (section above) with boundary assertions at 219/220 and 519/520 for both orientations, driven off `SM_MAX_WIDTH` / `MD_MAX_WIDTH` rather than hardcoded widths, plus a Chromatic-snapshotted `CategoryAxisBoundaries` story
- test: 36 new unit tests across `BarChart`, the chart theme, and the dashboard label defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)


