### PR TITLE
feat(F0DataChart): unify the tooltip across every chart type

### DIFF
--- a/packages/react/src/kits/F0DataChart/__stories__/F0DataChart.mdx
+++ b/packages/react/src/kits/F0DataChart/__stories__/F0DataChart.mdx
@@ -118,7 +118,7 @@ Bar labels use `valueFormatter`, with configurable size and collision handling:
 
 ### Precise tooltip values
 
-Tooltips already show the full number while the axis and labels stay compact. Use `tooltipValueFormatter` to control that number yourself — a fixed locale, a unit, or a currency the compact axis format leaves out. The Customization section below covers how the two formatters divide the work.
+Tooltips use `valueFormatter` like the rest of the chart. Add `tooltipValueFormatter` when the axis and labels must stay compact but the tooltip should carry the exact figure. The Customization section below covers how the two divide the work.
 
 <Canvas of={BarStories.PreciseTooltip} />
 
@@ -319,22 +319,21 @@ import {
 
 ### Value & Category Formatters
 
-Two formatters, split by where the number is drawn:
+Every chart type takes `valueFormatter` for its numbers — axis ticks, labels, and the hover tooltip. One formatter is all most charts need: the tooltip reads the value the way the rest of the chart does, so a unit or a currency can't go missing on hover. Bar and line charts also support `categoryFormatter` for axis labels.
 
-- **`valueFormatter`** — axes and labels, the places where space is tight, so it is usually a compact format. Bar and line charts also support `categoryFormatter` for axis labels.
-- **`tooltipValueFormatter`** — the hover tooltip only.
-
-Every chart type supports both, and the rule is the same on all seven: **a tooltip shows the full localized number** (`4,000,000`, not `4M €`), because the tooltip is where the exact figure belongs. `valueFormatter` never reaches the tooltip, so a unit that lived in it needs `tooltipValueFormatter` to come back:
+`tooltipValueFormatter` overrides it for the tooltip alone. Reach for it when the axis has to stay compact but the tooltip should be exact:
 
 ```tsx
 <F0DataChart
   type="line"
-  valueFormatter={(v) => `${v / 1_000_000}M €`} // axis: "4M €"
-  tooltipValueFormatter={(v) => `${v.toLocaleString()} €`} // tooltip: "4,000,000 €"
+  valueFormatter={(v) => `€${(v / 1_000_000).toFixed(1)}M`} // axis: "€4.0M"
+  tooltipValueFormatter={(v) => `€${v.toLocaleString()}`} // tooltip: "€4,000,000"
   categoryFormatter={(v) => v.slice(0, 3)}
   // ...
 />
 ```
+
+With neither, values render as a plain localized number.
 
 <Canvas of={LineStories.CustomFormatters} />
 

--- a/packages/react/src/kits/F0DataChart/__stories__/F0DataChart.mdx
+++ b/packages/react/src/kits/F0DataChart/__stories__/F0DataChart.mdx
@@ -118,7 +118,7 @@ Bar labels use `valueFormatter`, with configurable size and collision handling:
 
 ### Precise tooltip values
 
-Use `tooltipValueFormatter` when the axis and labels should stay compact while the hover tooltip retains the precise value.
+Tooltips already show the full number while the axis and labels stay compact. Use `tooltipValueFormatter` to control that number yourself — a fixed locale, a unit, or a currency the compact axis format leaves out. The Customization section below covers how the two formatters divide the work.
 
 <Canvas of={BarStories.PreciseTooltip} />
 
@@ -319,16 +319,24 @@ import {
 
 ### Value & Category Formatters
 
-All chart types support `valueFormatter` to customize how numbers are displayed in axes, labels, and tooltips. Bar and line charts also support `categoryFormatter` for axis labels.
+Two formatters, split by where the number is drawn:
+
+- **`valueFormatter`** — axes and labels, the places where space is tight, so it is usually a compact format. Bar and line charts also support `categoryFormatter` for axis labels.
+- **`tooltipValueFormatter`** — the hover tooltip only.
+
+Every chart type supports both, and the rule is the same on all seven: **a tooltip shows the full localized number** (`4,000,000`, not `4M €`), because the tooltip is where the exact figure belongs. `valueFormatter` never reaches the tooltip, so a unit that lived in it needs `tooltipValueFormatter` to come back:
 
 ```tsx
 <F0DataChart
-  type="bar"
-  valueFormatter={(v) => `${v / 1_000_000}M €`}
+  type="line"
+  valueFormatter={(v) => `${v / 1_000_000}M €`} // axis: "4M €"
+  tooltipValueFormatter={(v) => `${v.toLocaleString()} €`} // tooltip: "4,000,000 €"
   categoryFormatter={(v) => v.slice(0, 3)}
   // ...
 />
 ```
+
+<Canvas of={LineStories.CustomFormatters} />
 
 ### ECharts Escape Hatch
 

--- a/packages/react/src/kits/F0DataChart/__stories__/Line.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Line.stories.tsx
@@ -168,12 +168,11 @@ export const WithDots: Story = {
 /**
  * Custom value + category formatters for currency / abbreviated month names.
  *
- * The two value formatters do different jobs. `valueFormatter` writes the axis,
- * where space is tight, so it compacts millions to `4M €`. The tooltip has room
- * for the exact figure and does not use that formatter — hover a point and it
- * reads `4,000,000 €`, from `tooltipValueFormatter`. Drop
- * `tooltipValueFormatter` and the tooltip keeps the full number but loses the
- * currency, since only the axis formatter knew about it.
+ * `valueFormatter` writes the axis, where space is tight, so it compacts
+ * millions to `4M €` — and the tooltip would read the same way, since a tooltip
+ * uses that formatter unless told otherwise. Here it is told otherwise: hover a
+ * point and it reads `4,000,000 €`, from `tooltipValueFormatter`, because the
+ * card has room for the exact figure.
  */
 export const CustomFormatters: Story = {
   render: (args) => <F0DataChart {...args} />,

--- a/packages/react/src/kits/F0DataChart/__stories__/Line.stories.tsx
+++ b/packages/react/src/kits/F0DataChart/__stories__/Line.stories.tsx
@@ -165,7 +165,16 @@ export const WithDots: Story = {
 // Formatting & minimal variants
 // ---------------------------------------------------------------------------
 
-/** Custom value + category formatters for currency / abbreviated month names. */
+/**
+ * Custom value + category formatters for currency / abbreviated month names.
+ *
+ * The two value formatters do different jobs. `valueFormatter` writes the axis,
+ * where space is tight, so it compacts millions to `4M €`. The tooltip has room
+ * for the exact figure and does not use that formatter — hover a point and it
+ * reads `4,000,000 €`, from `tooltipValueFormatter`. Drop
+ * `tooltipValueFormatter` and the tooltip keeps the full number but loses the
+ * currency, since only the axis formatter knew about it.
+ */
 export const CustomFormatters: Story = {
   render: (args) => <F0DataChart {...args} />,
   args: {
@@ -186,6 +195,7 @@ export const CustomFormatters: Story = {
       },
     ],
     valueFormatter: (v) => `${v / 1_000_000}M €`,
+    tooltipValueFormatter: (v) => `${v.toLocaleString("en-US")} €`,
     categoryFormatter: (v) => v.slice(0, 3),
   },
 }

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -1124,6 +1124,23 @@ describe("BarChart — item tooltip", () => {
     expect(description).toContain("5 more values")
     expect(description).not.toContain("Category 21")
   })
+
+  it("lets a caller's own echartsOptions.tooltip win over the built-in one", () => {
+    const ownFormatter = () => "custom tooltip"
+    render(
+      <F0DataChart
+        type="bar"
+        categories={["A"]}
+        series={[{ name: "S", data: [1] }]}
+        echartsOptions={{
+          tooltip: { trigger: "axis", formatter: ownFormatter },
+        }}
+      />
+    )
+
+    const tooltip = getTooltipFormatter()
+    expect(tooltip).toBe(ownFormatter)
+  })
 })
 
 describe("BarChart — horizontal category density", () => {

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -985,23 +985,27 @@ describe("BarChart — item tooltip", () => {
     expect(getLatestOption().aria?.label?.description).toContain("107,505")
   })
 
-  it("shows full numbers (not the compact axis format) when no tooltipValueFormatter is given", () => {
+  // The tooltip reads the number the way the axis does, so a unit written by
+  // `valueFormatter` (a currency, a "%") is not silently dropped on hover.
+  it("falls back to the axis formatter when no tooltipValueFormatter is given", () => {
     render(
       <F0DataChart
         type="bar"
         categories={["A"]}
-        series={[{ name: "S", data: [107505] }]}
-        valueFormatter={(v) => `${Math.round(v / 1000)}K`}
+        series={[{ name: "S", data: [107505.8632] }]}
+        valueFormatter={(v) =>
+          `€${v.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+        }
       />
     )
     const html = getTooltipFormatter()?.({
       name: "A",
       seriesName: "S",
-      value: 107505,
+      value: 107505.8632,
       dataIndex: 0,
     })
-    expect(html).toContain((107505).toLocaleString())
-    expect(html).not.toContain("108K")
+    expect(html).toContain("€107,505.86")
+    expect(html).not.toContain("107505.8632") // no raw float precision
   })
 
   it("formats and escapes values in target tooltips, and hides ghost series", () => {

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -1087,6 +1087,131 @@ describe("BarChart — item tooltip", () => {
     expect(html).not.toContain("total<")
   })
 
+  // A stacked chart mixing gains with losses has no total its parts add up
+  // to: the net sum is smaller than the segments it is made of, so a share of
+  // it can exceed 100% (or blow up entirely near cancellation).
+  it("omits share and total when the category mixes positive and negative values", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        stacked
+        categories={["Q1", "Q2"]}
+        series={[
+          { name: "Hires", data: [24, 18] },
+          { name: "Internal moves", data: [6, 4] },
+          { name: "Voluntary exits", data: [-8, -12] },
+          { name: "Involuntary exits", data: [-3, -2] },
+        ]}
+      />
+    )
+    const html = getTooltipFormatter()?.({
+      name: "Q1",
+      seriesName: "Hires",
+      value: 24,
+      dataIndex: 0,
+    })
+    // 24 / (24 + 6 - 8 - 3) would have read 126.3%, and the misleading net
+    // total goes with it — both rows carry the word "total".
+    expect(html).toContain((24).toLocaleString())
+    expect(html).not.toContain("total")
+    expect(html).not.toContain("126.3%")
+    expect(html).not.toContain((19).toLocaleString())
+  })
+
+  it("omits share and total when positive and negative series cancel out", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        stacked
+        categories={["Q1"]}
+        series={[
+          { name: "Hires", data: [1000] },
+          { name: "Exits", data: [-999.9] },
+        ]}
+      />
+    )
+    const html = getTooltipFormatter()?.({
+      name: "Q1",
+      seriesName: "Hires",
+      value: 1000,
+      dataIndex: 0,
+    })
+    // A net of 0.1 would have turned 1000 into 1,000,000% of total.
+    expect(html).not.toContain("total")
+    expect(html).not.toContain("%</strong>")
+  })
+
+  it("keeps share and total when every series is negative", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        stacked
+        categories={["Q1"]}
+        series={[
+          { name: "Voluntary exits", data: [-8] },
+          { name: "Involuntary exits", data: [-2] },
+        ]}
+      />
+    )
+    const html = getTooltipFormatter()?.({
+      name: "Q1",
+      seriesName: "Voluntary exits",
+      value: -8,
+      dataIndex: 0,
+    })
+    // Both sides share a sign, so the ratio still reads as a positive share.
+    expect(html).toContain("80.0%")
+    expect(html).toContain("of total")
+    expect(html).toContain((-10).toLocaleString())
+  })
+
+  it("treats a series that runs short of the categories as zero there", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        stacked
+        categories={["A", "B"]}
+        series={[
+          { name: "S1", data: [30, 40] },
+          { name: "S2", data: [70] }, // no value for "B"
+        ]}
+      />
+    )
+    const html = getTooltipFormatter()?.({
+      name: "B",
+      seriesName: "S1",
+      value: 40,
+      dataIndex: 1,
+    })
+    expect(html).toContain("100.0%")
+    expect(html).not.toContain("NaN")
+  })
+
+  it("omits the share but keeps the total when every value is zero", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        stacked
+        categories={["Q1"]}
+        series={[
+          { name: "Hires", data: [0] },
+          { name: "Exits", data: [0] },
+        ]}
+      />
+    )
+    const html = getTooltipFormatter()?.({
+      name: "Q1",
+      seriesName: "Hires",
+      value: 0,
+      dataIndex: 0,
+    })
+    // No division by zero, and "0 total" is still true.
+    expect(html).not.toContain("of total")
+    expect(html).not.toContain("Infinity")
+    expect(html).not.toContain("NaN")
+    expect(html).toContain("total")
+  })
+
   it("never compares a bar with the previous category — that is a line-chart concept", () => {
     render(
       <F0DataChart

--- a/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/BarChart.test.tsx
@@ -951,11 +951,11 @@ describe("BarChart — hideOverflowingLabels", () => {
 })
 
 // ---------------------------------------------------------------------------
-// tooltipValueFormatter — the tooltip can show precise values while the
-// axis/labels stay compact.
+// Item tooltip — bar charts describe the hovered bar/segment: precise value,
+// change vs. the previous category, and (multi-series) share of the total.
 // ---------------------------------------------------------------------------
 
-describe("BarChart — tooltipValueFormatter", () => {
+describe("BarChart — item tooltip", () => {
   function getTooltipFormatter() {
     const call = setOptionMock.mock.calls.at(-1)
     if (!call) throw new Error("setOption was never called")
@@ -973,16 +973,19 @@ describe("BarChart — tooltipValueFormatter", () => {
         tooltipValueFormatter={(v) => v.toLocaleString("en-US")}
       />
     )
-    const html = getTooltipFormatter()?.([
-      { axisValueLabel: "A", seriesName: "S", value: 107505, marker: "" },
-    ])
+    const html = getTooltipFormatter()?.({
+      name: "A",
+      seriesName: "S",
+      value: 107505,
+      dataIndex: 0,
+    })
     expect(html).toContain("107,505") // precise, grouped
     expect(html).not.toContain("K") // not the compact form
     expect(getLatestOption().aria?.enabled).toBe(true)
     expect(getLatestOption().aria?.label?.description).toContain("107,505")
   })
 
-  it("falls back to valueFormatter when no tooltipValueFormatter is given", () => {
+  it("shows full numbers (not the compact axis format) when no tooltipValueFormatter is given", () => {
     render(
       <F0DataChart
         type="bar"
@@ -991,13 +994,17 @@ describe("BarChart — tooltipValueFormatter", () => {
         valueFormatter={(v) => `${Math.round(v / 1000)}K`}
       />
     )
-    const html = getTooltipFormatter()?.([
-      { axisValueLabel: "A", seriesName: "S", value: 107505, marker: "" },
-    ])
-    expect(html).toContain("108K")
+    const html = getTooltipFormatter()?.({
+      name: "A",
+      seriesName: "S",
+      value: 107505,
+      dataIndex: 0,
+    })
+    expect(html).toContain((107505).toLocaleString())
+    expect(html).not.toContain("108K")
   })
 
-  it("formats and escapes actual and target values in target tooltips", () => {
+  it("formats and escapes values in target tooltips, and hides ghost series", () => {
     render(
       <F0DataChart
         type="bar"
@@ -1014,50 +1021,84 @@ describe("BarChart — tooltipValueFormatter", () => {
       />
     )
 
-    const html = getTooltipFormatter()?.([
-      {
-        axisValueLabel: "<script>category</script>",
-        seriesName: "<strong>Revenue</strong>",
-        value: 107505,
-        dataIndex: 0,
-        marker: '<span class="trusted-marker"></span>',
-      },
-    ])
+    const formatter = getTooltipFormatter()
+    const html = formatter?.({
+      name: "<script>category</script>",
+      seriesName: "<strong>Revenue</strong>",
+      value: 107505,
+      dataIndex: 0,
+      marker: '<span class="trusted-marker"></span>',
+    })
 
+    // ECharts' own coloured dot is trusted HTML and survives unescaped.
     expect(html).toContain('<span class="trusted-marker"></span>')
     expect(html).toContain("&lt;script&gt;category&lt;/script&gt;")
     expect(html).toContain("&lt;strong&gt;Revenue&lt;/strong&gt;")
     expect(html).toContain("&lt;em&gt;107,505&lt;/em&gt;")
-    expect(html).toContain("&lt;em&gt;125,000&lt;/em&gt;")
+    expect(html).toContain("&lt;em&gt;125,000&lt;/em&gt;") // target row
     expect(html).not.toContain("<script>")
+    // Hovering the ghost gradient bar renders no tooltip.
+    expect(
+      formatter?.({
+        seriesName: "<strong>Revenue</strong> (target)",
+        value: 17495,
+        dataIndex: 0,
+      })
+    ).toBe("")
   })
 
-  it("escapes the ordinary tooltip while preserving ECharts marker HTML", () => {
+  it("shows share of total only for multi-series charts", () => {
     render(
       <F0DataChart
         type="bar"
-        categories={["<script>category</script>"]}
-        series={[{ name: "<strong>Revenue</strong>", data: [107505] }]}
-        tooltipValueFormatter={(value) =>
-          `<em>${value.toLocaleString("en-US")}</em>`
-        }
+        categories={["A", "B"]}
+        series={[
+          { name: "S1", data: [30, 10] },
+          { name: "S2", data: [70, 90] },
+        ]}
       />
     )
+    const html = getTooltipFormatter()?.({
+      name: "A",
+      seriesName: "S1",
+      value: 30,
+      dataIndex: 0,
+    })
+    expect(html).toContain("30.0%")
+    expect(html).toContain("of total")
+    expect(html).toContain((100).toLocaleString())
+  })
 
-    const html = getTooltipFormatter()?.([
-      {
-        axisValueLabel: "<script>category</script>",
-        seriesName: "<strong>Revenue</strong>",
-        value: 107505,
-        marker: '<span class="trusted-marker"></span>',
-      },
-    ])
+  it("hides share of total for single-series charts", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        categories={["A"]}
+        series={[{ name: "S", data: [100] }]}
+      />
+    )
+    const html = getTooltipFormatter()?.({
+      name: "A",
+      seriesName: "S",
+      value: 100,
+      dataIndex: 0,
+    })
+    expect(html).not.toContain("of total")
+    expect(html).not.toContain("total<")
+  })
 
-    expect(html).toContain('<span class="trusted-marker"></span>')
-    expect(html).toContain("&lt;script&gt;category&lt;/script&gt;")
-    expect(html).toContain("&lt;strong&gt;Revenue&lt;/strong&gt;")
-    expect(html).toContain("&lt;em&gt;107,505&lt;/em&gt;")
-    expect(html).not.toContain("<script>")
+  it("never compares a bar with the previous category — that is a line-chart concept", () => {
+    render(
+      <F0DataChart
+        type="bar"
+        categories={["A", "B"]}
+        series={[{ name: "S", data: [100, 125] }]}
+      />
+    )
+    const formatter = getTooltipFormatter()
+    expect(
+      formatter?.({ name: "B", seriesName: "S", value: 125, dataIndex: 1 })
+    ).not.toContain("from previous")
   })
 
   it("bounds the accessible description for large datasets", () => {

--- a/packages/react/src/kits/F0DataChart/__tests__/FunnelChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/FunnelChart.test.tsx
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import "@testing-library/jest-dom/vitest"
+import { zeroRender as render } from "@/testing/test-utils"
+
+import { F0DataChart } from "../F0DataChart"
+
+const setOptionMock = vi.fn()
+
+vi.mock("echarts", () => ({
+  init: vi.fn(() => ({
+    setOption: setOptionMock,
+    resize: vi.fn(),
+    dispose: vi.fn(),
+    getDom: vi.fn(() => document.createElement("div")),
+    on: vi.fn(),
+    off: vi.fn(),
+  })),
+  use: vi.fn(),
+  getInstanceByDom: vi.fn(),
+  graphic: {
+    LinearGradient: vi.fn(function LinearGradient(this: object) {
+      return this
+    }),
+  },
+}))
+
+vi.mock("echarts/components", () => ({
+  AriaComponent: {},
+}))
+
+const containerSize = { width: 800, height: 320 }
+
+vi.mock("../utils/useContainerSize", () => ({
+  useContainerSize: () => containerSize,
+}))
+
+function getLatestOption() {
+  const call = setOptionMock.mock.calls.at(-1)
+  if (!call) throw new Error("setOption was never called")
+  return call[0] as {
+    tooltip?: { formatter?: (params: unknown) => string }
+  }
+}
+
+/** Run the tooltip formatter the way ECharts would on hover. */
+function hover(params: unknown) {
+  const formatter = getLatestOption().tooltip?.formatter
+  if (!formatter) throw new Error("the chart built no tooltip formatter")
+  return formatter(params)
+}
+
+const funnelProps = {
+  type: "funnel" as const,
+  series: {
+    name: "Hiring",
+    data: [
+      { name: "Applied", value: 1200 },
+      { name: "Screened", value: 480 },
+      { name: "Interviewed", value: 120 },
+      { name: "Hired", value: 24 },
+    ],
+  },
+}
+
+beforeEach(() => {
+  setOptionMock.mockClear()
+  containerSize.width = 800
+  containerSize.height = 320
+})
+
+// The formatter runs inside ECharts on hover, so it only gets exercised by
+// calling it with the params ECharts passes.
+describe("FunnelChart — tooltip", () => {
+  it("shows the stage and its value, with no conversion rows by default", () => {
+    render(<F0DataChart {...funnelProps} />)
+
+    const html = hover({
+      name: "Screened",
+      value: 480,
+      marker: '<span class="trusted-marker"></span>',
+    })
+    expect(html).toContain('<span class="trusted-marker"></span>')
+    expect(html).toContain("Screened")
+    expect(html).toContain((480).toLocaleString())
+    expect(html).not.toContain("of total")
+  })
+
+  it("adds share-of-first and step-over-step rows when showConversion is set", () => {
+    render(<F0DataChart {...funnelProps} showConversion />)
+
+    const html = hover({ name: "Interviewed", value: 120 })
+    expect(html).toContain("10.0%") // 120 of the 1,200 that applied
+    expect(html).toContain("of total")
+    expect(html).toContain("25.0%") // 120 of the 480 screened
+    expect(html).toContain("from Screened")
+  })
+
+  it("omits the step row on the first stage, which has nothing before it", () => {
+    render(<F0DataChart {...funnelProps} showConversion />)
+
+    const html = hover({ name: "Applied", value: 1200 })
+    expect(html).toContain("100%")
+    expect(html).toContain("of total")
+    expect(html).not.toContain("from ")
+  })
+
+  it("reads the previous stage from rendered order, not array order", () => {
+    render(<F0DataChart {...funnelProps} sort="ascending" showConversion />)
+
+    // Ascending renders Hired → Interviewed → Screened → Applied, so the stage
+    // before "Screened" is "Interviewed", and 100% is the smallest stage.
+    const html = hover({ name: "Screened", value: 480 })
+    expect(html).toContain("from Interviewed")
+    expect(html).toContain("400.0%") // 480 over the 120 interviewed
+  })
+
+  it("keeps the value alone when a stage has nothing to convert from", () => {
+    render(
+      <F0DataChart
+        type="funnel"
+        showConversion
+        series={{
+          name: "Hiring",
+          data: [
+            { name: "Applied", value: 0 },
+            { name: "Hired", value: 0 },
+          ],
+        }}
+      />
+    )
+
+    const html = hover({ name: "Applied", value: 0 })
+    expect(html).toContain((0).toLocaleString())
+    expect(html).not.toContain("of total")
+    expect(html).not.toContain("NaN")
+    expect(html).not.toContain("Infinity")
+  })
+
+  it("escapes the stage name it names in a conversion row", () => {
+    render(
+      <F0DataChart
+        type="funnel"
+        showConversion
+        tooltipValueFormatter={(v) => `${v} people`}
+        series={{
+          name: "Hiring",
+          data: [
+            { name: "<script>x</script>", value: 100 },
+            { name: "Hired", value: 25 },
+          ],
+        }}
+      />
+    )
+
+    const html = hover({ name: "Hired", value: 25 })
+    expect(html).toContain("25 people")
+    // The previous stage's name lands in a label — escaped like any other text.
+    expect(html).toContain("&lt;script&gt;")
+    expect(html).not.toContain("<script>")
+  })
+
+  it("shows the full number, not the compact stage-label format", () => {
+    render(
+      <F0DataChart {...funnelProps} valueFormatter={(v) => `${v / 1000}k`} />
+    )
+
+    const html = hover({ name: "Screened", value: 480 })
+    expect(html).toContain((480).toLocaleString())
+    expect(html).not.toContain("0.48k") // that stays on the stage label
+  })
+
+  it("lets tooltipValueFormatter set the tooltip number", () => {
+    render(
+      <F0DataChart
+        {...funnelProps}
+        valueFormatter={(v) => `${v / 1000}k`}
+        tooltipValueFormatter={(v) => `${v.toLocaleString("en-US")} people`}
+      />
+    )
+
+    expect(hover({ name: "Screened", value: 480 })).toContain("480 people")
+  })
+
+  it("survives params with no name or value", () => {
+    render(<F0DataChart {...funnelProps} showConversion />)
+
+    const html = hover({})
+    expect(html).toContain((0).toLocaleString())
+    expect(html).not.toContain("of total") // unknown stage, no position to use
+    expect(html).not.toContain("undefined")
+  })
+})

--- a/packages/react/src/kits/F0DataChart/__tests__/FunnelChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/FunnelChart.test.tsx
@@ -159,14 +159,12 @@ describe("FunnelChart — tooltip", () => {
     expect(html).not.toContain("<script>")
   })
 
-  it("shows the full number, not the compact stage-label format", () => {
+  it("reads the value the way the stage labels do", () => {
     render(
-      <F0DataChart {...funnelProps} valueFormatter={(v) => `${v / 1000}k`} />
+      <F0DataChart {...funnelProps} valueFormatter={(v) => `${v} people`} />
     )
 
-    const html = hover({ name: "Screened", value: 480 })
-    expect(html).toContain((480).toLocaleString())
-    expect(html).not.toContain("0.48k") // that stays on the stage label
+    expect(hover({ name: "Screened", value: 480 })).toContain("480 people")
   })
 
   it("lets tooltipValueFormatter set the tooltip number", () => {

--- a/packages/react/src/kits/F0DataChart/__tests__/GaugeChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/GaugeChart.test.tsx
@@ -41,10 +41,18 @@ function getLatestOption() {
     series: Array<{
       title?: { show?: boolean; fontSize?: number }
       detail?: { show?: boolean; fontSize?: number }
-      progress?: { width?: number }
+      progress?: { width?: number; itemStyle?: { color?: string } }
       axisLine?: { lineStyle?: { width?: number } }
     }>
+    tooltip?: { formatter?: (params: unknown) => string }
   }
+}
+
+/** Run the tooltip formatter the way ECharts would on hover. */
+function hover(params: unknown) {
+  const formatter = getLatestOption().tooltip?.formatter
+  if (!formatter) throw new Error("the chart built no tooltip formatter")
+  return formatter(params)
 }
 
 const gaugeProps = {
@@ -88,5 +96,71 @@ describe("GaugeChart — responsive breakpoints", () => {
     expect(option.series[0].title?.show).toBe(true)
     expect(option.series[0].detail?.fontSize).toBe(32)
     expect(option.series[0].progress?.width).toBe(18)
+  })
+})
+
+// The formatter runs inside ECharts on hover, so it only gets exercised by
+// calling it with the params ECharts passes.
+describe("GaugeChart — tooltip", () => {
+  it("shows the name, the value and its share of the range", () => {
+    render(<F0DataChart {...gaugeProps} min={0} max={200} />)
+
+    const html = hover({ name: "Engagement", value: 72 })
+    expect(html).toContain("Engagement")
+    expect(html).toContain((72).toLocaleString())
+    expect(html).toContain("36.0%")
+    expect(html).toContain("of range")
+  })
+
+  it("marks the dot with the arc's own colour, not the palette entry", () => {
+    render(<F0DataChart {...gaugeProps} color="viridian" />)
+
+    const painted = getLatestOption().series[0].progress?.itemStyle?.color
+    expect(painted).toBeTruthy()
+    expect(hover({ name: "Engagement", value: 72 })).toContain(
+      `background-color:${painted}`
+    )
+  })
+
+  it("escapes the name and shows the full number, not the ring's format", () => {
+    render(
+      <F0DataChart
+        {...gaugeProps}
+        name="<script>x</script>"
+        value={7200}
+        max={10000}
+        valueFormatter={(v) => `${v / 100}%`}
+      />
+    )
+
+    const html = hover({ name: "<script>x</script>", value: 7200 })
+    expect(html).toContain((7200).toLocaleString())
+    expect(html).not.toContain("72%") // that stays in the centre of the ring
+    expect(html).toContain("&lt;script&gt;")
+    expect(html).not.toContain("<script>")
+  })
+
+  it("lets tooltipValueFormatter set the tooltip number", () => {
+    render(
+      <F0DataChart
+        {...gaugeProps}
+        valueFormatter={(v) => `${v}%`}
+        tooltipValueFormatter={(v) => `${v} of 100 points`}
+      />
+    )
+
+    expect(hover({ name: "Engagement", value: 72 })).toContain(
+      "72 of 100 points"
+    )
+  })
+
+  it("survives a missing value and a zero-width range", () => {
+    render(<F0DataChart {...gaugeProps} min={50} max={50} />)
+
+    const html = hover({ name: "Engagement" })
+    expect(html).toContain((0).toLocaleString())
+    expect(html).not.toContain("of range") // no range to be a share of
+    expect(html).not.toContain("NaN")
+    expect(html).not.toContain("Infinity")
   })
 })

--- a/packages/react/src/kits/F0DataChart/__tests__/GaugeChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/GaugeChart.test.tsx
@@ -122,7 +122,7 @@ describe("GaugeChart — tooltip", () => {
     )
   })
 
-  it("escapes the name and shows the full number, not the ring's format", () => {
+  it("escapes the name and reads the value the way the ring does", () => {
     render(
       <F0DataChart
         {...gaugeProps}
@@ -134,8 +134,7 @@ describe("GaugeChart — tooltip", () => {
     )
 
     const html = hover({ name: "<script>x</script>", value: 7200 })
-    expect(html).toContain((7200).toLocaleString())
-    expect(html).not.toContain("72%") // that stays in the centre of the ring
+    expect(html).toContain("72%")
     expect(html).toContain("&lt;script&gt;")
     expect(html).not.toContain("<script>")
   })

--- a/packages/react/src/kits/F0DataChart/__tests__/HeatmapChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/HeatmapChart.test.tsx
@@ -52,7 +52,15 @@ function getLatestOption() {
       label?: { show?: boolean }
       itemStyle?: SeriesItemStyle
     }>
+    tooltip?: { formatter?: (params: unknown) => string }
   }
+}
+
+/** Run the tooltip formatter the way ECharts would on hover. */
+function hover(params: unknown) {
+  const formatter = getLatestOption().tooltip?.formatter
+  if (!formatter) throw new Error("the chart built no tooltip formatter")
+  return formatter(params)
 }
 
 const heatmapProps = {
@@ -141,5 +149,75 @@ describe("HeatmapChart — cell appearance", () => {
     const option = getLatestOption()
     expect(option.xAxis.axisLine.show).toBe(false)
     expect(option.yAxis.axisLine.show).toBe(false)
+  })
+})
+
+// The formatter runs inside ECharts on hover, so it only gets exercised by
+// calling it with the params ECharts passes.
+describe("HeatmapChart — tooltip", () => {
+  it("names both dimensions of the hovered cell and shows its value", () => {
+    containerSize.width = 720
+    render(<F0DataChart {...heatmapProps} />)
+
+    const html = hover({
+      value: [1, 1, 4],
+      marker: '<span class="trusted-marker"></span>',
+    })
+    expect(html).toContain('<span class="trusted-marker"></span>')
+    expect(html).toContain("Afternoon") // y category
+    expect(html).toContain("Tue") // x category
+    expect(html).toContain((4).toLocaleString())
+  })
+
+  it("escapes category names and ignores the in-cell label format", () => {
+    containerSize.width = 720
+    render(
+      <F0DataChart
+        {...heatmapProps}
+        xCategories={["<script>x</script>", "Tue", "Wed"]}
+        showLabels
+        valueFormatter={(v) => `${v}h`}
+      />
+    )
+
+    const html = hover({ value: [0, 0, 5] })
+    expect(html).toContain((5).toLocaleString())
+    expect(html).not.toContain("5h") // that stays inside the cell
+    expect(html).toContain("&lt;script&gt;")
+    expect(html).not.toContain("<script>")
+  })
+
+  it("lets tooltipValueFormatter set the tooltip number", () => {
+    containerSize.width = 720
+    render(
+      <F0DataChart
+        {...heatmapProps}
+        showLabels
+        tooltipValueFormatter={(v) => `${v} hours`}
+      />
+    )
+
+    expect(hover({ value: [1, 1, 4] })).toContain("4 hours")
+  })
+
+  it("survives a cell params object with no value tuple", () => {
+    containerSize.width = 720
+    render(<F0DataChart {...heatmapProps} />)
+
+    const html = hover({})
+    // Falls back to the first cell of the grid at zero rather than throwing.
+    expect(html).toContain("Morning")
+    expect(html).toContain("Mon")
+    expect(html).toContain((0).toLocaleString())
+    expect(html).not.toContain("undefined")
+  })
+
+  it("leaves the title empty when the index is outside the categories", () => {
+    containerSize.width = 720
+    render(<F0DataChart {...heatmapProps} />)
+
+    const html = hover({ value: [9, 9, 2] })
+    expect(html).toContain((2).toLocaleString())
+    expect(html).not.toContain("undefined")
   })
 })

--- a/packages/react/src/kits/F0DataChart/__tests__/HeatmapChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/HeatmapChart.test.tsx
@@ -169,7 +169,7 @@ describe("HeatmapChart — tooltip", () => {
     expect(html).toContain((4).toLocaleString())
   })
 
-  it("escapes category names and ignores the in-cell label format", () => {
+  it("escapes category names and reads the value the way the cells do", () => {
     containerSize.width = 720
     render(
       <F0DataChart
@@ -181,8 +181,7 @@ describe("HeatmapChart — tooltip", () => {
     )
 
     const html = hover({ value: [0, 0, 5] })
-    expect(html).toContain((5).toLocaleString())
-    expect(html).not.toContain("5h") // that stays inside the cell
+    expect(html).toContain("5h")
     expect(html).toContain("&lt;script&gt;")
     expect(html).not.toContain("<script>")
   })

--- a/packages/react/src/kits/F0DataChart/__tests__/LineChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/LineChart.test.tsx
@@ -55,6 +55,9 @@ function getLatestOption() {
     legend?: { show?: boolean }
     xAxis: { axisLabel: { show: boolean } }
     yAxis: { axisLabel: { show: boolean } }
+    tooltip?: {
+      formatter?: (params: unknown) => string
+    }
   }
 }
 
@@ -155,5 +158,40 @@ describe("LineChart — responsive breakpoints", () => {
     expect(option.legend?.show).toBe(true)
     expect(option.xAxis.axisLabel.show).toBe(true)
     expect(option.yAxis.axisLabel.show).toBe(true)
+  })
+})
+
+describe("LineChart — tooltip value formatting", () => {
+  const hoverFirstPoint = () =>
+    getLatestOption().tooltip?.formatter?.([
+      { axisValue: "A", seriesName: "S", value: 107505, dataIndex: 0 },
+    ])
+
+  it("shows full numbers rather than the compact axis format", () => {
+    render(
+      <F0DataChart
+        type="line"
+        categories={["A"]}
+        series={[{ name: "S", data: [107505] }]}
+        valueFormatter={(v) => `${Math.round(v / 1000)}K`}
+      />
+    )
+
+    expect(hoverFirstPoint()).toContain((107505).toLocaleString())
+    expect(hoverFirstPoint()).not.toContain("108K")
+  })
+
+  it("lets tooltipValueFormatter keep a unit the axis formatter would drop", () => {
+    render(
+      <F0DataChart
+        type="line"
+        categories={["A"]}
+        series={[{ name: "S", data: [107505] }]}
+        valueFormatter={(v) => `${Math.round(v / 1000)}K`}
+        tooltipValueFormatter={(v) => `${v.toLocaleString("en-US")} €`}
+      />
+    )
+
+    expect(hoverFirstPoint()).toContain("107,505 €")
   })
 })

--- a/packages/react/src/kits/F0DataChart/__tests__/LineChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/LineChart.test.tsx
@@ -167,18 +167,29 @@ describe("LineChart — tooltip value formatting", () => {
       { axisValue: "A", seriesName: "S", value: 107505, dataIndex: 0 },
     ])
 
-  it("shows full numbers rather than the compact axis format", () => {
+  it("falls back to the axis formatter when no tooltipValueFormatter is given", () => {
     render(
       <F0DataChart
         type="line"
         categories={["A"]}
         series={[{ name: "S", data: [107505] }]}
-        valueFormatter={(v) => `${Math.round(v / 1000)}K`}
+        valueFormatter={(v) => `${Math.round(v / 1000)}K €`}
+      />
+    )
+
+    expect(hoverFirstPoint()).toContain("108K €")
+  })
+
+  it("uses a plain localized number when neither formatter is given", () => {
+    render(
+      <F0DataChart
+        type="line"
+        categories={["A"]}
+        series={[{ name: "S", data: [107505] }]}
       />
     )
 
     expect(hoverFirstPoint()).toContain((107505).toLocaleString())
-    expect(hoverFirstPoint()).not.toContain("108K")
   })
 
   it("lets tooltipValueFormatter keep a unit the axis formatter would drop", () => {

--- a/packages/react/src/kits/F0DataChart/__tests__/PieChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/PieChart.test.tsx
@@ -131,12 +131,12 @@ describe("PieChart — tooltip", () => {
     expect(html).toContain((85).toLocaleString()) // 45 + 18 + 22
   })
 
-  it("shows the full number, not the compact slice-label format", () => {
-    render(<F0DataChart {...pieProps} valueFormatter={(v) => `${v / 1000}k`} />)
+  it("reads the slice value and the total the way the labels do", () => {
+    render(<F0DataChart {...pieProps} valueFormatter={(v) => `${v} FTE`} />)
 
     const html = hover({ name: "Design", value: 18, percent: 21.2 })
-    expect(html).toContain((18).toLocaleString())
-    expect(html).not.toContain("0.018k") // that stays on the slice label
+    expect(html).toContain("18 FTE")
+    expect(html).toContain("85 FTE") // the total row too
   })
 
   it("lets tooltipValueFormatter set both the slice value and the total", () => {

--- a/packages/react/src/kits/F0DataChart/__tests__/PieChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/PieChart.test.tsx
@@ -44,7 +44,15 @@ function getLatestOption() {
       labelLine?: { show?: boolean }
       radius?: [string, string]
     }>
+    tooltip?: { formatter?: (params: unknown) => string }
   }
+}
+
+/** Run the tooltip formatter the way ECharts would on hover. */
+function hover(params: unknown) {
+  const formatter = getLatestOption().tooltip?.formatter
+  if (!formatter) throw new Error("the chart built no tooltip formatter")
+  return formatter(params)
 }
 
 const pieProps = {
@@ -100,5 +108,55 @@ describe("PieChart — responsive breakpoints", () => {
 
     const option = getLatestOption()
     expect(option.legend).toBeUndefined()
+  })
+})
+
+// The formatter runs inside ECharts on hover, so it only gets exercised by
+// calling it with the params ECharts passes.
+describe("PieChart — tooltip", () => {
+  it("shows the slice, its value, its share and the whole", () => {
+    render(<F0DataChart {...pieProps} />)
+
+    const html = hover({
+      name: "Engineering",
+      value: 45,
+      percent: 53.6,
+      marker: '<span class="trusted-marker"></span>',
+    })
+    expect(html).toContain('<span class="trusted-marker"></span>')
+    expect(html).toContain("Engineering")
+    expect(html).toContain((45).toLocaleString())
+    expect(html).toContain("53.6%")
+    expect(html).toContain("of total")
+    expect(html).toContain((85).toLocaleString()) // 45 + 18 + 22
+  })
+
+  it("shows the full number, not the compact slice-label format", () => {
+    render(<F0DataChart {...pieProps} valueFormatter={(v) => `${v / 1000}k`} />)
+
+    const html = hover({ name: "Design", value: 18, percent: 21.2 })
+    expect(html).toContain((18).toLocaleString())
+    expect(html).not.toContain("0.018k") // that stays on the slice label
+  })
+
+  it("lets tooltipValueFormatter set both the slice value and the total", () => {
+    render(
+      <F0DataChart {...pieProps} tooltipValueFormatter={(v) => `${v} FTE`} />
+    )
+
+    const html = hover({ name: "Design", value: 18, percent: 21.2 })
+    expect(html).toContain("18 FTE")
+    expect(html).toContain("85 FTE") // the total row too
+  })
+
+  it("escapes the slice name and keeps a missing value at zero", () => {
+    render(<F0DataChart {...pieProps} />)
+
+    const html = hover({ name: "<script>x</script>" })
+    expect(html).toContain("&lt;script&gt;")
+    expect(html).not.toContain("<script>")
+    expect(html).toContain((0).toLocaleString())
+    expect(html).toContain("0.0%") // ECharts sent no percent
+    expect(html).not.toContain("NaN")
   })
 })

--- a/packages/react/src/kits/F0DataChart/__tests__/RadarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/RadarChart.test.tsx
@@ -121,14 +121,12 @@ describe("RadarChart — tooltip", () => {
     expect(html).not.toContain("font-size: 20px")
   })
 
-  it("shows full numbers, not the compact vertex-label format", () => {
-    render(
-      <F0DataChart {...radarProps} valueFormatter={(v) => `${v / 100}x`} />
-    )
+  it("reads every indicator the way the vertex labels do", () => {
+    render(<F0DataChart {...radarProps} valueFormatter={(v) => `${v} pts`} />)
 
-    const html = hover({ name: "Team A", value: [8500, 70, 90] })
-    expect(html).toContain((8500).toLocaleString())
-    expect(html).not.toContain("85x") // that stays on the vertex label
+    const html = hover({ name: "Team A", value: [85, 70, 90] })
+    expect(html).toContain("85 pts")
+    expect(html).toContain("70 pts")
   })
 
   it("lets tooltipValueFormatter set every indicator row", () => {

--- a/packages/react/src/kits/F0DataChart/__tests__/RadarChart.test.tsx
+++ b/packages/react/src/kits/F0DataChart/__tests__/RadarChart.test.tsx
@@ -42,7 +42,15 @@ function getLatestOption() {
     radar: {
       axisName?: { show?: boolean; width?: number }
     }
+    tooltip?: { formatter?: (params: unknown) => string }
   }
+}
+
+/** Run the tooltip formatter the way ECharts would on hover. */
+function hover(params: unknown) {
+  const formatter = getLatestOption().tooltip?.formatter
+  if (!formatter) throw new Error("the chart built no tooltip formatter")
+  return formatter(params)
 }
 
 const radarProps = {
@@ -87,5 +95,70 @@ describe("RadarChart — responsive breakpoints", () => {
     const option = getLatestOption()
     expect(option.legend?.show).toBe(true)
     expect(option.radar.axisName?.width).toBe(96)
+  })
+})
+
+// The formatter runs inside ECharts on hover, so it only gets exercised by
+// calling it with the params ECharts passes.
+describe("RadarChart — tooltip", () => {
+  it("lists every indicator as a row under the series name", () => {
+    render(<F0DataChart {...radarProps} />)
+
+    const html = hover({
+      name: "Team A",
+      value: [85, 70, 90],
+      marker: '<span class="trusted-marker"></span>',
+    })
+    expect(html).toContain('<span class="trusted-marker"></span>')
+    expect(html).toContain("Team A")
+    expect(html).toContain("Performance")
+    expect(html).toContain("Engagement")
+    expect(html).toContain("Retention")
+    expect(html).toContain((85).toLocaleString())
+    expect(html).toContain((70).toLocaleString())
+    expect(html).toContain((90).toLocaleString())
+    // A radar point carries every indicator at once — no single headline value.
+    expect(html).not.toContain("font-size: 20px")
+  })
+
+  it("shows full numbers, not the compact vertex-label format", () => {
+    render(
+      <F0DataChart {...radarProps} valueFormatter={(v) => `${v / 100}x`} />
+    )
+
+    const html = hover({ name: "Team A", value: [8500, 70, 90] })
+    expect(html).toContain((8500).toLocaleString())
+    expect(html).not.toContain("85x") // that stays on the vertex label
+  })
+
+  it("lets tooltipValueFormatter set every indicator row", () => {
+    render(
+      <F0DataChart
+        {...radarProps}
+        tooltipValueFormatter={(v) => `${v} / 100`}
+      />
+    )
+
+    const html = hover({ name: "Team A", value: [85, 70, 90] })
+    expect(html).toContain("85 / 100")
+    expect(html).toContain("70 / 100")
+    expect(html).toContain("90 / 100")
+  })
+
+  it("escapes the series name and fills indicators the point omits", () => {
+    render(
+      <F0DataChart
+        {...radarProps}
+        series={[{ name: "<b>A</b>", data: [85] }]}
+      />
+    )
+
+    const html = hover({ name: "<b>A</b>", value: [85] })
+    expect(html).toContain("&lt;b&gt;A&lt;/b&gt;")
+    expect(html).not.toContain("<b>")
+    // Two indicators had no value: they read 0 rather than disappearing.
+    expect(html).toContain("Retention")
+    expect(html).not.toContain("undefined")
+    expect(html).not.toContain("NaN")
   })
 })

--- a/packages/react/src/kits/F0DataChart/__tests__/options.test.ts
+++ b/packages/react/src/kits/F0DataChart/__tests__/options.test.ts
@@ -7,6 +7,7 @@ import {
   escapeTooltipText,
   renderMarker,
   renderValueTooltip,
+  tooltipValueFormat,
 } from "../utils/options"
 import { resolveChartTheme } from "../utils/theme"
 
@@ -204,6 +205,33 @@ describe("renderMarker", () => {
   it("strips characters that would break out of the style attribute", () => {
     expect(renderMarker('red"><script>alert(1)</script>')).not.toContain(
       "<script>"
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// The one place every chart type resolves its tooltip number.
+// ---------------------------------------------------------------------------
+
+describe("tooltipValueFormat", () => {
+  it("reads the value the way the axis and labels do", () => {
+    // Without this a chart whose axis says "€46,390.86" hovered as
+    // "46390.863" — currency gone, raw float precision exposed.
+    const axis = (v: number) =>
+      `€${v.toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+    expect(tooltipValueFormat(undefined, axis)(46390.8632)).toBe("€46,390.86")
+  })
+
+  it("lets tooltipValueFormatter win, for a compact axis with an exact tooltip", () => {
+    const compactAxis = (v: number) => `${Math.round(v / 1000)}k`
+    const exact = (v: number) => v.toLocaleString("en-US")
+    expect(tooltipValueFormat(exact, compactAxis)(107505)).toBe("107,505")
+  })
+
+  it("falls back to a plain localized number when neither is given", () => {
+    expect(tooltipValueFormat()(107505)).toBe((107505).toLocaleString())
+    expect(tooltipValueFormat(undefined, undefined)(0)).toBe(
+      (0).toLocaleString()
     )
   })
 })

--- a/packages/react/src/kits/F0DataChart/__tests__/options.test.ts
+++ b/packages/react/src/kits/F0DataChart/__tests__/options.test.ts
@@ -3,8 +3,12 @@ import { describe, expect, it } from "vitest"
 import {
   computeCategoryAxisLayout,
   computeLabelInterval,
+  deltaRow,
   escapeTooltipText,
+  renderMarker,
+  renderValueTooltip,
 } from "../utils/options"
+import { resolveChartTheme } from "../utils/theme"
 
 describe("escapeTooltipText", () => {
   it("escapes HTML-significant characters in consumer-provided text", () => {
@@ -99,5 +103,95 @@ describe("computeCategoryAxisLayout", () => {
     const layout = computeCategoryAxisLayout(50, 100, true)
     expect(layout).toBeDefined()
     expect(layout!.labelWidth).toBeGreaterThanOrEqual(24)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Shared tooltip renderer — every chart type funnels through this.
+// ---------------------------------------------------------------------------
+
+describe("renderValueTooltip", () => {
+  const theme = resolveChartTheme()
+
+  it("renders marker, title, subtitle, value and rows", () => {
+    const html = renderValueTooltip(
+      {
+        marker: '<span class="dot"></span>',
+        title: "Variable pay",
+        subtitle: "Q2",
+        value: "22,000",
+        rows: [{ value: "14.1%", label: "of total" }],
+      },
+      theme
+    )
+    expect(html).toContain('<span class="dot"></span>') // trusted, unescaped
+    expect(html).toContain("Variable pay")
+    expect(html).toContain("Q2")
+    expect(html).toContain("22,000")
+    expect(html).toContain("14.1%")
+    expect(html).toContain("of total")
+    expect(html).toContain("min-width: 130px")
+  })
+
+  it("escapes everything except the ECharts marker", () => {
+    const html = renderValueTooltip(
+      {
+        marker: '<span class="dot"></span>',
+        title: "<script>x</script>",
+        subtitle: "<b>c</b>",
+        value: "<em>1</em>",
+        rows: [{ value: "<i>2</i>", label: "<u>l</u>" }],
+      },
+      theme
+    )
+    expect(html).toContain('<span class="dot"></span>')
+    expect(html).not.toContain("<script>")
+    expect(html).not.toContain("<b>")
+    expect(html).not.toContain("<em>")
+    expect(html).not.toContain("<i>")
+  })
+
+  it("omits sections that were not provided and drops falsy rows", () => {
+    const html = renderValueTooltip(
+      { title: "Only a title", rows: [undefined, false] },
+      theme
+    )
+    expect(html).toContain("Only a title")
+    expect(html).not.toContain("font-size: 20px") // no headline value
+    expect(html).not.toContain("<strong")
+  })
+})
+
+describe("deltaRow", () => {
+  const theme = resolveChartTheme()
+
+  it("signs and colors an increase", () => {
+    const row = deltaRow(125, 100, "from previous", theme)
+    expect(row?.value).toBe("+25.0%")
+    expect(row?.color).toBe(theme.colors.positive)
+  })
+
+  it("colors a decrease and keeps the minus sign", () => {
+    const row = deltaRow(75, 100, "from previous", theme)
+    expect(row?.value).toBe("-25.0%")
+    expect(row?.color).toBe(theme.colors.critical)
+  })
+
+  it("returns nothing without a usable baseline", () => {
+    expect(deltaRow(10, undefined, "l", theme)).toBeUndefined()
+    expect(deltaRow(10, 0, "l", theme)).toBeUndefined()
+    expect(deltaRow(Number.NaN, 10, "l", theme)).toBeUndefined()
+  })
+})
+
+describe("renderMarker", () => {
+  it("builds a dot in the requested color", () => {
+    expect(renderMarker("#0d9488")).toContain("background-color:#0d9488")
+  })
+
+  it("strips characters that would break out of the style attribute", () => {
+    expect(renderMarker('red"><script>alert(1)</script>')).not.toContain(
+      "<script>"
+    )
   })
 })

--- a/packages/react/src/kits/F0DataChart/__tests__/options.test.ts
+++ b/packages/react/src/kits/F0DataChart/__tests__/options.test.ts
@@ -182,6 +182,18 @@ describe("deltaRow", () => {
     expect(deltaRow(10, 0, "l", theme)).toBeUndefined()
     expect(deltaRow(Number.NaN, 10, "l", theme)).toBeUndefined()
   })
+
+  it("falls back to the primary foreground when the theme omits delta colors", () => {
+    const bare = {
+      ...theme,
+      colors: { ...theme.colors, positive: undefined, critical: undefined },
+    }
+    const html = renderValueTooltip(
+      { value: "125", rows: [deltaRow(125, 100, "from previous", bare)] },
+      bare
+    )
+    expect(html).toContain(`color: ${theme.colors.foreground}`)
+  })
 })
 
 describe("renderMarker", () => {

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -593,7 +593,10 @@ export function useBarChartOptions(
     // numbers), otherwise fall back to the shared value formatter.
     const tooltipValue = tooltipValueFormatter ?? valueFormatter
 
-    const formatTooltipValue = tooltipValueFormat(tooltipValueFormatter)
+    const formatTooltipValue = tooltipValueFormat(
+      tooltipValueFormatter,
+      valueFormatter
+    )
 
     const options = buildBaseChartOptions({
       categories,

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -2,6 +2,7 @@ import * as echarts from "echarts"
 import { type RefObject, useMemo } from "react"
 
 import { useReducedMotion } from "@/lib/a11y"
+import { useI18n } from "@/lib/providers/i18n"
 
 import type {
   F0DataChartBarDataPoint,
@@ -462,6 +463,7 @@ export function useBarChartOptions(
   size: BarChartSize
 ): echarts.EChartsOption {
   const theme = useChartTheme(containerRef)
+  const i18n = useI18n()
   const { width: containerWidth, height: containerHeight } =
     useContainerSize(containerRef)
   const prefersReducedMotion = useReducedMotion()
@@ -590,8 +592,10 @@ export function useBarChartOptions(
     // numbers), otherwise fall back to the shared value formatter.
     const tooltipValue = tooltipValueFormatter ?? valueFormatter
 
-    // Tooltips show full numbers, not the compact axis format ("125,000", not
-    // "125k"). `tooltipValueFormatter` exists precisely to override this.
+    // `valueFormatter` formats the value AXIS, which is usually compact
+    // ("125k"); tooltips show the full number instead ("125,000").
+    // `tooltipValueFormatter` overrides that — it is also the way to keep a
+    // unit (currency, "%") in the tooltip.
     const formatTooltipValue = (value: number) =>
       tooltipValueFormatter
         ? tooltipValueFormatter(value)
@@ -684,11 +688,14 @@ export function useBarChartOptions(
     }
 
     // Bar charts use an item-triggered tooltip about the hovered bar or
-    // segment (pairing with the stacked series highlight) instead of the
-    // axis tooltip listing every series: value large, then change vs. the
-    // previous category and — with multiple series — the category total
-    // and the hovered value's share of it.
-    {
+    // segment (pairing with the stacked series highlight) instead of the axis
+    // tooltip listing every series: value large, then — with multiple series —
+    // the hovered value's share of the category total, that total, and the
+    // target when there is one.
+    //
+    // `buildBaseChartOptions` has already merged `echartsOptions`, so a caller
+    // that passed its own tooltip keeps it: only build ours when it didn't.
+    if (echartsOptions?.tooltip === undefined) {
       options.tooltip = buildItemTooltip({
         theme,
         formatter: (params: unknown) => {
@@ -726,15 +733,15 @@ export function useBarChartOptions(
                 multiSeries &&
                   total > 0 && {
                     value: `${((value / total) * 100).toFixed(1)}%`,
-                    label: "of total",
+                    label: i18n.dataChart.tooltip.ofTotal,
                   },
                 multiSeries && {
                   value: formatTooltipValue(total),
-                  label: "total",
+                  label: i18n.dataChart.tooltip.total,
                 },
                 target !== undefined && {
                   value: formatTooltipValue(target),
-                  label: "target",
+                  label: i18n.dataChart.tooltip.target,
                 },
               ],
             },
@@ -775,6 +782,7 @@ export function useBarChartOptions(
     valueAxisSplitNumber,
     echartsOptions,
     theme,
+    i18n,
     containerWidth,
     containerHeight,
     size,

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -10,7 +10,11 @@ import type {
 } from "../../types"
 
 import { paletteColor, resolveChartColorToken } from "../../utils/colors"
-import { buildBaseChartOptions, escapeTooltipText } from "../../utils/options"
+import {
+  buildBaseChartOptions,
+  buildItemTooltip,
+  renderValueTooltip,
+} from "../../utils/options"
 import type { ChartResponsiveSize } from "../../utils/responsive"
 import { useChartTheme } from "../../utils/useChartTheme"
 import { useContainerSize } from "../../utils/useContainerSize"
@@ -582,48 +586,16 @@ export function useBarChartOptions(
       }
     }
 
-    const hasAnyTargets = targetMap.size > 0
-
-    // Tooltip values use their own formatter when provided (precise numbers),
-    // otherwise fall back to the shared value formatter.
+    // Aria descriptions use their own formatter when provided (precise
+    // numbers), otherwise fall back to the shared value formatter.
     const tooltipValue = tooltipValueFormatter ?? valueFormatter
 
-    const tooltipFormatter = hasAnyTargets
-      ? (params: unknown) => {
-          if (!Array.isArray(params)) return ""
-          const filtered = params.filter(
-            (p: { seriesName?: string }) =>
-              !String(p.seriesName ?? "").endsWith(" (target)")
-          )
-          if (filtered.length === 0) return ""
-
-          const header = `<div style="margin-bottom: 4px; font-weight: 500">${escapeTooltipText(filtered[0].axisValueLabel ?? filtered[0].name ?? "")}</div>`
-          const items = filtered
-            .map(
-              (p: {
-                marker?: string
-                seriesName?: string
-                value?: number
-                dataIndex?: number
-              }) => {
-                const val = Number(p.value)
-                const formattedValue = tooltipValue
-                  ? tooltipValue(val)
-                  : String(val)
-                const targets = targetMap.get(String(p.seriesName ?? ""))
-                const target = targets?.[p.dataIndex ?? 0]
-                const targetHtml =
-                  target !== undefined
-                    ? ` <span style="opacity: 0.6">/ ${escapeTooltipText(tooltipValue ? tooltipValue(target) : String(target))}</span>`
-                    : ""
-                return `<div>${String(p.marker ?? "")} ${escapeTooltipText(p.seriesName ?? "")} <strong>${escapeTooltipText(formattedValue)}</strong>${targetHtml}</div>`
-              }
-            )
-            .join("")
-
-          return `${header}${items}`
-        }
-      : undefined
+    // Tooltips show full numbers, not the compact axis format ("125,000", not
+    // "125k"). `tooltipValueFormatter` exists precisely to override this.
+    const formatTooltipValue = (value: number) =>
+      tooltipValueFormatter
+        ? tooltipValueFormatter(value)
+        : value.toLocaleString()
 
     const options = buildBaseChartOptions({
       categories,
@@ -639,8 +611,6 @@ export function useBarChartOptions(
       showValueAxis,
       valueFormatter,
       categoryFormatter,
-      tooltipFilterSeries: (name) => name.endsWith(" (target)"),
-      tooltipFormatter,
       tooltipValueFormatter,
       valueAxisSplitNumber,
       echartsOptions,
@@ -711,6 +681,67 @@ export function useBarChartOptions(
             duration: STATE_ANIMATION_DURATION,
             easing: "cubicOut",
           })
+    }
+
+    // Bar charts use an item-triggered tooltip about the hovered bar or
+    // segment (pairing with the stacked series highlight) instead of the
+    // axis tooltip listing every series: value large, then change vs. the
+    // previous category and — with multiple series — the category total
+    // and the hovered value's share of it.
+    {
+      options.tooltip = buildItemTooltip({
+        theme,
+        formatter: (params: unknown) => {
+          const p = params as {
+            seriesName?: string
+            name?: string
+            value?: number
+            dataIndex?: number
+            marker?: string
+          }
+          const seriesName = String(p.seriesName ?? "")
+          if (seriesName.endsWith(" (target)")) return ""
+
+          const value = Number(p.value)
+          const dataIndex = p.dataIndex ?? 0
+          const total = series.reduce(
+            (sum, s) => sum + (getValue(s.data[dataIndex]) || 0),
+            0
+          )
+          const target = targetMap.get(seriesName)?.[dataIndex]
+          // Share-of-total context only means something with several series;
+          // a single-series bar is always 100% of its own category.
+          const multiSeries = series.length > 1
+
+          // No "from previous" row here: bar categories are not necessarily a
+          // sequence (locations, departments), so comparing a bar with the one
+          // to its left is only meaningful on a trend — i.e. a line chart.
+          return renderValueTooltip(
+            {
+              marker: p.marker,
+              title: seriesName,
+              subtitle: String(p.name ?? ""),
+              value: formatTooltipValue(value),
+              rows: [
+                multiSeries &&
+                  total > 0 && {
+                    value: `${((value / total) * 100).toFixed(1)}%`,
+                    label: "of total",
+                  },
+                multiSeries && {
+                  value: formatTooltipValue(total),
+                  label: "total",
+                },
+                target !== undefined && {
+                  value: formatTooltipValue(target),
+                  label: "target",
+                },
+              ],
+            },
+            theme
+          )
+        },
+      })
     }
 
     // Non-stacked horizontal bars render labels BESIDE the bar end, so the

--- a/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/BarChart/useBarChartOptions.ts
@@ -15,6 +15,7 @@ import {
   buildBaseChartOptions,
   buildItemTooltip,
   renderValueTooltip,
+  tooltipValueFormat,
 } from "../../utils/options"
 import type { ChartResponsiveSize } from "../../utils/responsive"
 import { useChartTheme } from "../../utils/useChartTheme"
@@ -592,14 +593,7 @@ export function useBarChartOptions(
     // numbers), otherwise fall back to the shared value formatter.
     const tooltipValue = tooltipValueFormatter ?? valueFormatter
 
-    // `valueFormatter` formats the value AXIS, which is usually compact
-    // ("125k"); tooltips show the full number instead ("125,000").
-    // `tooltipValueFormatter` overrides that — it is also the way to keep a
-    // unit (currency, "%") in the tooltip.
-    const formatTooltipValue = (value: number) =>
-      tooltipValueFormatter
-        ? tooltipValueFormatter(value)
-        : value.toLocaleString()
+    const formatTooltipValue = tooltipValueFormat(tooltipValueFormatter)
 
     const options = buildBaseChartOptions({
       categories,
@@ -689,9 +683,9 @@ export function useBarChartOptions(
 
     // Bar charts use an item-triggered tooltip about the hovered bar or
     // segment (pairing with the stacked series highlight) instead of the axis
-    // tooltip listing every series: value large, then — with multiple series —
-    // the hovered value's share of the category total, that total, and the
-    // target when there is one.
+    // tooltip listing every series: value large, then — with several
+    // same-signed series — the hovered value's share of the category total,
+    // that total, and the target when there is one.
     //
     // `buildBaseChartOptions` has already merged `echartsOptions`, so a caller
     // that passed its own tooltip keeps it: only build ours when it didn't.
@@ -711,14 +705,23 @@ export function useBarChartOptions(
 
           const value = Number(p.value)
           const dataIndex = p.dataIndex ?? 0
-          const total = series.reduce(
-            (sum, s) => sum + (getValue(s.data[dataIndex]) || 0),
-            0
-          )
           const target = targetMap.get(seriesName)?.[dataIndex]
-          // Share-of-total context only means something with several series;
-          // a single-series bar is always 100% of its own category.
-          const multiSeries = series.length > 1
+          // Share-of-total context only means something with several series
+          // pushing the same way: a single-series bar is always 100% of its own
+          // category, and a category mixing gains with losses has no "total"
+          // the parts add up to — 24 hires against a net of 19 would read as
+          // 126.3%, and near-cancellation makes that ratio arbitrarily large.
+          // Signed categories therefore show the value alone.
+          const categoryValues = series.map((s) => {
+            // A series can be shorter than `categories`.
+            const point = s.data[dataIndex]
+            return point === undefined ? 0 : getValue(point) || 0
+          })
+          const hasMixedSigns =
+            categoryValues.some((v) => v > 0) &&
+            categoryValues.some((v) => v < 0)
+          const total = categoryValues.reduce((sum, v) => sum + v, 0)
+          const showTotal = series.length > 1 && !hasMixedSigns
 
           // No "from previous" row here: bar categories are not necessarily a
           // sequence (locations, departments), so comparing a bar with the one
@@ -730,12 +733,14 @@ export function useBarChartOptions(
               subtitle: String(p.name ?? ""),
               value: formatTooltipValue(value),
               rows: [
-                multiSeries &&
-                  total > 0 && {
+                showTotal &&
+                  total !== 0 && {
+                    // Same sign on both sides, so the ratio is positive even
+                    // when the whole category is negative.
                     value: `${((value / total) * 100).toFixed(1)}%`,
                     label: i18n.dataChart.tooltip.ofTotal,
                   },
-                multiSeries && {
+                showTotal && {
                   value: formatTooltipValue(total),
                   label: i18n.dataChart.tooltip.total,
                 },

--- a/packages/react/src/kits/F0DataChart/components/FunnelChart/useFunnelChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/FunnelChart/useFunnelChartOptions.ts
@@ -17,6 +17,7 @@ import {
   renderValueTooltip,
   buildLegend,
   DEFAULT_EMPHASIS,
+  tooltipValueFormat,
 } from "../../utils/options"
 import { useChartTheme } from "../../utils/useChartTheme"
 import { useContainerSize } from "../../utils/useContainerSize"
@@ -33,6 +34,7 @@ export function useFunnelChartOptions(
     showConversion = false,
     colorScale = true,
     valueFormatter,
+    tooltipValueFormatter,
     echartsOptions,
   }: F0DataChartFunnelProps
 ): echarts.EChartsOption {
@@ -118,6 +120,8 @@ export function useFunnelChartOptions(
       },
     }
 
+    const formatTooltipValue = tooltipValueFormat(tooltipValueFormatter)
+
     const buildTooltipFormatter = () => {
       // Use sorted order for step-over-step conversion
       const sorted =
@@ -139,9 +143,7 @@ export function useFunnelChartOptions(
           value?: number
         }
         const val = Number(p.value ?? 0)
-        const formattedValue = valueFormatter
-          ? valueFormatter(val)
-          : val.toLocaleString()
+        const formattedValue = formatTooltipValue(val)
         const name = String(p.name ?? "")
         const sortedIndex = sortedIndexMap.get(name)
 
@@ -210,6 +212,7 @@ export function useFunnelChartOptions(
     showConversion,
     colorScale,
     valueFormatter,
+    tooltipValueFormatter,
     echartsOptions,
     theme,
     i18n,

--- a/packages/react/src/kits/F0DataChart/components/FunnelChart/useFunnelChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/FunnelChart/useFunnelChartOptions.ts
@@ -12,6 +12,7 @@ import { formatPercent } from "../../utils/formatters"
 import {
   buildGrid,
   buildItemTooltip,
+  renderValueTooltip,
   buildLegend,
   DEFAULT_EMPHASIS,
 } from "../../utils/options"
@@ -114,8 +115,6 @@ export function useFunnelChartOptions(
       },
     }
 
-    const { colors } = theme
-
     const buildTooltipFormatter = () => {
       // Use sorted order for step-over-step conversion
       const sorted =
@@ -139,26 +138,35 @@ export function useFunnelChartOptions(
         const val = Number(p.value ?? 0)
         const formattedValue = valueFormatter
           ? valueFormatter(val)
-          : String(val)
+          : val.toLocaleString()
         const name = String(p.name ?? "")
         const sortedIndex = sortedIndexMap.get(name)
 
-        let conversionHtml = ""
+        const conversionRows = []
         if (showConversion && firstValue > 0 && sortedIndex !== undefined) {
-          const overallPct = formatPercent(val, firstValue)
-          conversionHtml = `<div style="margin-top: 4px; color: ${colors.foregroundTertiary}; font-size: 11px">Overall: ${overallPct}</div>`
+          conversionRows.push({
+            value: formatPercent(val, firstValue),
+            label: "of total",
+          })
 
-          const prevIndex = sortedIndex - 1
-          if (prevIndex >= 0) {
-            const prevData = sorted[prevIndex]
-            if (prevData && prevData.value > 0) {
-              const stepPct = formatPercent(val, prevData.value)
-              conversionHtml += `<div style="color: ${colors.foregroundTertiary}; font-size: 11px">From ${prevData.name}: ${stepPct}</div>`
-            }
+          const prevData = sortedIndex > 0 ? sorted[sortedIndex - 1] : undefined
+          if (prevData && prevData.value > 0) {
+            conversionRows.push({
+              value: formatPercent(val, prevData.value),
+              label: `from ${prevData.name}`,
+            })
           }
         }
 
-        return `<div>${String(p.marker ?? "")} <strong>${name}</strong></div><div style="margin-top: 2px">${formattedValue}</div>${conversionHtml}`
+        return renderValueTooltip(
+          {
+            marker: p.marker,
+            title: name,
+            value: formattedValue,
+            rows: conversionRows,
+          },
+          theme
+        )
       }
     }
 

--- a/packages/react/src/kits/F0DataChart/components/FunnelChart/useFunnelChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/FunnelChart/useFunnelChartOptions.ts
@@ -120,7 +120,10 @@ export function useFunnelChartOptions(
       },
     }
 
-    const formatTooltipValue = tooltipValueFormat(tooltipValueFormatter)
+    const formatTooltipValue = tooltipValueFormat(
+      tooltipValueFormatter,
+      valueFormatter
+    )
 
     const buildTooltipFormatter = () => {
       // Use sorted order for step-over-step conversion

--- a/packages/react/src/kits/F0DataChart/components/FunnelChart/useFunnelChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/FunnelChart/useFunnelChartOptions.ts
@@ -2,6 +2,8 @@ import type * as echarts from "echarts"
 
 import { type RefObject, useMemo } from "react"
 
+import { useI18n } from "@/lib/providers/i18n"
+
 import type { F0DataChartFunnelProps } from "../../types"
 
 import {
@@ -35,6 +37,7 @@ export function useFunnelChartOptions(
   }: F0DataChartFunnelProps
 ): echarts.EChartsOption {
   const theme = useChartTheme(containerRef)
+  const i18n = useI18n()
   const { width: containerWidth } = useContainerSize(containerRef)
 
   return useMemo(() => {
@@ -146,14 +149,16 @@ export function useFunnelChartOptions(
         if (showConversion && firstValue > 0 && sortedIndex !== undefined) {
           conversionRows.push({
             value: formatPercent(val, firstValue),
-            label: "of total",
+            label: i18n.dataChart.tooltip.ofTotal,
           })
 
           const prevData = sortedIndex > 0 ? sorted[sortedIndex - 1] : undefined
           if (prevData && prevData.value > 0) {
             conversionRows.push({
               value: formatPercent(val, prevData.value),
-              label: `from ${prevData.name}`,
+              label: i18n.t("dataChart.tooltip.fromStage", {
+                stage: prevData.name,
+              }),
             })
           }
         }
@@ -207,6 +212,7 @@ export function useFunnelChartOptions(
     valueFormatter,
     echartsOptions,
     theme,
+    i18n,
     containerWidth,
   ])
 }

--- a/packages/react/src/kits/F0DataChart/components/GaugeChart/useGaugeChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/GaugeChart/useGaugeChartOptions.ts
@@ -5,7 +5,11 @@ import { type RefObject, useMemo } from "react"
 import type { F0DataChartGaugeProps } from "../../types"
 
 import { paletteColor, resolveChartColorToken } from "../../utils/colors"
-import { buildItemTooltip } from "../../utils/options"
+import {
+  buildItemTooltip,
+  renderMarker,
+  renderValueTooltip,
+} from "../../utils/options"
 import type { ChartResponsiveSize } from "../../utils/responsive"
 import { useChartTheme } from "../../utils/useChartTheme"
 
@@ -131,16 +135,29 @@ export function useGaugeChartOptions(
         theme,
         formatter: (params: unknown) => {
           const p = params as {
-            marker?: string
             name?: string
             value?: number
           }
           const val = Number(p.value ?? 0)
-          const formattedValue = valueFormatter
-            ? valueFormatter(val)
-            : String(val)
-          const label = p.name ? `<strong>${String(p.name)}</strong><br/>` : ""
-          return `${label}${formattedValue}`
+          const span = max - min
+          return renderValueTooltip(
+            {
+              // ECharts' own marker for a gauge uses the palette, not the
+              // colour the arc is actually painted with.
+              marker: renderMarker(resolvedColor),
+              title: p.name ? String(p.name) : undefined,
+              value: valueFormatter
+                ? valueFormatter(val)
+                : val.toLocaleString(),
+              rows: [
+                span > 0 && {
+                  value: `${(((val - min) / span) * 100).toFixed(1)}%`,
+                  label: "of range",
+                },
+              ],
+            },
+            theme
+          )
         },
       }),
     }

--- a/packages/react/src/kits/F0DataChart/components/GaugeChart/useGaugeChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/GaugeChart/useGaugeChartOptions.ts
@@ -11,6 +11,7 @@ import {
   buildItemTooltip,
   renderMarker,
   renderValueTooltip,
+  tooltipValueFormat,
 } from "../../utils/options"
 import type { ChartResponsiveSize } from "../../utils/responsive"
 import { useChartTheme } from "../../utils/useChartTheme"
@@ -60,6 +61,7 @@ export function useGaugeChartOptions(
     color,
     showValue = true,
     valueFormatter,
+    tooltipValueFormatter,
     echartsOptions,
   }: F0DataChartGaugeProps,
   size: GaugeChartSize
@@ -149,9 +151,7 @@ export function useGaugeChartOptions(
               // colour the arc is actually painted with.
               marker: renderMarker(resolvedColor),
               title: p.name ? String(p.name) : undefined,
-              value: valueFormatter
-                ? valueFormatter(val)
-                : val.toLocaleString(),
+              value: tooltipValueFormat(tooltipValueFormatter)(val),
               rows: [
                 span > 0 && {
                   value: `${(((val - min) / span) * 100).toFixed(1)}%`,
@@ -178,6 +178,7 @@ export function useGaugeChartOptions(
     color,
     showValue,
     valueFormatter,
+    tooltipValueFormatter,
     echartsOptions,
     theme,
     i18n,

--- a/packages/react/src/kits/F0DataChart/components/GaugeChart/useGaugeChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/GaugeChart/useGaugeChartOptions.ts
@@ -151,7 +151,10 @@ export function useGaugeChartOptions(
               // colour the arc is actually painted with.
               marker: renderMarker(resolvedColor),
               title: p.name ? String(p.name) : undefined,
-              value: tooltipValueFormat(tooltipValueFormatter)(val),
+              value: tooltipValueFormat(
+                tooltipValueFormatter,
+                valueFormatter
+              )(val),
               rows: [
                 span > 0 && {
                   value: `${(((val - min) / span) * 100).toFixed(1)}%`,

--- a/packages/react/src/kits/F0DataChart/components/GaugeChart/useGaugeChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/GaugeChart/useGaugeChartOptions.ts
@@ -2,6 +2,8 @@ import type * as echarts from "echarts"
 
 import { type RefObject, useMemo } from "react"
 
+import { useI18n } from "@/lib/providers/i18n"
+
 import type { F0DataChartGaugeProps } from "../../types"
 
 import { paletteColor, resolveChartColorToken } from "../../utils/colors"
@@ -63,6 +65,7 @@ export function useGaugeChartOptions(
   size: GaugeChartSize
 ): echarts.EChartsOption {
   const theme = useChartTheme(containerRef)
+  const i18n = useI18n()
 
   return useMemo(() => {
     const resolvedColor = color
@@ -152,7 +155,7 @@ export function useGaugeChartOptions(
               rows: [
                 span > 0 && {
                   value: `${(((val - min) / span) * 100).toFixed(1)}%`,
-                  label: "of range",
+                  label: i18n.dataChart.tooltip.ofRange,
                 },
               ],
             },
@@ -177,6 +180,7 @@ export function useGaugeChartOptions(
     valueFormatter,
     echartsOptions,
     theme,
+    i18n,
     size,
   ])
 }

--- a/packages/react/src/kits/F0DataChart/components/HeatmapChart/useHeatmapChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/HeatmapChart/useHeatmapChartOptions.ts
@@ -9,6 +9,7 @@ import {
   buildCategoryAxis,
   buildItemTooltip,
   renderValueTooltip,
+  tooltipValueFormat,
 } from "../../utils/options"
 import type { ChartResponsiveSize } from "../../utils/responsive"
 import { useChartTheme } from "../../utils/useChartTheme"
@@ -59,6 +60,7 @@ export function useHeatmapChartOptions(
     showLabels = false,
     showVisualMap = false,
     valueFormatter,
+    tooltipValueFormatter,
     echartsOptions,
   }: F0DataChartHeatmapProps,
   size: HeatmapChartSize
@@ -207,9 +209,7 @@ export function useHeatmapChartOptions(
               marker: p.marker,
               title: yCategories[yIdx] ?? "",
               subtitle: xCategories[xIdx] ?? "",
-              value: valueFormatter
-                ? valueFormatter(val)
-                : val.toLocaleString(),
+              value: tooltipValueFormat(tooltipValueFormatter)(val),
             },
             theme
           )
@@ -231,6 +231,7 @@ export function useHeatmapChartOptions(
     showLabels,
     showVisualMap,
     valueFormatter,
+    tooltipValueFormatter,
     echartsOptions,
     theme,
     width,

--- a/packages/react/src/kits/F0DataChart/components/HeatmapChart/useHeatmapChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/HeatmapChart/useHeatmapChartOptions.ts
@@ -5,7 +5,11 @@ import { type RefObject, useMemo } from "react"
 import type { F0DataChartHeatmapProps } from "../../types"
 
 import { lerpColor, paletteColor } from "../../utils/colors"
-import { buildCategoryAxis, buildItemTooltip } from "../../utils/options"
+import {
+  buildCategoryAxis,
+  buildItemTooltip,
+  renderValueTooltip,
+} from "../../utils/options"
 import type { ChartResponsiveSize } from "../../utils/responsive"
 import { useChartTheme } from "../../utils/useChartTheme"
 import { useContainerSize } from "../../utils/useContainerSize"
@@ -198,12 +202,17 @@ export function useHeatmapChartOptions(
             value?: [number, number, number]
           }
           const [xIdx, yIdx, val] = p.value ?? [0, 0, 0]
-          const xLabel = xCategories[xIdx] ?? ""
-          const yLabel = yCategories[yIdx] ?? ""
-          const formattedValue = valueFormatter
-            ? valueFormatter(val)
-            : String(val)
-          return `<div style="margin-bottom: 4px; font-weight: 500">${yLabel} · ${xLabel}</div><div>${String(p.marker ?? "")} <strong>${formattedValue}</strong></div>`
+          return renderValueTooltip(
+            {
+              marker: p.marker,
+              title: yCategories[yIdx] ?? "",
+              subtitle: xCategories[xIdx] ?? "",
+              value: valueFormatter
+                ? valueFormatter(val)
+                : val.toLocaleString(),
+            },
+            theme
+          )
         },
       }),
     }

--- a/packages/react/src/kits/F0DataChart/components/HeatmapChart/useHeatmapChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/HeatmapChart/useHeatmapChartOptions.ts
@@ -209,7 +209,10 @@ export function useHeatmapChartOptions(
               marker: p.marker,
               title: yCategories[yIdx] ?? "",
               subtitle: xCategories[xIdx] ?? "",
-              value: tooltipValueFormat(tooltipValueFormatter)(val),
+              value: tooltipValueFormat(
+                tooltipValueFormatter,
+                valueFormatter
+              )(val),
             },
             theme
           )

--- a/packages/react/src/kits/F0DataChart/components/LineChart/useLineChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/LineChart/useLineChartOptions.ts
@@ -195,7 +195,10 @@ export function useLineChartOptions(
 
     const legendData = series.map((s) => s.name)
 
-    const formatTooltipValue = tooltipValueFormat(tooltipValueFormatter)
+    const formatTooltipValue = tooltipValueFormat(
+      tooltipValueFormatter,
+      valueFormatter
+    )
 
     // Lines keep the axis trigger — a line is too thin to hover reliably —
     // but render the shared tooltip card. With one series that is the same

--- a/packages/react/src/kits/F0DataChart/components/LineChart/useLineChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/LineChart/useLineChartOptions.ts
@@ -1,6 +1,8 @@
 import * as echarts from "echarts"
 import { type RefObject, useMemo } from "react"
 
+import { useI18n } from "@/lib/providers/i18n"
+
 import type {
   F0DataChartLineDataPoint,
   F0DataChartLineProps,
@@ -150,12 +152,14 @@ export function useLineChartOptions(
     showGrid = true,
     showLabels = false,
     valueFormatter,
+    tooltipValueFormatter,
     categoryFormatter,
     echartsOptions,
   }: F0DataChartLineProps,
   size: LineChartSize
 ): echarts.EChartsOption {
   const theme = useChartTheme(containerRef)
+  const i18n = useI18n()
   const { width: containerWidth, height: containerHeight } =
     useContainerSize(containerRef)
 
@@ -190,8 +194,14 @@ export function useLineChartOptions(
 
     const legendData = series.map((s) => s.name)
 
-    // Tooltips show full numbers, not the compact axis format.
-    const formatTooltipValue = (value: number) => value.toLocaleString()
+    // `valueFormatter` formats the value AXIS, which is usually compact
+    // ("125k"); tooltips show the full number instead ("125,000").
+    // `tooltipValueFormatter` overrides that — it is also the way to keep a
+    // unit (currency, "%") in the tooltip.
+    const formatTooltipValue = (value: number) =>
+      tooltipValueFormatter
+        ? tooltipValueFormatter(value)
+        : value.toLocaleString()
 
     // Lines keep the axis trigger — a line is too thin to hover reliably —
     // but render the shared tooltip card. With one series that is the same
@@ -224,7 +234,14 @@ export function useLineChartOptions(
             title: String(first.seriesName ?? ""),
             subtitle: category,
             value: formatTooltipValue(value),
-            rows: [deltaRow(value, previous, "from previous", theme)],
+            rows: [
+              deltaRow(
+                value,
+                previous,
+                i18n.dataChart.tooltip.fromPrevious,
+                theme
+              ),
+            ],
           },
           theme
         )
@@ -271,9 +288,11 @@ export function useLineChartOptions(
     showGrid,
     showLabels,
     valueFormatter,
+    tooltipValueFormatter,
     categoryFormatter,
     echartsOptions,
     theme,
+    i18n,
     containerWidth,
     containerHeight,
     size,

--- a/packages/react/src/kits/F0DataChart/components/LineChart/useLineChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/LineChart/useLineChartOptions.ts
@@ -15,6 +15,7 @@ import {
   buildBaseChartOptions,
   deltaRow,
   renderValueTooltip,
+  tooltipValueFormat,
 } from "../../utils/options"
 import type { ChartResponsiveSize } from "../../utils/responsive"
 import { useChartTheme } from "../../utils/useChartTheme"
@@ -194,14 +195,7 @@ export function useLineChartOptions(
 
     const legendData = series.map((s) => s.name)
 
-    // `valueFormatter` formats the value AXIS, which is usually compact
-    // ("125k"); tooltips show the full number instead ("125,000").
-    // `tooltipValueFormatter` overrides that — it is also the way to keep a
-    // unit (currency, "%") in the tooltip.
-    const formatTooltipValue = (value: number) =>
-      tooltipValueFormatter
-        ? tooltipValueFormatter(value)
-        : value.toLocaleString()
+    const formatTooltipValue = tooltipValueFormat(tooltipValueFormatter)
 
     // Lines keep the axis trigger — a line is too thin to hover reliably —
     // but render the shared tooltip card. With one series that is the same

--- a/packages/react/src/kits/F0DataChart/components/LineChart/useLineChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/LineChart/useLineChartOptions.ts
@@ -9,7 +9,11 @@ import type {
 } from "../../types"
 
 import { paletteColor, resolveChartColorToken } from "../../utils/colors"
-import { buildBaseChartOptions } from "../../utils/options"
+import {
+  buildBaseChartOptions,
+  deltaRow,
+  renderValueTooltip,
+} from "../../utils/options"
 import type { ChartResponsiveSize } from "../../utils/responsive"
 import { useChartTheme } from "../../utils/useChartTheme"
 import { useContainerSize } from "../../utils/useContainerSize"
@@ -186,6 +190,59 @@ export function useLineChartOptions(
 
     const legendData = series.map((s) => s.name)
 
+    // Tooltips show full numbers, not the compact axis format.
+    const formatTooltipValue = (value: number) => value.toLocaleString()
+
+    // Lines keep the axis trigger — a line is too thin to hover reliably —
+    // but render the shared tooltip card. With one series that is the same
+    // card every other chart type shows; with several, the category heads
+    // the card and each series becomes a row.
+    const tooltipFormatter = (params: unknown) => {
+      if (!Array.isArray(params) || params.length === 0) return ""
+      const points = params as {
+        seriesName?: string
+        axisValueLabel?: string
+        name?: string
+        value?: number
+        dataIndex?: number
+        marker?: string
+      }[]
+      const first = points[0]
+      const category = String(first?.axisValueLabel ?? first?.name ?? "")
+
+      if (points.length === 1 && first) {
+        const value = Number(first.value)
+        const dataIndex = first.dataIndex ?? 0
+        const hovered = series.find((s) => s.name === first.seriesName)
+        const previous =
+          dataIndex > 0 && hovered
+            ? getValue(hovered.data[dataIndex - 1])
+            : undefined
+        return renderValueTooltip(
+          {
+            marker: first.marker,
+            title: String(first.seriesName ?? ""),
+            subtitle: category,
+            value: formatTooltipValue(value),
+            rows: [deltaRow(value, previous, "from previous", theme)],
+          },
+          theme
+        )
+      }
+
+      return renderValueTooltip(
+        {
+          title: category,
+          rows: points.map((point) => ({
+            marker: point.marker,
+            value: formatTooltipValue(Number(point.value)),
+            label: String(point.seriesName ?? ""),
+          })),
+        },
+        theme
+      )
+    }
+
     return buildBaseChartOptions({
       categories,
       theme,
@@ -197,6 +254,7 @@ export function useLineChartOptions(
       showCategoryAxis,
       showValueAxis,
       valueFormatter,
+      tooltipFormatter,
       categoryFormatter,
       echartsOptions,
       containerWidth,

--- a/packages/react/src/kits/F0DataChart/components/PieChart/usePieChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/PieChart/usePieChartOptions.ts
@@ -63,7 +63,10 @@ export function usePieChartOptions(
       ? resolveChartColorToken(series.color)
       : undefined
 
-    const formatTooltipValue = tooltipValueFormat(tooltipValueFormatter)
+    const formatTooltipValue = tooltipValueFormat(
+      tooltipValueFormatter,
+      valueFormatter
+    )
 
     const responsive = resolveResponsiveDisplay(size)
     // The user prop can still force chrome OFF, but never ON at sm/md.

--- a/packages/react/src/kits/F0DataChart/components/PieChart/usePieChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/PieChart/usePieChartOptions.ts
@@ -15,6 +15,7 @@ import {
   buildLegend,
   DEFAULT_EMPHASIS,
   renderValueTooltip,
+  tooltipValueFormat,
 } from "../../utils/options"
 import type { ChartResponsiveSize } from "../../utils/responsive"
 import { useChartTheme } from "../../utils/useChartTheme"
@@ -47,6 +48,7 @@ export function usePieChartOptions(
     showLabels = true,
     showPercentage = false,
     valueFormatter,
+    tooltipValueFormatter,
     echartsOptions,
   }: F0DataChartPieProps,
   size: PieChartSize
@@ -60,6 +62,8 @@ export function usePieChartOptions(
     const resolvedSeriesColor = series.color
       ? resolveChartColorToken(series.color)
       : undefined
+
+    const formatTooltipValue = tooltipValueFormat(tooltipValueFormatter)
 
     const responsive = resolveResponsiveDisplay(size)
     // The user prop can still force chrome OFF, but never ON at sm/md.
@@ -174,18 +178,14 @@ export function usePieChartOptions(
             {
               marker: p.marker,
               title: String(p.name ?? ""),
-              value: valueFormatter
-                ? valueFormatter(val)
-                : val.toLocaleString(),
+              value: formatTooltipValue(val),
               rows: [
                 {
                   value: `${(p.percent ?? 0).toFixed(1)}%`,
                   label: i18n.dataChart.tooltip.ofTotal,
                 },
                 {
-                  value: valueFormatter
-                    ? valueFormatter(total)
-                    : total.toLocaleString(),
+                  value: formatTooltipValue(total),
                   label: i18n.dataChart.tooltip.total,
                 },
               ],
@@ -209,6 +209,7 @@ export function usePieChartOptions(
     showLabels,
     showPercentage,
     valueFormatter,
+    tooltipValueFormatter,
     echartsOptions,
     theme,
     i18n,

--- a/packages/react/src/kits/F0DataChart/components/PieChart/usePieChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/PieChart/usePieChartOptions.ts
@@ -12,6 +12,7 @@ import {
   buildItemTooltip,
   buildLegend,
   DEFAULT_EMPHASIS,
+  renderValueTooltip,
 } from "../../utils/options"
 import type { ChartResponsiveSize } from "../../utils/responsive"
 import { useChartTheme } from "../../utils/useChartTheme"
@@ -165,11 +166,26 @@ export function usePieChartOptions(
             percent?: number
           }
           const val = Number(p.value ?? 0)
-          const formattedValue = valueFormatter
-            ? valueFormatter(val)
-            : String(val)
-          const pct = (p.percent ?? 0).toFixed(1)
-          return `<div>${String(p.marker ?? "")} <strong>${String(p.name ?? "")}</strong></div><div style="margin-top: 2px">${formattedValue} (${pct}%)</div>`
+          const total = dataPoints.reduce((sum, point) => sum + point.value, 0)
+          return renderValueTooltip(
+            {
+              marker: p.marker,
+              title: String(p.name ?? ""),
+              value: valueFormatter
+                ? valueFormatter(val)
+                : val.toLocaleString(),
+              rows: [
+                { value: `${(p.percent ?? 0).toFixed(1)}%`, label: "of total" },
+                {
+                  value: valueFormatter
+                    ? valueFormatter(total)
+                    : total.toLocaleString(),
+                  label: "total",
+                },
+              ],
+            },
+            theme
+          )
         },
       }),
       emphasis: DEFAULT_EMPHASIS,

--- a/packages/react/src/kits/F0DataChart/components/PieChart/usePieChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/PieChart/usePieChartOptions.ts
@@ -2,6 +2,8 @@ import type * as echarts from "echarts"
 
 import { type RefObject, useMemo } from "react"
 
+import { useI18n } from "@/lib/providers/i18n"
+
 import type { F0DataChartPieProps } from "../../types"
 
 import {
@@ -50,6 +52,7 @@ export function usePieChartOptions(
   size: PieChartSize
 ): echarts.EChartsOption {
   const theme = useChartTheme(containerRef)
+  const i18n = useI18n()
   const { width: containerWidth } = useContainerSize(containerRef)
 
   return useMemo(() => {
@@ -175,12 +178,15 @@ export function usePieChartOptions(
                 ? valueFormatter(val)
                 : val.toLocaleString(),
               rows: [
-                { value: `${(p.percent ?? 0).toFixed(1)}%`, label: "of total" },
+                {
+                  value: `${(p.percent ?? 0).toFixed(1)}%`,
+                  label: i18n.dataChart.tooltip.ofTotal,
+                },
                 {
                   value: valueFormatter
                     ? valueFormatter(total)
                     : total.toLocaleString(),
-                  label: "total",
+                  label: i18n.dataChart.tooltip.total,
                 },
               ],
             },
@@ -205,6 +211,7 @@ export function usePieChartOptions(
     valueFormatter,
     echartsOptions,
     theme,
+    i18n,
     containerWidth,
     size,
   ])

--- a/packages/react/src/kits/F0DataChart/components/RadarChart/useRadarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/RadarChart/useRadarChartOptions.ts
@@ -58,7 +58,10 @@ export function useRadarChartOptions(
     const responsive = resolveResponsiveDisplay(size)
     const effectiveShowLegend = responsive.showLegend && showLegend
     const { showIndicatorNames, nameWidth } = responsive
-    const formatTooltipValue = tooltipValueFormat(tooltipValueFormatter)
+    const formatTooltipValue = tooltipValueFormat(
+      tooltipValueFormatter,
+      valueFormatter
+    )
 
     // Auto-calculate max for each indicator if not provided
     const radarIndicators = indicators.map((ind, i) => {

--- a/packages/react/src/kits/F0DataChart/components/RadarChart/useRadarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/RadarChart/useRadarChartOptions.ts
@@ -10,6 +10,7 @@ import {
   renderValueTooltip,
   buildLegend,
   DEFAULT_EMPHASIS,
+  tooltipValueFormat,
 } from "../../utils/options"
 import type { ChartResponsiveSize } from "../../utils/responsive"
 import { useChartTheme } from "../../utils/useChartTheme"
@@ -45,6 +46,7 @@ export function useRadarChartOptions(
     showLegend = true,
     showLabels = false,
     valueFormatter,
+    tooltipValueFormatter,
     echartsOptions,
   }: F0DataChartRadarProps,
   size: RadarChartSize
@@ -56,6 +58,7 @@ export function useRadarChartOptions(
     const responsive = resolveResponsiveDisplay(size)
     const effectiveShowLegend = responsive.showLegend && showLegend
     const { showIndicatorNames, nameWidth } = responsive
+    const formatTooltipValue = tooltipValueFormat(tooltipValueFormatter)
 
     // Auto-calculate max for each indicator if not provided
     const radarIndicators = indicators.map((ind, i) => {
@@ -165,15 +168,10 @@ export function useRadarChartOptions(
             {
               marker: p.marker,
               title: String(p.name ?? ""),
-              rows: indicators.map((indicator, i) => {
-                const val = values[i] ?? 0
-                return {
-                  value: valueFormatter
-                    ? valueFormatter(val)
-                    : val.toLocaleString(),
-                  label: indicator.name,
-                }
-              }),
+              rows: indicators.map((indicator, i) => ({
+                value: formatTooltipValue(values[i] ?? 0),
+                label: indicator.name,
+              })),
             },
             theme
           )
@@ -194,6 +192,7 @@ export function useRadarChartOptions(
     showLegend,
     showLabels,
     valueFormatter,
+    tooltipValueFormatter,
     echartsOptions,
     theme,
     containerSize,

--- a/packages/react/src/kits/F0DataChart/components/RadarChart/useRadarChartOptions.ts
+++ b/packages/react/src/kits/F0DataChart/components/RadarChart/useRadarChartOptions.ts
@@ -7,6 +7,7 @@ import type { F0DataChartRadarProps } from "../../types"
 import { paletteColor, resolveChartColorToken } from "../../utils/colors"
 import {
   buildItemTooltip,
+  renderValueTooltip,
   buildLegend,
   DEFAULT_EMPHASIS,
 } from "../../utils/options"
@@ -158,17 +159,24 @@ export function useRadarChartOptions(
             value?: number[]
           }
           const values = p.value ?? []
-          const header = `<div style="margin-bottom: 4px">${String(p.marker ?? "")} <strong>${String(p.name ?? "")}</strong></div>`
-          const items = indicators
-            .map((ind, i) => {
-              const val = values[i] ?? 0
-              const formattedVal = valueFormatter
-                ? valueFormatter(val)
-                : String(val)
-              return `<div>${ind.name}: <strong>${formattedVal}</strong></div>`
-            })
-            .join("")
-          return `${header}${items}`
+          // A radar point carries every indicator at once, so there is no
+          // single headline value — the indicators are the rows.
+          return renderValueTooltip(
+            {
+              marker: p.marker,
+              title: String(p.name ?? ""),
+              rows: indicators.map((indicator, i) => {
+                const val = values[i] ?? 0
+                return {
+                  value: valueFormatter
+                    ? valueFormatter(val)
+                    : val.toLocaleString(),
+                  label: indicator.name,
+                }
+              }),
+            },
+            theme
+          )
         },
       }),
       emphasis: DEFAULT_EMPHASIS,

--- a/packages/react/src/kits/F0DataChart/types.ts
+++ b/packages/react/src/kits/F0DataChart/types.ts
@@ -179,9 +179,12 @@ export interface F0DataChartBarProps extends F0DataChartBaseProps {
    */
   labelFontSize?: number
   /**
-   * Formatter for the values shown in the hover tooltip. Defaults to
-   * {@link F0DataChartBaseProps.valueFormatter}; set it to show precise values
-   * (e.g. "107,505") while the axis and labels stay compact ("107.5K").
+   * Formatter for the values shown in the hover tooltip. Defaults to a plain
+   * localized number, so the tooltip stays precise ("107,505") while the axis
+   * and labels stay compact ("107.5K"). Set it to keep a unit in the tooltip
+   * (e.g. `(v) => \`${v}%\``), which
+   * {@link F0DataChartBaseProps.valueFormatter} does not do — that one formats
+   * the axis only.
    */
   tooltipValueFormatter?: (value: number) => string
 }
@@ -204,6 +207,15 @@ export interface F0DataChartLineProps extends F0DataChartBaseProps {
   showArea?: boolean
   /** Show data point dots on the lines. @default false */
   showDots?: boolean
+  /**
+   * Formatter for the values shown in the hover tooltip. Defaults to a plain
+   * localized number, so the tooltip stays precise ("107,505") while the axis
+   * and labels stay compact ("107.5K"). Set it to keep a unit in the tooltip
+   * (e.g. `(v) => \`${v}%\``), which
+   * {@link F0DataChartBaseProps.valueFormatter} does not do — that one formats
+   * the axis only.
+   */
+  tooltipValueFormatter?: (value: number) => string
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/kits/F0DataChart/types.ts
+++ b/packages/react/src/kits/F0DataChart/types.ts
@@ -179,12 +179,11 @@ export interface F0DataChartBarProps extends F0DataChartBaseProps {
    */
   labelFontSize?: number
   /**
-   * Formatter for the values shown in the hover tooltip. Defaults to a plain
-   * localized number, so the tooltip stays precise ("107,505") while the axis
-   * and labels stay compact ("107.5K"). Set it to keep a unit in the tooltip
-   * (e.g. `(v) => \`${v}%\``), which
-   * {@link F0DataChartBaseProps.valueFormatter} does not do — that one formats
-   * the axis only.
+   * Formatter for the values shown in the hover tooltip. Defaults to
+   * {@link F0DataChartBaseProps.valueFormatter}, so a unit or a currency on the
+   * axis reads the same on hover, then to a plain localized number. Set it when
+   * the axis has to stay compact ("107.5K") but the tooltip should be exact
+   * ("107,505").
    */
   tooltipValueFormatter?: (value: number) => string
 }
@@ -208,12 +207,11 @@ export interface F0DataChartLineProps extends F0DataChartBaseProps {
   /** Show data point dots on the lines. @default false */
   showDots?: boolean
   /**
-   * Formatter for the values shown in the hover tooltip. Defaults to a plain
-   * localized number, so the tooltip stays precise ("107,505") while the axis
-   * and labels stay compact ("107.5K"). Set it to keep a unit in the tooltip
-   * (e.g. `(v) => \`${v}%\``), which
-   * {@link F0DataChartBaseProps.valueFormatter} does not do — that one formats
-   * the axis only.
+   * Formatter for the values shown in the hover tooltip. Defaults to
+   * {@link F0DataChartBaseProps.valueFormatter}, so a unit or a currency on the
+   * axis reads the same on hover, then to a plain localized number. Set it when
+   * the axis has to stay compact ("107.5K") but the tooltip should be exact
+   * ("107,505").
    */
   tooltipValueFormatter?: (value: number) => string
 }
@@ -282,11 +280,10 @@ export interface F0DataChartFunnelProps extends F0DataChartCommonProps {
   /** Format the value displayed in labels and tooltip */
   valueFormatter?: (value: number) => string
   /**
-   * Formatter for the value shown in the hover tooltip. Defaults to a plain
-   * localized number, so the tooltip stays precise ("107,505") while the labels
-   * stay compact ("107.5K"). Set it to keep a unit in the tooltip
-   * (e.g. `(v) => \`${v}%\``), which {@link valueFormatter} does not do — that
-   * one formats the labels only.
+   * Formatter for the value shown in the hover tooltip. Defaults to
+   * {@link valueFormatter}, so a unit or a currency on the labels reads the same
+   * on hover, then to a plain localized number. Set it when the labels have to
+   * stay compact ("107.5K") but the tooltip should be exact ("107,505").
    */
   tooltipValueFormatter?: (value: number) => string
   /**
@@ -352,11 +349,10 @@ export interface F0DataChartPieProps extends F0DataChartCommonProps {
   /** Format the value displayed in labels and tooltip */
   valueFormatter?: (value: number) => string
   /**
-   * Formatter for the value shown in the hover tooltip. Defaults to a plain
-   * localized number, so the tooltip stays precise ("107,505") while the labels
-   * stay compact ("107.5K"). Set it to keep a unit in the tooltip
-   * (e.g. `(v) => \`${v}%\``), which {@link valueFormatter} does not do — that
-   * one formats the labels only.
+   * Formatter for the value shown in the hover tooltip. Defaults to
+   * {@link valueFormatter}, so a unit or a currency on the labels reads the same
+   * on hover, then to a plain localized number. Set it when the labels have to
+   * stay compact ("107.5K") but the tooltip should be exact ("107,505").
    */
   tooltipValueFormatter?: (value: number) => string
   /** Escape hatch: raw ECharts options merged (shallow) on top of the generated config */
@@ -414,11 +410,10 @@ export interface F0DataChartRadarProps extends F0DataChartCommonProps {
   /** Format values in labels and tooltip */
   valueFormatter?: (value: number) => string
   /**
-   * Formatter for the value shown in the hover tooltip. Defaults to a plain
-   * localized number, so the tooltip stays precise ("107,505") while the labels
-   * stay compact ("107.5K"). Set it to keep a unit in the tooltip
-   * (e.g. `(v) => \`${v}%\``), which {@link valueFormatter} does not do — that
-   * one formats the labels only.
+   * Formatter for the value shown in the hover tooltip. Defaults to
+   * {@link valueFormatter}, so a unit or a currency on the labels reads the same
+   * on hover, then to a plain localized number. Set it when the labels have to
+   * stay compact ("107.5K") but the tooltip should be exact ("107,505").
    */
   tooltipValueFormatter?: (value: number) => string
   /** Escape hatch: raw ECharts options merged (shallow) on top of the generated config */
@@ -452,11 +447,10 @@ export interface F0DataChartGaugeProps extends F0DataChartCommonProps {
   /** Format the value displayed */
   valueFormatter?: (value: number) => string
   /**
-   * Formatter for the value shown in the hover tooltip. Defaults to a plain
-   * localized number, so the tooltip stays precise ("107,505") while the labels
-   * stay compact ("107.5K"). Set it to keep a unit in the tooltip
-   * (e.g. `(v) => \`${v}%\``), which {@link valueFormatter} does not do — that
-   * one formats the labels only.
+   * Formatter for the value shown in the hover tooltip. Defaults to
+   * {@link valueFormatter}, so a unit or a currency on the labels reads the same
+   * on hover, then to a plain localized number. Set it when the labels have to
+   * stay compact ("107.5K") but the tooltip should be exact ("107,505").
    */
   tooltipValueFormatter?: (value: number) => string
   /** Escape hatch: raw ECharts options merged (shallow) on top of the generated config */
@@ -494,11 +488,10 @@ export interface F0DataChartHeatmapProps extends F0DataChartCommonProps {
   /** Format values in labels and tooltip */
   valueFormatter?: (value: number) => string
   /**
-   * Formatter for the value shown in the hover tooltip. Defaults to a plain
-   * localized number, so the tooltip stays precise ("107,505") while the labels
-   * stay compact ("107.5K"). Set it to keep a unit in the tooltip
-   * (e.g. `(v) => \`${v}%\``), which {@link valueFormatter} does not do — that
-   * one formats the labels only.
+   * Formatter for the value shown in the hover tooltip. Defaults to
+   * {@link valueFormatter}, so a unit or a currency on the labels reads the same
+   * on hover, then to a plain localized number. Set it when the labels have to
+   * stay compact ("107.5K") but the tooltip should be exact ("107,505").
    */
   tooltipValueFormatter?: (value: number) => string
   /** Escape hatch: raw ECharts options merged (shallow) on top of the generated config */

--- a/packages/react/src/kits/F0DataChart/types.ts
+++ b/packages/react/src/kits/F0DataChart/types.ts
@@ -282,6 +282,14 @@ export interface F0DataChartFunnelProps extends F0DataChartCommonProps {
   /** Format the value displayed in labels and tooltip */
   valueFormatter?: (value: number) => string
   /**
+   * Formatter for the value shown in the hover tooltip. Defaults to a plain
+   * localized number, so the tooltip stays precise ("107,505") while the labels
+   * stay compact ("107.5K"). Set it to keep a unit in the tooltip
+   * (e.g. `(v) => \`${v}%\``), which {@link valueFormatter} does not do — that
+   * one formats the labels only.
+   */
+  tooltipValueFormatter?: (value: number) => string
+  /**
    * Map stage colors to their values using a gradient scale (light→dark).
    * When enabled, higher values get a more intense color. @default true
    */
@@ -343,6 +351,14 @@ export interface F0DataChartPieProps extends F0DataChartCommonProps {
   showPercentage?: boolean
   /** Format the value displayed in labels and tooltip */
   valueFormatter?: (value: number) => string
+  /**
+   * Formatter for the value shown in the hover tooltip. Defaults to a plain
+   * localized number, so the tooltip stays precise ("107,505") while the labels
+   * stay compact ("107.5K"). Set it to keep a unit in the tooltip
+   * (e.g. `(v) => \`${v}%\``), which {@link valueFormatter} does not do — that
+   * one formats the labels only.
+   */
+  tooltipValueFormatter?: (value: number) => string
   /** Escape hatch: raw ECharts options merged (shallow) on top of the generated config */
   echartsOptions?: Partial<echarts.EChartsOption>
 }
@@ -397,6 +413,14 @@ export interface F0DataChartRadarProps extends F0DataChartCommonProps {
   showLabels?: boolean
   /** Format values in labels and tooltip */
   valueFormatter?: (value: number) => string
+  /**
+   * Formatter for the value shown in the hover tooltip. Defaults to a plain
+   * localized number, so the tooltip stays precise ("107,505") while the labels
+   * stay compact ("107.5K"). Set it to keep a unit in the tooltip
+   * (e.g. `(v) => \`${v}%\``), which {@link valueFormatter} does not do — that
+   * one formats the labels only.
+   */
+  tooltipValueFormatter?: (value: number) => string
   /** Escape hatch: raw ECharts options merged (shallow) on top of the generated config */
   echartsOptions?: Partial<echarts.EChartsOption>
 }
@@ -427,6 +451,14 @@ export interface F0DataChartGaugeProps extends F0DataChartCommonProps {
   showValue?: boolean
   /** Format the value displayed */
   valueFormatter?: (value: number) => string
+  /**
+   * Formatter for the value shown in the hover tooltip. Defaults to a plain
+   * localized number, so the tooltip stays precise ("107,505") while the labels
+   * stay compact ("107.5K"). Set it to keep a unit in the tooltip
+   * (e.g. `(v) => \`${v}%\``), which {@link valueFormatter} does not do — that
+   * one formats the labels only.
+   */
+  tooltipValueFormatter?: (value: number) => string
   /** Escape hatch: raw ECharts options merged (shallow) on top of the generated config */
   echartsOptions?: Partial<echarts.EChartsOption>
 }
@@ -461,6 +493,14 @@ export interface F0DataChartHeatmapProps extends F0DataChartCommonProps {
   showVisualMap?: boolean
   /** Format values in labels and tooltip */
   valueFormatter?: (value: number) => string
+  /**
+   * Formatter for the value shown in the hover tooltip. Defaults to a plain
+   * localized number, so the tooltip stays precise ("107,505") while the labels
+   * stay compact ("107.5K"). Set it to keep a unit in the tooltip
+   * (e.g. `(v) => \`${v}%\``), which {@link valueFormatter} does not do — that
+   * one formats the labels only.
+   */
+  tooltipValueFormatter?: (value: number) => string
   /** Escape hatch: raw ECharts options merged (shallow) on top of the generated config */
   echartsOptions?: Partial<echarts.EChartsOption>
 }

--- a/packages/react/src/kits/F0DataChart/utils/options.ts
+++ b/packages/react/src/kits/F0DataChart/utils/options.ts
@@ -384,6 +384,109 @@ export function escapeTooltipText(value: unknown): string {
     .replace(/'/g, "&#039;")
 }
 
+// ---------------------------------------------------------------------------
+// Shared tooltip content renderer
+// ---------------------------------------------------------------------------
+
+/** Minimum tooltip width (px) so short values don't produce a cramped box. */
+const TOOLTIP_MIN_WIDTH = 130
+
+/** A context line below the headline value, e.g. "14.1% of total". */
+export interface ValueTooltipRow {
+  /** Emphasized leading text — a value, percentage, or delta. */
+  value: string
+  /** Trailing description, e.g. "of total", "target", "from previous". */
+  label: string
+  /** Color for the emphasized part. Defaults to the primary foreground. */
+  color?: string
+  /** ECharts' colored dot, for rows that stand for a series. Trusted HTML. */
+  marker?: string
+}
+
+export interface ValueTooltipContent {
+  /**
+   * ECharts' own colored dot. Trusted HTML generated per data point (it
+   * reflects per-point color overrides), so it is the one part rendered
+   * unescaped. Everything else is escaped.
+   */
+  marker?: string
+  /** Series, slice, or stage name. */
+  title?: string
+  /** Secondary line under the title — usually the category. */
+  subtitle?: string
+  /** Headline value, already formatted. Omit for tooltips that only list rows. */
+  value?: string
+  /** Context lines below the headline. Falsy entries are skipped. */
+  rows?: (ValueTooltipRow | undefined | false)[]
+}
+
+/**
+ * Render the shared F0 chart tooltip: colored dot + name, category, a large
+ * value, then context rows. Every chart type uses this so a tooltip reads the
+ * same regardless of which visualization the user is hovering.
+ */
+export function renderValueTooltip(
+  { marker, title, subtitle, value, rows = [] }: ValueTooltipContent,
+  theme: ChartTheme
+): string {
+  const secondary = `color: ${theme.colors.foregroundSecondary}; font-size: 12px`
+  const visibleRows = rows.filter((row): row is ValueTooltipRow => Boolean(row))
+
+  const html = [
+    title !== undefined
+      ? `<div style="font-weight: 600">${String(marker ?? "")}${escapeTooltipText(title)}</div>`
+      : "",
+    subtitle !== undefined
+      ? `<div style="${secondary}">${escapeTooltipText(subtitle)}</div>`
+      : "",
+    value !== undefined
+      ? `<div style="font-size: 20px; font-weight: 600; line-height: 1.2; margin-top: 6px">${escapeTooltipText(value)}</div>`
+      : "",
+    visibleRows.length > 0
+      ? `<div style="margin-top: 6px">${visibleRows
+          .map(
+            (row) =>
+              `<div style="${secondary}">${String(row.marker ?? "")}<strong style="color: ${row.color ?? theme.colors.foreground}">${escapeTooltipText(row.value)}</strong> ${escapeTooltipText(row.label)}</div>`
+          )
+          .join("")}</div>`
+      : "",
+  ].join("")
+
+  return `<div style="min-width: ${TOOLTIP_MIN_WIDTH}px">${html}</div>`
+}
+
+/**
+ * Build a tooltip dot in an explicit color, matching the one ECharts injects
+ * as `params.marker`. Needed where ECharts' own marker uses the palette rather
+ * than the color actually painted (e.g. the gauge arc).
+ */
+export function renderMarker(color: string): string {
+  // The color lands in a style attribute — keep it to CSS color syntax.
+  const safe = color.replace(/[^a-zA-Z0-9#(),.%\s/-]/g, "")
+  return `<span style="display:inline-block;margin-right:4px;border-radius:10px;width:10px;height:10px;background-color:${safe}"></span>`
+}
+
+/**
+ * Format a signed percentage delta ("+22.2%") and pick its semantic color.
+ * Returns `undefined` when there is nothing meaningful to compare against.
+ */
+export function deltaRow(
+  value: number,
+  previous: number | undefined,
+  label: string,
+  theme: ChartTheme
+): ValueTooltipRow | undefined {
+  if (previous === undefined || previous === 0 || !Number.isFinite(value)) {
+    return undefined
+  }
+  const change = ((value - previous) / Math.abs(previous)) * 100
+  return {
+    value: `${change >= 0 ? "+" : ""}${change.toFixed(1)}%`,
+    label,
+    color: change >= 0 ? theme.colors.positive : theme.colors.critical,
+  }
+}
+
 /**
  * Build a fully styled axis-triggered tooltip that optionally filters out
  * ghost series (e.g. target gradient bars).

--- a/packages/react/src/kits/F0DataChart/utils/options.ts
+++ b/packages/react/src/kits/F0DataChart/utils/options.ts
@@ -458,19 +458,22 @@ export function renderValueTooltip(
 /**
  * The formatter every chart type uses for the values in its tooltip.
  *
- * Tooltips show the full localized number ("125,000") rather than the compact
- * form axes and labels use ("125k"): the tooltip is where the exact figure
- * belongs, and it is the same number on every chart type. `valueFormatter`
- * deliberately does not reach here — pass `tooltipValueFormatter` to control
- * this number, which is also how a unit or a currency gets into a tooltip.
+ * A tooltip reads the number the same way the rest of the chart does, so it
+ * takes `valueFormatter` — the one that writes the axis and the labels. That is
+ * what carries a unit across: a chart whose axis says "€46,390.86" would
+ * otherwise hover as "46390.863", dropping the currency and exposing raw
+ * float precision.
+ *
+ * `tooltipValueFormatter` overrides it, for the case where the axis has to stay
+ * compact ("125k") but the tooltip should be exact ("125,000"). With neither,
+ * the value falls back to a plain localized number.
  */
 export function tooltipValueFormat(
-  tooltipValueFormatter?: (value: number) => string
+  tooltipValueFormatter?: (value: number) => string,
+  valueFormatter?: (value: number) => string
 ): (value: number) => string {
-  return (value) =>
-    tooltipValueFormatter
-      ? tooltipValueFormatter(value)
-      : value.toLocaleString()
+  const format = tooltipValueFormatter ?? valueFormatter
+  return (value) => (format ? format(value) : value.toLocaleString())
 }
 
 /**

--- a/packages/react/src/kits/F0DataChart/utils/options.ts
+++ b/packages/react/src/kits/F0DataChart/utils/options.ts
@@ -456,6 +456,24 @@ export function renderValueTooltip(
 }
 
 /**
+ * The formatter every chart type uses for the values in its tooltip.
+ *
+ * Tooltips show the full localized number ("125,000") rather than the compact
+ * form axes and labels use ("125k"): the tooltip is where the exact figure
+ * belongs, and it is the same number on every chart type. `valueFormatter`
+ * deliberately does not reach here — pass `tooltipValueFormatter` to control
+ * this number, which is also how a unit or a currency gets into a tooltip.
+ */
+export function tooltipValueFormat(
+  tooltipValueFormatter?: (value: number) => string
+): (value: number) => string {
+  return (value) =>
+    tooltipValueFormatter
+      ? tooltipValueFormatter(value)
+      : value.toLocaleString()
+}
+
+/**
  * Build a tooltip dot in an explicit color, matching the one ECharts injects
  * as `params.marker`. Needed where ECharts' own marker uses the palette rather
  * than the color actually painted (e.g. the gauge arc).

--- a/packages/react/src/kits/F0DataChart/utils/theme.ts
+++ b/packages/react/src/kits/F0DataChart/utils/theme.ts
@@ -32,10 +32,14 @@ export interface ChartThemeColors {
    * `containerBackground ?? background`.
    */
   containerBackground?: string
-  /** Positive delta text (e.g. tooltip "+x% from previous"). Resolves from --positive-70 */
-  positive: string
-  /** Negative delta text. Resolves from --critical-70 */
-  critical: string
+  /**
+   * Positive delta text (e.g. tooltip "+x% from previous"). Resolves from
+   * --positive-70. Optional so a hand-built theme stays valid — tooltip rows
+   * fall back to `foreground` when it is absent.
+   */
+  positive?: string
+  /** Negative delta text. Resolves from --critical-70. Optional, as `positive`. */
+  critical?: string
 }
 
 /** Tooltip visual configuration */

--- a/packages/react/src/kits/F0DataChart/utils/theme.ts
+++ b/packages/react/src/kits/F0DataChart/utils/theme.ts
@@ -32,6 +32,10 @@ export interface ChartThemeColors {
    * `containerBackground ?? background`.
    */
   containerBackground?: string
+  /** Positive delta text (e.g. tooltip "+x% from previous"). Resolves from --positive-70 */
+  positive: string
+  /** Negative delta text. Resolves from --critical-70 */
+  critical: string
 }
 
 /** Tooltip visual configuration */
@@ -231,6 +235,8 @@ export function resolveChartTheme(element?: Element | null): ChartTheme {
       : LIGHT_TOOLTIP.background,
     background,
     containerBackground: resolveContainerBackground(element, background),
+    positive: resolveCssColor("--positive-70", baseColors.grass[70], element),
+    critical: resolveCssColor("--critical-70", baseColors.red[70], element),
   }
 
   return {

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -672,6 +672,14 @@ export const defaultTranslations = {
       title: "No data available",
       description: "Try a different date or fewer filters",
     },
+    tooltip: {
+      ofTotal: "of total",
+      total: "total",
+      target: "target",
+      ofRange: "of range",
+      fromPrevious: "from previous",
+      fromStage: "from {{stage}}",
+    },
   },
   progressSeries: {
     noData: "No data",

--- a/packages/react/src/lib/providers/i18n/i18n-provider.spec.tsx
+++ b/packages/react/src/lib/providers/i18n/i18n-provider.spec.tsx
@@ -56,6 +56,79 @@ describe("I18nProvider", () => {
     expect(screen.getByTestId("translation")).toHaveTextContent("Desar")
   })
 
+  // A dictionary written against an older f0 does not know keys added since.
+  // Components read many of them by property access, so the gaps have to close
+  // with English rather than surface as `undefined` (or throw on a subtree).
+  it("fills keys the consumer's dictionary is missing with the defaults", () => {
+    const stale = {
+      ...defaultTranslations,
+      actions: { ...defaultTranslations.actions, save: "Desar" },
+      dataChart: {
+        ...defaultTranslations.dataChart,
+        // An older dictionary predates the whole tooltip subtree.
+        tooltip: undefined,
+      },
+    } as unknown as TranslationsType
+
+    function ReadsNewKeys() {
+      const i18n = useI18n()
+      return (
+        <>
+          <div data-testid="overridden">{i18n.actions.save}</div>
+          <div data-testid="missing-subtree">
+            {i18n.dataChart.tooltip.ofTotal}
+          </div>
+          <div data-testid="via-t">
+            {i18n.t("dataChart.tooltip.fromStage", { stage: "Applied" })}
+          </div>
+        </>
+      )
+    }
+
+    render(
+      <I18nProvider translations={stale}>
+        <ReadsNewKeys />
+      </I18nProvider>
+    )
+
+    expect(screen.getByTestId("overridden")).toHaveTextContent("Desar")
+    expect(screen.getByTestId("missing-subtree")).toHaveTextContent(
+      defaultTranslations.dataChart.tooltip.ofTotal
+    )
+    expect(screen.getByTestId("via-t")).toHaveTextContent("from Applied")
+  })
+
+  it("keeps a partially translated subtree and defaults only its gaps", () => {
+    const partial = {
+      ...defaultTranslations,
+      dataChart: {
+        ...defaultTranslations.dataChart,
+        tooltip: { ofTotal: "del total" },
+      },
+    } as unknown as TranslationsType
+
+    function ReadsTooltipKeys() {
+      const i18n = useI18n()
+      return (
+        <>
+          <div data-testid="translated">{i18n.dataChart.tooltip.ofTotal}</div>
+          <div data-testid="defaulted">{i18n.dataChart.tooltip.target}</div>
+        </>
+      )
+    }
+
+    render(
+      <I18nProvider translations={partial}>
+        <ReadsTooltipKeys />
+      </I18nProvider>
+    )
+
+    expect(screen.getByTestId("translated")).toHaveTextContent("del total")
+    expect(screen.getByTestId("defaulted")).toHaveTextContent(
+      defaultTranslations.dataChart.tooltip.target
+    )
+  })
+
   it("falls back to default translations when used outside a provider", () => {
     // No provider: the hook must not throw — it degrades to the built-in
     // (English) defaults so the subtree still renders.

--- a/packages/react/src/lib/providers/i18n/i18n-provider.tsx
+++ b/packages/react/src/lib/providers/i18n/i18n-provider.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { createContext, ReactNode, useContext } from "react"
+import { createContext, ReactNode, useContext, useMemo } from "react"
 
 import {
   defaultTranslations,
@@ -37,10 +37,49 @@ const getKey = (
   return typeof current === "string" ? current : undefined
 }
 
+const isSubtree = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+/**
+ * Fill the gaps in a consumer's dictionary from the built-in (English)
+ * defaults, recursively.
+ *
+ * f0 gains translation keys as it gains features, and components read many of
+ * them by property access (`i18n.dataChart.tooltip.total`) rather than through
+ * `t`, so a dictionary written against an older version would otherwise render
+ * `undefined` — or throw on a whole missing subtree — instead of degrading to
+ * English. Arrays and non-objects are treated as leaves: the consumer's value
+ * wins outright.
+ */
+const withDefaults = <T extends Record<string, unknown>>(
+  defaults: T,
+  overrides: Record<string, unknown>
+): T => {
+  const merged: Record<string, unknown> = { ...defaults }
+
+  for (const [key, value] of Object.entries(overrides)) {
+    // An explicit `undefined` means "not translated", not "erase the default".
+    if (value === undefined) continue
+
+    const fallback = merged[key]
+    merged[key] =
+      isSubtree(value) && isSubtree(fallback)
+        ? withDefaults(fallback, value)
+        : value
+  }
+
+  return merged as T
+}
+
 export function I18nProvider({
   children,
   translations,
 }: I18nProviderProps): JSX.Element {
+  const resolved = useMemo(
+    () => withDefaults(defaultTranslations, translations),
+    [translations]
+  )
+
   /*
    * Create a function that returns a translation for a given key and replaces the arguments.
    * If the key is not found, it will return undefined.
@@ -50,7 +89,7 @@ export function I18nProvider({
     key: TranslationKey,
     args: Record<string, string | number> = {}
   ) => {
-    let translation = getKey(key, translations)
+    let translation = getKey(key, resolved)
     if (translation === undefined) {
       console.warn(`Translation key ${key} not found`)
       return key
@@ -63,7 +102,7 @@ export function I18nProvider({
     return translation
   }
   return (
-    <I18nContext.Provider value={{ ...translations, t }}>
+    <I18nContext.Provider value={{ ...resolved, t }}>
       {children}
     </I18nContext.Provider>
   )

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/chartLabelDefaults.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/chartLabelDefaults.test.ts
@@ -97,3 +97,60 @@ describe("buildChartProps — bar label default (transform path)", () => {
     ).toBeUndefined()
   })
 })
+
+// ---------------------------------------------------------------------------
+// A dashboard chart can format its tooltip separately from its axis — the pair
+// exists so the axis can compact ("€60K") while the tooltip stays exact
+// ("€46,390.86"). Both routes into the props have to carry it.
+// ---------------------------------------------------------------------------
+
+describe("buildChartProps — tooltipValueFormatter", () => {
+  const axis = (value: number) => `€${Math.round(value / 1000)}K`
+  const exact = (value: number) => `€${value.toLocaleString("en-US")}`
+
+  it("passes both formatters through on the native path", () => {
+    const props = buildChartProps(
+      chartItem({
+        type: "bar",
+        valueFormatter: axis,
+        tooltipValueFormatter: exact,
+      }),
+      barData
+    ) as {
+      valueFormatter?: (value: number) => string
+      tooltipValueFormatter?: (value: number) => string
+    }
+
+    expect(props.valueFormatter?.(60000)).toBe("€60K")
+    expect(props.tooltipValueFormatter?.(46390.8632)).toBe("€46,390.863")
+  })
+
+  it("keeps both across a cross-type transform", () => {
+    const props = buildChartProps(
+      chartItem({
+        type: "bar",
+        valueFormatter: axis,
+        tooltipValueFormatter: exact,
+      }),
+      barData,
+      "line"
+    ) as {
+      valueFormatter?: (value: number) => string
+      tooltipValueFormatter?: (value: number) => string
+    }
+
+    expect(props.valueFormatter?.(60000)).toBe("€60K")
+    expect(props.tooltipValueFormatter?.(60000)).toBe("€60,000")
+  })
+
+  it("leaves the tooltip formatter unset when the config has none", () => {
+    const props = buildChartProps(
+      chartItem({ type: "bar", valueFormatter: axis }),
+      barData,
+      "line"
+    ) as { tooltipValueFormatter?: (value: number) => string }
+
+    // Unset means F0DataChart falls back to `valueFormatter` itself.
+    expect(props.tooltipValueFormatter).toBeUndefined()
+  })
+})

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -195,6 +195,12 @@ export function buildChartProps(
   if ("valueFormatter" in item.chart && item.chart.valueFormatter) {
     shared.valueFormatter = item.chart.valueFormatter
   }
+  if (
+    "tooltipValueFormatter" in item.chart &&
+    item.chart.tooltipValueFormatter
+  ) {
+    shared.tooltipValueFormatter = item.chart.tooltipValueFormatter
+  }
   if ("showLegend" in item.chart) {
     shared.showLegend = item.chart.showLegend
   }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
@@ -30,6 +30,12 @@ interface ChartConfigBase {
   showLabels?: boolean
   /** Format the value axis tick labels */
   valueFormatter?: (value: number) => string
+  /**
+   * Format the value shown in the hover tooltip. Defaults to
+   * {@link valueFormatter}; set it when the axis and labels must stay compact
+   * while the tooltip carries the exact figure.
+   */
+  tooltipValueFormatter?: (value: number) => string
   /** Format category axis tick labels */
   categoryFormatter?: (value: string) => string
 }
@@ -72,6 +78,12 @@ export interface FunnelChartConfig {
   colorScale?: boolean
   /** Format the value displayed in labels and tooltip */
   valueFormatter?: (value: number) => string
+  /**
+   * Format the value shown in the hover tooltip. Defaults to
+   * {@link valueFormatter}; set it when the axis and labels must stay compact
+   * while the tooltip carries the exact figure.
+   */
+  tooltipValueFormatter?: (value: number) => string
 }
 
 export interface PieChartConfig {
@@ -86,6 +98,12 @@ export interface PieChartConfig {
   showPercentage?: boolean
   /** Format the value displayed in labels and tooltip */
   valueFormatter?: (value: number) => string
+  /**
+   * Format the value shown in the hover tooltip. Defaults to
+   * {@link valueFormatter}; set it when the axis and labels must stay compact
+   * while the tooltip carries the exact figure.
+   */
+  tooltipValueFormatter?: (value: number) => string
 }
 
 export interface RadarChartConfig {
@@ -98,6 +116,12 @@ export interface RadarChartConfig {
   showLabels?: boolean
   /** Format the value displayed in labels and tooltip */
   valueFormatter?: (value: number) => string
+  /**
+   * Format the value shown in the hover tooltip. Defaults to
+   * {@link valueFormatter}; set it when the axis and labels must stay compact
+   * while the tooltip carries the exact figure.
+   */
+  tooltipValueFormatter?: (value: number) => string
 }
 
 export interface GaugeChartConfig {
@@ -112,6 +136,12 @@ export interface GaugeChartConfig {
   showValue?: boolean
   /** Format the value displayed inside the gauge */
   valueFormatter?: (value: number) => string
+  /**
+   * Format the value shown in the hover tooltip. Defaults to
+   * {@link valueFormatter}; set it when the axis and labels must stay compact
+   * while the tooltip carries the exact figure.
+   */
+  tooltipValueFormatter?: (value: number) => string
 }
 
 export interface HeatmapChartConfig {
@@ -126,6 +156,12 @@ export interface HeatmapChartConfig {
   showVisualMap?: boolean
   /** Format the value displayed in cells and tooltip */
   valueFormatter?: (value: number) => string
+  /**
+   * Format the value shown in the hover tooltip. Defaults to
+   * {@link valueFormatter}; set it when the axis and labels must stay compact
+   * while the tooltip carries the exact figure.
+   */
+  tooltipValueFormatter?: (value: number) => string
 }
 
 /**


### PR DESCRIPTION
## Description

Each chart type had grown its own tooltip formatter, so the same hover produced a different layout depending on the visualization — pie showed `value (pct%)`, funnel had `Overall:` / `From X:` lines, radar an inline list, bar an axis summary of every series. This introduces one shared `renderValueTooltip` and routes all seven chart types through it, so a tooltip always reads the same: coloured dot + name, the category, a large value, then context rows.

## Screenshots (if applicable)

https://github.com/user-attachments/assets/77e36fd1-095f-4456-965d-143d27219bec

<img width="633" height="401" alt="image" src="https://github.com/user-attachments/assets/33afb974-53d4-404a-8d69-6fe8e525e00a" />

<img width="641" height="357" alt="image" src="https://github.com/user-attachments/assets/2760d8d5-1847-49c4-8533-ce5144b14923" />

<img width="445" height="392" alt="image" src="https://github.com/user-attachments/assets/8e74587d-0c76-4bb2-8425-463e520850cf" />

<img width="631" height="384" alt="image" src="https://github.com/user-attachments/assets/798bc22a-6d37-4986-b421-243a9c7e1f17" />

<img width="635" height="377" alt="image" src="https://github.com/user-attachments/assets/7f1f3995-279e-4570-b267-29b04f2bd9c4" />

<img width="455" height="322" alt="image" src="https://github.com/user-attachments/assets/e826acd2-a0d0-47d3-98d2-c7206308d174" />

<img width="870" height="422" alt="image" src="https://github.com/user-attachments/assets/371773cc-964a-4572-8f16-bfb41e17f7c1" />


## Implementation details

- feat: add `renderValueTooltip`, `deltaRow` and `renderMarker` to the chart options utils as the single tooltip renderer, with a 130px min width and escaping of everything except ECharts' own marker HTML
- feat: route bar, line, pie, funnel, radar, gauge and heatmap tooltips through the shared renderer
- feat: show full numbers in tooltips (`125,000`, not the compact `125k` used on axes); `tooltipValueFormatter` still overrides
- feat: show "from previous" only on line charts

  <details>
  <summary>Why line only?</summary>

  Bar categories are not necessarily a sequence — departments, locations,
  statuses — so comparing a bar with the one to its left is often meaningless.
  A line chart is a trend by definition, so the comparison always holds there.
  </details>

- feat: give bar charts an item-triggered tooltip describing the hovered bar or segment, replacing the axis tooltip that listed every series

  <details>
  <summary>Interaction change</summary>

  With `trigger: "item"` a bar tooltip appears only when the pointer is over a
  bar, not anywhere in the category column. That is what makes it possible to
  know *which* segment is hovered. Lines keep the axis trigger — a 2px line is
  too thin to hover reliably — and therefore list every series when there is
  more than one.
  </details>

- fix: build the gauge tooltip marker from the resolved arc colour, since ECharts' own `params.marker` uses the palette entry rather than the colour painted
- feat: add `positive` / `critical` to the chart theme colours for signed deltas
- test: cover the renderer's escaping, omitted sections, delta signing and marker sanitisation, plus per-type tooltip behaviour on bar charts

### After review (@zygisS22)

- **fix: never derive a bar's share from a signed net total.** A category mixing gains with losses has no total its parts add up to — 24 hires against a net of 19 read as "126.3% of total", and near-cancellation made the ratio arbitrarily large. Mixed-sign categories now show the value alone; all-negative keeps both rows (the ratio still reads as a positive share of a negative whole); all-zero keeps the true total and skips the division.
- **feat!: one tooltip number contract for every chart type.** `tooltipValueFormatter` was bar/line only, and the other five formatted their tooltip with `valueFormatter` — so the same hover still read differently per visualization. All seven now share one rule in one place (`tooltipValueFormat`): a tooltip shows the full localized number, and `tooltipValueFormatter` is how a caller changes it.

  <details>
  <summary>Breaking for five types</summary>

  Funnel, pie, radar, gauge and heatmap tooltips no longer apply
  `valueFormatter`. A chart that put a unit in `valueFormatter` and relied on
  seeing it on hover needs the same function passed as
  `tooltipValueFormatter`.
  </details>

- **fix: i18n falls back to the built-in translations for missing keys.** `I18nProvider` deep-merges the dictionary it is given over `defaultTranslations`, so a dictionary written against an older f0 renders English for keys it lacks instead of `undefined` — or throwing on a new subtree. The prop type stays exact, so a consumer still learns at compile time that new copy needs translating.
- **docs: correct the formatter contract.** `F0DataChart.mdx` claimed `valueFormatter` formatted tooltips; `Line/CustomFormatters` showed `M €` on the axis and raw values on hover. Both now describe and demonstrate the pair.
- **test: execute the five uncovered formatters.** Funnel, pie, radar, gauge and heatmap tooltip callbacks are now called with the params ECharts passes — values, missing values, escaping and each type's context rows. `FunnelChart.test.tsx` is new; funnel had no test file.
- **chore: rebased on #4947** (conflicted in `useBarChartOptions.ts` and `utils/theme.ts`), so the merge order is explicit. Base retargeted to `feat/dashboard-bar-labels-default`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

