### PR TITLE
test(ApplicationFrame): fix flaky inline-video assertions

### DIFF
--- a/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
+++ b/packages/react/src/patterns/ApplicationFrame/index.stories.tsx
@@ -1764,6 +1764,14 @@ export const CommunicationsVideoAttachments: Story = {
       )
       await expect(players).toHaveLength(2)
 
+      // The transcript keeps its subtree in the a11y tree while it's still
+      // `opacity-0` (it fades in once Virtuoso has positioned the entry row),
+      // so `findBy*` resolves before anything inside is actually visible. Gate
+      // on the region itself becoming visible — a starved frame budget on CI
+      // otherwise lets the video's `loadeddata` mount the controls first and
+      // every `toBeVisible()` below asserts against a hidden transcript.
+      await waitFor(() => expect(players[0]).toBeVisible())
+
       const widths = players.map(
         (player) => player.getBoundingClientRect().width
       )
@@ -1788,20 +1796,18 @@ export const CommunicationsVideoAttachments: Story = {
         ).toBeLessThanOrEqual(1)
 
         const controls = within(player)
-        await expect(
-          await controls.findByRole(
-            "button",
-            { name: "Play" },
-            { timeout: 5_000 }
-          )
-        ).toBeVisible()
-        await expect(
-          await controls.findByRole(
-            "button",
-            { name: "Enter fullscreen" },
-            { timeout: 5_000 }
-          )
-        ).toBeVisible()
+        const playButton = await controls.findByRole(
+          "button",
+          { name: "Play" },
+          { timeout: 5_000 }
+        )
+        await waitFor(() => expect(playButton).toBeVisible())
+        const fullscreenButton = await controls.findByRole(
+          "button",
+          { name: "Enter fullscreen" },
+          { timeout: 5_000 }
+        )
+        await waitFor(() => expect(fullscreenButton).toBeVisible())
         const video = player.querySelector("video")
         await expect(video).not.toBeNull()
         await expect(video!).toHaveAttribute("src", "/Big_Buck_Bunny_alt.webm")
@@ -1811,7 +1817,9 @@ export const CommunicationsVideoAttachments: Story = {
         cards[0].getBoundingClientRect().bottom
       )
 
-      await expect(canvas.getByText("kickoff-deck.pptx")).toBeVisible()
+      await waitFor(() =>
+        expect(canvas.getByText("kickoff-deck.pptx")).toBeVisible()
+      )
     })
   },
 }


### PR DESCRIPTION
## Description

The Communications inline-video story fails intermittently on CI with `expect(element).toBeVisible()` on the video player's Play button, both on `main` and on every PR branch. The chat transcript keeps its subtree in the a11y tree while it is still `opacity-0`, so `findBy*` resolves on content that isn't visible yet and chaining `toBeVisible()` onto a presence-only query samples visibility exactly once. On a loaded runner the video's `loadeddata` can mount the controls before the reveal frames land, and that single sample loses the race. This waits for the transcript to reveal before measuring and retries the visibility assertions instead of sampling them once.

## Implementation details

- test: wait for the video region to become visible before measuring player layout

  <details>
  <summary>Why?</summary>

  The transcript reveals only after Virtuoso reports its first rendered window, gated on a nested `requestAnimationFrame` pair (`useChatVirtuoso.ts`, `ChatMessagesContainer.tsx`). Until then the whole subtree is `opacity-0` while staying in the a11y tree — deliberately, so layout and screen-reader output survive the fade-in. That combination makes every `findBy*` inside the transcript resolve before its target is visible.

  Confirmed the dependency by starving the frame budget in Chrome: with `requestAnimationFrame` throttled to zero, `setInterval` kept ticking while the transcript wrapper stayed at computed `opacity: 0` with zero rendered rows. CI sits on the same gradient — frames arrive late rather than never, which is why this shows up as a flake instead of a hard failure.
  </details>

- test: retry the Play, fullscreen and attachment-name visibility assertions via `waitFor`

## Notes for review

No component change: `ChatMessagesContainer` is imported only by `F0Chat.tsx` and is not exported from the package, so the fix is scoped to the story.

A local pass does not prove the flake is fixed — the story passed locally before this change too. The argument is mechanical: `waitFor` retries what was previously a single sample. Real confirmation is Storybook Tests staying green across several runs.

The reveal gate itself remains an unbounded wait — if those frames never fire, the transcript stays invisible. Out of scope here, worth a follow-up if it ever bites outside tests.