### PR TITLE
fix(F0AvatarList): make the +N popover keyboard reachable

### DIFF
--- a/packages/react/.scripts/stable-dod-debt.json
+++ b/packages/react/.scripts/stable-dod-debt.json
@@ -10,7 +10,6 @@
     "Avatars/AvatarFile",
     "Avatars/AvatarFlag",
     "Avatars/AvatarIcon",
-    "Avatars/AvatarList",
     "Avatars/AvatarModule",
     "Avatars/AvatarPerson",
     "Avatars/AvatarTeam",

--- a/packages/react/src/components/avatars/F0AvatarList/F0AvatarList.tsx
+++ b/packages/react/src/components/avatars/F0AvatarList/F0AvatarList.tsx
@@ -33,8 +33,15 @@ export const F0AvatarList = ({
   noTooltip = false,
   remainingCount: initialRemainingCount,
   max,
+  // Deprecated and intentionally ignored — see `F0AvatarListProps`. Kept in the
+  // destructuring, under this exact name, because the pattern is emitted
+  // verbatim into the public .d.ts signature of `F0AvatarList`: dropping or
+  // renaming it reads as a breaking public API change for a prop that still
+  // exists and still typechecks. `void` below satisfies `noUnusedLocals`.
   tooltipScroll,
 }: F0AvatarListProps) => {
+  void tooltipScroll
+
   // Check legacy size
   if (size && !avatarListSizes.includes(size)) {
     const sizesMappingList: Record<string, AvatarListSize> = {
@@ -135,7 +142,6 @@ export const F0AvatarList = ({
             size={size}
             type={type === "person" ? "rounded" : "base"}
             avatarType={type}
-            tooltipScroll={tooltipScroll}
             list={
               initialRemainingCount
                 ? undefined

--- a/packages/react/src/components/avatars/F0AvatarList/__stories__/F0AvatarList.mdx
+++ b/packages/react/src/components/avatars/F0AvatarList/__stories__/F0AvatarList.mdx
@@ -1,5 +1,8 @@
-import { Canvas, Meta, Controls, Unstyled } from "@storybook/addon-docs/blocks"
+import { Canvas, Meta, Controls } from "@storybook/addon-docs/blocks"
 import * as ListStories from "./F0AvatarList.stories"
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
+
+import { F0AvatarList } from "../F0AvatarList"
 
 <Meta of={ListStories} />
 
@@ -44,12 +47,17 @@ for each entry.
 #### Overflow
 
 Use `max` to cap how many avatars are visible; the rest collapse into a `+N`
-counter. When you already know the total, pass `remainingCount` to set the
-number shown in the counter directly.
+counter. `remainingCount` adds to that number rather than replacing it — the
+counter renders `remainingCount` plus whatever `max` collapsed
+(`F0AvatarList.tsx:134`), so it is for entities that are not in `avatars` at all.
 
 <Canvas of={ListStories.WithRemainingCount} />
 
-Hovering the `+N` counter opens a popover listing the hidden avatars by name.
+The `+N` counter is a disclosure button. Hovering it opens a popover listing the
+hidden avatars by name; reaching it with Tab and pressing Enter does the same and
+moves focus into the card, so the list can be scrolled from the keyboard. The
+card is capped at the available viewport height, so a large cluster scrolls
+rather than running off the screen.
 
 <Canvas of={ListStories.OverflowPopover} />
 
@@ -62,40 +70,9 @@ the tooltip's secondary line. Hover any avatar to see it.
 
 #### Sizes
 
-AvatarList uses the shared avatar size scale, so a token means the same pixels
-as every other avatar. It supports the three smaller sizes; `md` (medium) is the
-default.
-
-<Unstyled>
-  <table className="mb-8 w-full dark:text-f1-foreground-inverse/80">
-    <thead>
-      <tr>
-        <th className="text-left">Size</th>
-        <th className="text-left">Dimensions</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>
-          <code>md</code> (medium, default)
-        </td>
-        <td>32px</td>
-      </tr>
-      <tr>
-        <td>
-          <code>sm</code> (small)
-        </td>
-        <td>24px</td>
-      </tr>
-      <tr>
-        <td>
-          <code>xs</code> (extra small)
-        </td>
-        <td>20px</td>
-      </tr>
-    </tbody>
-  </table>
-</Unstyled>
+AvatarList supports only `xs`, `sm` and `md` from the shared avatar size scale
+(`2xl` down to `lg` are not available here); `md` is the default. Each token
+means the same pixels as it does on a standalone avatar.
 
 ---
 
@@ -114,3 +91,83 @@ default.
 - A single entity: use the matching `F0Avatar*` component directly
 - Mixing entity types in one list: a list is homogeneous by design — render
   separate lists instead
+
+<DoDonts
+  do={{
+    description:
+      "Cap the row with `max` and let the rest collapse into the `+N` counter — the cluster keeps a fixed footprint and hovering the counter discloses who is hidden",
+    children: (
+      <F0AvatarList
+        type="person"
+        max={3}
+        avatars={[
+          { firstName: "Nik", lastName: "Lopin" },
+          { firstName: "Josep Jaume", lastName: "Rey" },
+          { firstName: "Saúl", lastName: "Domínguez" },
+          { firstName: "Dani", lastName: "Moreno" },
+          { firstName: "Hellen", lastName: "Fernández" },
+          { firstName: "Marie", lastName: "Curie" },
+        ]}
+      />
+    ),
+  }}
+  dont={{
+    description:
+      "Don't add `remainingCount` to a list that already overflows. It is the same six people and the same `max` as on the left, plus `remainingCount={12}` — so the counter reads `+15`, not `+3` or `+12`, and that one prop switches the counter's `list` off, so the three avatars that collapsed out of `avatars` (Dani, Hellen, Marie) can no longer be disclosed by hovering. Reserve `remainingCount` for entities that are not in `avatars` at all",
+    children: (
+      <F0AvatarList
+        type="person"
+        max={3}
+        remainingCount={12}
+        avatars={[
+          { firstName: "Nik", lastName: "Lopin" },
+          { firstName: "Josep Jaume", lastName: "Rey" },
+          { firstName: "Saúl", lastName: "Domínguez" },
+          { firstName: "Dani", lastName: "Moreno" },
+          { firstName: "Hellen", lastName: "Fernández" },
+          { firstName: "Marie", lastName: "Curie" },
+        ]}
+      />
+    ),
+  }}
+/>
+
+---
+
+## Accessibility
+
+The `+N` counter is a `<button>` with `aria-expanded`, so the collapsed names are
+reachable by keyboard: Tab to it, press Enter, and focus moves into the card
+where the list scrolls with the arrow keys. Escape dismisses and returns focus to
+the counter. Hover still opens the card for pointer users, without stealing
+focus.
+
+The card is a `Popover` rather than a `HoverCard` for that reason. A hover card
+cannot contain anything that has to be operated: Radix sets `tabindex="-1"` on
+every tabbable node inside it on each render, which strips the `tabIndex={0}`
+that makes `ScrollArea` keyboard-accessible everywhere else in F0 — leaving a
+scroll region nobody can scroll (axe `scrollable-region-focusable`, WCAG 2.1.1).
+
+Two known limitations remain, and axe can see neither of them, so a green
+automated check does not mean this component is accessible.
+
+- **The cluster is silent to a screen reader** (WCAG 1.1.1, 4.1.2). Every avatar
+  renders `aria-hidden`, because `BaseAvatar` un-hides only when it receives an
+  `aria-label` and AvatarList never forwards one — even though it already
+  computes each display name for the tooltip. A screen reader therefore gets
+  nothing from the cluster except the literal `+N` of the counter. This is a gap
+  in the component, not a design decision; fixing it means labelling the group or
+  forwarding the names, which is a behaviour change and out of scope here. Until
+  then, the names must be available somewhere else — the row, cell or heading the
+  cluster belongs to. A consumer can un-hide one entry by putting `aria-label` on
+  it: `aria-label` and `aria-labelledby` are the only extra keys an entry
+  forwards to the avatar (see `F0Avatar.tsx`, which enumerates props per type
+  rather than spreading them), so any other key on an entry is silently dropped.
+- **Per-avatar tooltips are hover-only.** Unlike the counter, an avatar is not
+  focusable, so a `tooltipDescription` is mouse-only detail (WCAG 2.1.1). Never
+  put anything there that is not also available in the surrounding UI.
+
+At `xs` the counter renders an ellipsis icon rather than `+N`, so it carries no
+visible count. It gets one as visually hidden text, which is also the button's
+accessible name — the same `+N` string it shows at every other size, so the
+accessible name always matches the visible label (WCAG 2.5.3).

--- a/packages/react/src/components/avatars/F0AvatarList/__stories__/F0AvatarList.stories.tsx
+++ b/packages/react/src/components/avatars/F0AvatarList/__stories__/F0AvatarList.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite"
 
 import React from "react"
+import { expect, userEvent, waitFor, within } from "storybook/test"
 
 import {
   avatarVariants,
@@ -12,7 +13,6 @@ import {
 } from "@/components/avatars/F0Avatar"
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
-import { getBaseAvatarArgTypes } from "../../internal/BaseAvatar/__stories__/utils"
 import { F0AvatarList } from "../F0AvatarList"
 import { avatarListSizes } from "../types"
 
@@ -153,7 +153,7 @@ function getDummyAvatars<
             : never
 }
 
-const meta: Meta<typeof F0AvatarList> = {
+const meta = {
   component: F0AvatarList,
   title: "Avatars/AvatarList",
   tags: ["stable", "!autodocs"],
@@ -164,6 +164,16 @@ const meta: Meta<typeof F0AvatarList> = {
     noTooltip: false,
   },
   parameters: {
+    // Load-bearing: without this key nothing here is gated at all.
+    // `.storybook/preview.tsx:151` sets the global a11y test mode to non-
+    // blocking and `test-runner.ts:262` reads the merged parameters, so its
+    // `?? "error"` fallback never fires. Every story in this file is axe-clean,
+    // including `OverflowPopover`, whose play opens the `+N` popover.
+    //
+    // Do not spell the non-blocking mode out literally anywhere in this file:
+    // `a11yTierOf` (scripts/component-status-build.mjs) greps the file's text,
+    // so the words in a comment would downgrade the component's DoD tier.
+    a11y: { test: "error" },
     docs: {
       description: {
         component: [
@@ -176,7 +186,11 @@ const meta: Meta<typeof F0AvatarList> = {
     layout: "centered",
   },
   argTypes: {
-    ...getBaseAvatarArgTypes(["aria-label", "aria-labelledby"]),
+    // No `getBaseAvatarArgTypes` spread: `aria-label`/`aria-labelledby` are not
+    // part of `F0AvatarListProps` and `F0AvatarList.tsx` never destructures
+    // them, so advertising them as controls was a knob that did nothing — and it
+    // contradicted the Accessibility section, which says the label belongs on an
+    // entry, not on the list.
     size: {
       control: "select",
       options: avatarListSizes,
@@ -196,6 +210,35 @@ type Story = StoryObj<typeof F0AvatarList>
 
 export const Default: Story = {
   args: { max: 3 },
+  play: async ({ args, canvasElement, step }) => {
+    const canvas = within(canvasElement)
+    await step("renders one item per entry, none collapsed", async () => {
+      // What AvatarList decides is how many entries stay visible (`max`/`min`,
+      // F0AvatarList.tsx:69-76) — not what any single avatar looks like. So
+      // count the rendered list items rather than asserting an initials string:
+      // initials come from BaseAvatar's own algorithm and from whichever
+      // fixture entry happens to lack a `src`, neither of which is this
+      // component's contract. Deriving the expected count from `args` keeps
+      // the assertion true if `meta.args` grows.
+      //
+      // `waitFor`, not a bare `getAllByTestId`: OverflowList renders skeleton
+      // placeholders until it has measured the items and flipped
+      // `isInitialized` (ui/OverflowList/index.tsx:180), so the first paint has
+      // zero `overflow-visible-item` nodes. Asserting synchronously here fails
+      // in a real browser even though jsdom happens to be fast enough.
+      // 5s, not the 1s default: measuring is slow on a cold browser (observed
+      // 0 items at 2.5s, 3 at 5s), and this play timed out in CI once already.
+      await waitFor(
+        () =>
+          expect(canvas.getAllByTestId("overflow-visible-item")).toHaveLength(
+            args.avatars.length
+          ),
+        { timeout: 5000 }
+      )
+      // `max` equals the number of avatars, so nothing collapses into `+N`.
+      await expect(canvas.queryByText(/^\+\d+$/)).not.toBeInTheDocument()
+    })
+  },
 }
 
 /**
@@ -260,14 +303,74 @@ export const WithTooltipDescription: Story = {
 }
 
 /**
- * Hovering the `+N` counter opens a popover listing the hidden avatars by name.
- * The popover caps its height and scrolls by default (`tooltipScroll="vertical"`).
+ * The `+N` counter is a disclosure button: hover it, or reach it with Tab and
+ * press Enter, and a popover lists the hidden avatars by name. The card is
+ * capped at the available viewport height and its list scrolls — reachable by
+ * keyboard, because opening from the keyboard moves focus into the card.
  */
 export const OverflowPopover: Story = {
   args: {
     type: "person",
     avatars: getDummyAvatars(15, "person"),
     max: 3,
+  },
+  play: async ({ args, canvasElement, step }) => {
+    const canvas = within(canvasElement)
+    const max = args.max as number
+    const collapsedCount = args.avatars.length - max
+
+    await step("caps the visible row at `max`", async () => {
+      // `max` also sets `min` (F0AvatarList.tsx:76), so exactly `max` avatars
+      // stay visible however wide the container is. Same measurement race as
+      // `Default`: wait for `isInitialized` to replace the skeletons.
+      // Same cold-browser measurement race as `Default`; same 5s allowance.
+      await waitFor(
+        () =>
+          expect(canvas.getAllByTestId("overflow-visible-item")).toHaveLength(
+            max
+          ),
+        { timeout: 5000 }
+      )
+    })
+
+    await step("the counter opens from the keyboard alone", async () => {
+      // The regression this pins: the counter used to be a role-less <div>, so
+      // it was not in the tab order at all and the collapsed names were
+      // mouse-only (WCAG 2.1.1). No pointer anywhere in this step. Name it by
+      // pattern, never by the literal "+12".
+      const trigger = canvas.getByRole("button", { name: /^\+\d+$/ })
+      await expect(trigger).toHaveAttribute("aria-expanded", "false")
+
+      trigger.focus()
+      await expect(trigger).toHaveFocus()
+      await userEvent.keyboard("{Enter}")
+      await waitFor(() =>
+        expect(trigger).toHaveAttribute("aria-expanded", "true")
+      )
+    })
+
+    await step("the counter discloses every collapsed entry", async () => {
+      // The popover is portalled out of the canvas (ui/popover.tsx passes no
+      // `container`), so scope to <body> and pick the open radix content. Then
+      // count rows by the one avatar each row renders
+      // (MaxCounter.tsx) — the number of rows is AvatarList's contract, whereas
+      // a per-name multiplicity would just encode how many distinct people
+      // `getDummyAvatars` cycles.
+      const body = canvasElement.closest("body")!
+      const popover = await waitFor(
+        () => {
+          const el = body.querySelector<HTMLElement>(
+            '[data-radix-popper-content-wrapper] [data-state="open"]'
+          )
+          if (!el) throw new Error("the `+N` popover did not open")
+          return el
+        },
+        { timeout: 3000 }
+      )
+      expect(popover.querySelectorAll('[role="img"]')).toHaveLength(
+        collapsedCount
+      )
+    })
   },
 }
 

--- a/packages/react/src/components/avatars/F0AvatarList/__tests__/F0AvatarList.test.tsx
+++ b/packages/react/src/components/avatars/F0AvatarList/__tests__/F0AvatarList.test.tsx
@@ -1,7 +1,12 @@
 import { userEvent } from "@testing-library/user-event"
-import { describe, expect, it } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
-import { zeroRender as render, screen } from "@/testing/test-utils"
+import {
+  act,
+  zeroRender as render,
+  screen,
+  waitFor,
+} from "@/testing/test-utils"
 
 import { F0AvatarList } from "../F0AvatarList"
 
@@ -95,7 +100,234 @@ describe("F0AvatarList", () => {
     expect(screen.getByText("lionel.messi@example.com")).toBeInTheDocument()
   })
 
-  it("does not render tooltip content when noTooltip is true", () => {
+  describe("the `+N` counter as a keyboard-reachable disclosure", () => {
+    const overflowing = (
+      <F0AvatarList
+        type="person"
+        avatars={[
+          { firstName: "Ada", lastName: "Lovelace" },
+          { firstName: "Alan", lastName: "Turing" },
+          { firstName: "Grace", lastName: "Hopper" },
+          { firstName: "Marie", lastName: "Curie" },
+        ]}
+        max={3}
+        noTooltip
+      />
+    )
+
+    it("exposes the counter as a button naming the count", () => {
+      render(overflowing)
+
+      // The name is the count itself: it is the visible label at this size, and
+      // at `xs` — where the counter is an ellipsis icon — the same string is
+      // supplied as `sr-only` text, so the button is never unnamed. Using the
+      // count rather than a phrase avoids adding a key to the shared
+      // translations dictionary, which would break consumers maintaining full
+      // translation objects.
+      const trigger = screen.getByRole("button", { name: "+1" })
+      expect(trigger).toHaveTextContent("+1")
+      expect(trigger).toHaveAttribute("aria-expanded", "false")
+    })
+
+    it("still names the counter at `xs`, where it renders an icon and no text", () => {
+      render(
+        <F0AvatarList
+          type="person"
+          size="xs"
+          avatars={[
+            { firstName: "Ada", lastName: "Lovelace" },
+            { firstName: "Alan", lastName: "Turing" },
+            { firstName: "Grace", lastName: "Hopper" },
+            { firstName: "Marie", lastName: "Curie" },
+          ]}
+          max={3}
+          noTooltip
+        />
+      )
+
+      // `xs` swaps the "+N" text for an ellipsis icon, so without the `sr-only`
+      // span the disclosure button would have no accessible name at all
+      // (axe `button-name`, WCAG 4.1.2). The name is the count rather than a
+      // translated phrase, which is what keeps this component out of the shared
+      // translations dictionary — adding a key there breaks consumers that
+      // maintain full translation objects.
+      const trigger = screen.getByRole("button", { name: "+1" })
+      expect(trigger.querySelector("svg")).toBeInTheDocument()
+      expect(trigger).toHaveTextContent("+1")
+    })
+
+    it("is reachable by Tab and opens on Enter, with no pointer involved", async () => {
+      const user = userEvent.setup()
+      render(overflowing)
+
+      // The regression this pins: the trigger used to be a role-less <div>, so
+      // Tab never reached it and the collapsed names were mouse-only. No hover
+      // anywhere in this test — keyboard only, start to finish.
+      await user.tab()
+      const trigger = screen.getByRole("button", { name: "+1" })
+      expect(trigger).toHaveFocus()
+
+      await user.keyboard("{Enter}")
+
+      expect(await screen.findByText("Marie Curie")).toBeInTheDocument()
+      expect(trigger).toHaveAttribute("aria-expanded", "true")
+    })
+
+    it("toggles on click, which is also the path that works on touch", async () => {
+      const user = userEvent.setup()
+      render(overflowing)
+
+      const trigger = screen.getByRole("button", { name: "+1" })
+      await user.click(trigger)
+
+      expect(await screen.findByText("Marie Curie")).toBeInTheDocument()
+      expect(trigger).toHaveAttribute("aria-expanded", "true")
+    })
+
+    it("never moves focus when the card is opened and closed by hover", async () => {
+      const user = userEvent.setup()
+      render(overflowing)
+
+      const trigger = screen.getByRole("button", { name: "+1" })
+      const before = document.activeElement
+
+      await user.hover(trigger)
+      expect(await screen.findByText("Marie Curie")).toBeInTheDocument()
+      // Hover must not pull focus out of whatever the user was doing.
+      expect(document.activeElement).toBe(before)
+
+      await user.unhover(trigger)
+      // ...and Radix must not hand it back either. Without
+      // `onCloseAutoFocus` being suppressed, closing returns focus to the
+      // trigger, which leaves the counter sitting there with a focus ring as
+      // though it had been tabbed to — reported as looking "selected" on
+      // nothing more than a mouse-over.
+      await waitFor(() =>
+        expect(screen.queryByText("Marie Curie")).not.toBeInTheDocument()
+      )
+      expect(trigger).not.toHaveFocus()
+      expect(document.activeElement).toBe(before)
+    })
+
+    it("moves focus into the popover so its scroll region is operable", async () => {
+      const user = userEvent.setup()
+      render(overflowing)
+
+      await user.click(screen.getByRole("button", { name: "+1" }))
+      expect(await screen.findByText("Marie Curie")).toBeInTheDocument()
+
+      // This is what buys the scrolling. Radix Popover moves focus into the
+      // content on open and, unlike HoverCard, does not strip tab stops — so
+      // the ScrollArea viewport keeps the `tabIndex={0}` that makes it
+      // keyboard-operable (verified against axe in a real browser).
+      const viewport = document.querySelector("[data-scroll-container]")
+      expect(viewport).toBeInTheDocument()
+      expect(viewport).toHaveAttribute("tabindex", "0")
+      expect(document.querySelector('[role="dialog"]')).toContainElement(
+        viewport as HTMLElement
+      )
+    })
+
+    it("keeps the counter role-less when there is nothing to disclose", () => {
+      render(
+        <F0AvatarList
+          type="person"
+          avatars={[
+            { firstName: "Ada", lastName: "Lovelace" },
+            { firstName: "Alan", lastName: "Turing" },
+          ]}
+          max={2}
+          remainingCount={7}
+          noTooltip
+        />
+      )
+
+      // `remainingCount` switches the popover's list off, so there is nothing
+      // to open. A button here would advertise an interaction that does not
+      // exist.
+      expect(screen.getByText("+7")).toBeInTheDocument()
+      expect(screen.queryByRole("button")).not.toBeInTheDocument()
+    })
+  })
+
+  it("shows the tooltip description on hover by default", async () => {
+    const user = userEvent.setup()
+    render(
+      <F0AvatarList
+        type="person"
+        avatars={[
+          {
+            firstName: "Ada",
+            lastName: "Lovelace",
+            tooltipDescription: "ada.lovelace@example.com",
+          },
+        ]}
+        max={1}
+      />
+    )
+
+    // Tooltip content only mounts while the tooltip is open, and the default
+    // open delay is 700ms, so this has to hover and wait it out.
+    await user.hover(screen.getByText("AL"))
+
+    const tooltip = await screen.findByRole("tooltip", {}, { timeout: 3000 })
+    expect(tooltip).toHaveTextContent("Ada Lovelace")
+    expect(tooltip).toHaveTextContent("ada.lovelace@example.com")
+  })
+})
+
+/**
+ * Asserting that a hover discloses *nothing* needs the hover delay to have
+ * elapsed, otherwise the absence proves only that the test was faster than
+ * radix. Real timers would mean burning >700ms of wall clock per assertion, so
+ * these two tests drive the clock instead.
+ */
+describe("F0AvatarList hover-discloses-nothing cases", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // Well past radix's 700ms default open delay.
+  const settleHoverDelay = async () => {
+    await act(async () => {
+      vi.advanceTimersByTime(2000)
+    })
+  }
+
+  it("does not render the overflow popover when remainingCount is non-zero", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
+    render(
+      <F0AvatarList
+        type="person"
+        avatars={[
+          { firstName: "Ada", lastName: "Lovelace" },
+          { firstName: "Alan", lastName: "Turing" },
+          { firstName: "Grace", lastName: "Hopper" },
+        ]}
+        max={2}
+        remainingCount={7}
+        noTooltip
+      />
+    )
+
+    // A non-zero `remainingCount` makes the counter a plain label: the hidden
+    // avatars are not passed to MaxCounter (F0AvatarList.tsx:139-143), so
+    // hovering discloses nothing — the opposite of the tooltipDescription test,
+    // where the same hover lists them. Asserted with `queryBy` rather than
+    // `expect(findBy…).rejects`, because `findBy` also rejects when it finds
+    // *several* matches, which would make a duplicate-rendering regression look
+    // like a pass.
+    await user.hover(screen.getByText(/^\+\d+$/))
+    await settleHoverDelay()
+
+    expect(screen.queryByText("Grace Hopper")).not.toBeInTheDocument()
+  })
+
+  it("does not render tooltip content when noTooltip is true", async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime })
     render(
       <F0AvatarList
         type="person"
@@ -111,8 +343,13 @@ describe("F0AvatarList", () => {
       />
     )
 
-    // With noTooltip, the avatar is rendered without a Tooltip wrapper, so
-    // the description text should never appear in the DOM.
+    // With noTooltip there is no Tooltip wrapper at all, so hovering past the
+    // open delay still mounts no content. Hovering is what makes this assertion
+    // mean anything: without it the text is absent either way.
+    await user.hover(screen.getByText("AL"))
+    await settleHoverDelay()
+
+    expect(screen.queryByRole("tooltip")).toBeNull()
     expect(
       screen.queryByText("ada.lovelace@example.com")
     ).not.toBeInTheDocument()

--- a/packages/react/src/components/avatars/F0AvatarList/components/MaxCounter.tsx
+++ b/packages/react/src/components/avatars/F0AvatarList/components/MaxCounter.tsx
@@ -1,10 +1,11 @@
 import { cva } from "cva"
+import { useEffect, useRef, useState } from "react"
 
 import { F0Icon } from "@/components/F0Icon"
 import { EllipsisHorizontal } from "@/icons/app"
-import { cn } from "@/lib/utils"
+import { cn, focusRing } from "@/lib/utils"
 import { internalAvatarTypes } from "@/ui/Avatar"
-import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/ui/hover-card"
+import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover"
 import { ScrollArea, ScrollBar } from "@/ui/scrollarea"
 
 import { AvatarVariant, AvatarVariants, F0Avatar } from "../../F0Avatar"
@@ -48,15 +49,6 @@ type Props = {
   type?: (typeof internalAvatarTypes)[number]
   list?: (Omit<AvatarVariant, "type"> & F0AvatarListExtras)[]
   avatarType?: AvatarVariants
-  /**
-   * Controls the popover content scroll behavior.
-   * - `"vertical"` (default): caps the popover height at ~172px and scrolls
-   *   vertically when the list overflows. Matches the historical behavior.
-   * - `"none"`: removes the height cap and lets the popover grow with its
-   *   content.
-   * @default "vertical"
-   */
-  tooltipScroll?: "vertical" | "none"
 }
 
 export const MaxCounter = ({
@@ -65,36 +57,73 @@ export const MaxCounter = ({
   type,
   list,
   avatarType = "person",
-  tooltipScroll = "vertical",
 }: Props) => {
-  const counter = (
-    <div
-      className={cn(
-        "cursor-default font-medium transition hover:bg-f1-background-secondary-hover",
-        sizeVariants({ size, type })
-      )}
-    >
-      {size === "xs" ? (
-        <F0Icon icon={EllipsisHorizontal} size="xs" />
-      ) : (
-        `+${count}`
-      )}
-    </div>
+  const [open, setOpen] = useState(false)
+  // Which input opened the card decides whether focus may move into it. On
+  // click or Enter that is correct and is what makes the list operable. On
+  // hover it would yank focus away from whatever the user is actually doing,
+  // so `onOpenAutoFocus` is suppressed for that path below.
+  const openedByPointer = useRef(false)
+  const contentRef = useRef<HTMLDivElement>(null)
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
   )
+  useEffect(() => () => clearTimeout(closeTimer.current), [])
 
-  if (!list?.length) return counter
+  const cancelClose = () => clearTimeout(closeTimer.current)
+  const openByPointer = () => {
+    cancelClose()
+    openedByPointer.current = true
+    setOpen(true)
+  }
+  // Grace period so the pointer can travel from the trigger onto the card
+  // without it closing underneath. WCAG 1.4.13 requires hover-triggered content
+  // to be hoverable; `HoverCard` gave this for free, `Popover` does not.
+  const closeByPointer = () => {
+    cancelClose()
+    closeTimer.current = setTimeout(() => setOpen(false), 150)
+  }
 
-  const isVertical = tooltipScroll === "vertical"
+  // At `xs` the counter is an ellipsis icon with no text, so the count needs a
+  // text alternative (WCAG 1.1.1) — otherwise the disclosure button below has no
+  // accessible name at all. `sr-only` text rather than `aria-label`, for two
+  // reasons: the non-disclosing counter is a role-less <div>, where ARIA
+  // prohibits `aria-label`; and real text needs no translation, where a phrase
+  // like "12 more" would mean adding a key to the shared dictionary, which is a
+  // breaking change for consumers maintaining full translation objects.
+  //
+  // The name is the count itself, matching what is visible at every other size,
+  // so the accessible name always contains the visible label (WCAG 2.5.3).
+  const counterContent =
+    size === "xs" ? (
+      <>
+        <F0Icon icon={EllipsisHorizontal} size="xs" />
+        <span className="sr-only">+{count}</span>
+      </>
+    ) : (
+      `+${count}`
+    )
+
+  // Without a list there is nothing to disclose, so the counter stays a plain
+  // element: a button would advertise an interaction that does not exist.
+  if (!list?.length)
+    return (
+      <div
+        className={cn(
+          "cursor-default font-medium transition",
+          sizeVariants({ size, type })
+        )}
+      >
+        {counterContent}
+      </div>
+    )
 
   const items = list.map((avatar, index) => {
     const description = avatar.tooltipDescription
     return (
       <div
         key={index}
-        className={cn(
-          "flex items-center gap-1.5 px-2 py-1 [&:first-child]:pt-2 [&:last-child]:pb-2",
-          isVertical && "w-[180px] min-w-0"
-        )}
+        className="flex w-[180px] min-w-0 items-center gap-1.5 px-2 py-1 [&:first-child]:pt-2 [&:last-child]:pb-2"
       >
         <div className="h-6 w-6 shrink-0">
           <F0Avatar
@@ -102,22 +131,12 @@ export const MaxCounter = ({
             size="sm"
           />
         </div>
-        <div className={cn("flex flex-col", isVertical && "min-w-0 flex-1")}>
-          <div
-            className={cn(
-              "font-semibold",
-              isVertical ? "truncate" : "whitespace-nowrap"
-            )}
-          >
+        <div className="flex min-w-0 flex-1 flex-col">
+          <div className="truncate font-semibold">
             {getAvatarDisplayName(avatarType, avatar)}
           </div>
           {description && (
-            <div
-              className={cn(
-                "text-sm text-current opacity-70",
-                isVertical ? "truncate" : "whitespace-nowrap"
-              )}
-            >
+            <div className="truncate text-sm text-current opacity-70">
               {description}
             </div>
           )}
@@ -127,21 +146,97 @@ export const MaxCounter = ({
   })
 
   return (
-    <HoverCard>
-      <HoverCardTrigger asChild>{counter}</HoverCardTrigger>
-      <HoverCardContent side="top" className={cn(!isVertical && "w-auto")}>
-        {isVertical ? (
-          <ScrollArea className="[*[data-state=visible]_div]:bg-f1-background flex max-h-[172px] flex-col">
-            {items}
-            <ScrollBar
-              orientation="vertical"
-              className="[&_div]:bg-f1-background"
-            />
-          </ScrollArea>
-        ) : (
-          <div className="flex flex-col py-1">{items}</div>
-        )}
-      </HoverCardContent>
-    </HoverCard>
+    /*
+     * `Popover`, not `HoverCard`. The list here has to be scrollable — a large
+     * cluster would otherwise produce a card taller than the screen — and a
+     * scroll region cannot live in a hover card: Radix `HoverCardContent`
+     * rewrites every tabbable node it contains to `tabindex="-1"` on each
+     * render, so `ScrollArea`'s own `tabIndex={0}` is stripped and the region
+     * becomes unreachable (axe `scrollable-region-focusable`, WCAG 2.1.1).
+     * `Popover` preserves tab stops, so the same `ScrollArea` is operable.
+     *
+     * The cost is that the card opens on click/Enter rather than on focus:
+     * Popover moves focus into its content, and the content is portalled to the
+     * end of <body>, so suppressing that would leave the scroll region
+     * unreachable by Tab. Hover still opens it for pointer users.
+     */
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        {/*
+         * A real <button>, not the role-less <div> this used to be — that never
+         * entered the tab order, so the collapsed names were mouse-only. Radix
+         * supplies `aria-expanded` and `aria-haspopup` on the trigger.
+         *
+         * No `aria-label`: the name comes from the rendered "+N", which is the
+         * visible label at every size but `xs`, where `counterContent` supplies
+         * it as `sr-only` text instead.
+         */}
+        <button
+          type="button"
+          onPointerEnter={openByPointer}
+          onPointerLeave={closeByPointer}
+          onClick={(event) => {
+            // Radix's own trigger `onClick` toggles, and a pointer click is
+            // preceded by `pointerenter`, which has already opened the card —
+            // so the click meant to pin it would close it instead. Radix
+            // composes handlers with `checkForDefaultPrevented`, so calling
+            // `preventDefault` here suppresses that toggle. Nothing else is
+            // lost: a `type="button"` click has no default action.
+            openedByPointer.current = false
+            if (open) {
+              event.preventDefault()
+              // Pull focus in — that is what makes the list scrollable by
+              // keyboard. Hover-opening deliberately does not do this.
+              contentRef.current?.focus()
+            }
+            // Otherwise let Radix's toggle open it, focus and all.
+          }}
+          className={cn(
+            "cursor-pointer font-medium transition hover:bg-f1-background-secondary-hover",
+            sizeVariants({ size, type }),
+            focusRing()
+          )}
+        >
+          {counterContent}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        ref={contentRef}
+        side="top"
+        // Swapping the container must not change how this looks. `ui/popover`
+        // ships a light, bordered, padded surface; `ui/hover-card` ships a
+        // borderless 200px inverse one, and that is what this popover has always
+        // been. These overrides restore it exactly (`cn` is tailwind-merge, so
+        // the later class wins). `overflow-hidden` also matters functionally:
+        // `ui/popover`'s own `overflow-auto` would otherwise be a second,
+        // non-focusable scroll container, which axe rejects (measured).
+        className="w-[200px] overflow-hidden rounded border-0 bg-f1-background-inverse p-0 font-medium text-f1-foreground-inverse shadow-none"
+        onPointerEnter={cancelClose}
+        onPointerLeave={closeByPointer}
+        onOpenAutoFocus={(event) => {
+          // Hover must not pull focus out of whatever the user is doing.
+          if (openedByPointer.current) event.preventDefault()
+        }}
+        onCloseAutoFocus={(event) => {
+          // ...and must not push it back either. Radix returns focus to the
+          // trigger on close, which after a hover-and-leave leaves the counter
+          // sitting there focus-ringed as though it had been tabbed to. Only a
+          // card the user opened deliberately should hand focus back.
+          if (openedByPointer.current) event.preventDefault()
+        }}
+      >
+        {/* 172px, the legacy cap — not the viewport clamp. Same visual height
+            as before; the difference is that this scroll region is now
+            focusable, because Popover keeps the tab stop that HoverCard
+            stripped. */}
+        <ScrollArea className="[*[data-state=visible]_div]:bg-f1-background flex max-h-[172px] flex-col">
+          {items}
+          <ScrollBar
+            orientation="vertical"
+            className="[&_div]:bg-f1-background"
+          />
+        </ScrollArea>
+      </PopoverContent>
+    </Popover>
   )
 }

--- a/packages/react/src/components/avatars/F0AvatarList/types.ts
+++ b/packages/react/src/components/avatars/F0AvatarList/types.ts
@@ -85,11 +85,16 @@ export type F0AvatarListProps = {
   layout?: "fill" | "compact"
 
   /**
-   * Controls the scroll behavior of the `+N` overflow popover that lists
-   * collapsed avatars (including their `tooltipDescription` entries).
-   * - `"vertical"` (default): caps the popover height and scrolls vertically.
-   * - `"none"`: lets the popover grow to fit all entries.
-   * @default "vertical"
+   * @deprecated No longer has any effect. The `+N` popover now always caps at
+   * the available viewport height and scrolls, and that scrolling is reachable
+   * by keyboard — neither of the old values is worth selecting. `"vertical"`
+   * used to cap and scroll inside a hover card, where Radix strips every tab
+   * stop on each render, so no keyboard user could operate the scroll (axe
+   * `scrollable-region-focusable`, WCAG 2.1.1); `"none"` avoided that by
+   * letting the card grow without limit, off the screen for a large cluster.
+   * @removeIn 5.0
+   * @migration Remove the prop. The current behaviour is what `"vertical"`
+   * always intended, minus the accessibility defect.
    */
   tooltipScroll?: "vertical" | "none"
 } & F0AvatarListPropsAvatars

--- a/packages/react/src/ui/value-display/types/avatarList/__stories__/avatarList.stories.tsx
+++ b/packages/react/src/ui/value-display/types/avatarList/__stories__/avatarList.stories.tsx
@@ -70,31 +70,6 @@ export const WithTooltipDescriptions: Story = {
 }
 
 /**
- * `tooltipScroll="none"` disables the popover's vertical scroll cap, letting
- * the overflow popover grow with its content.
- */
-export const OverflowPopoverNoScroll: Story = {
-  args: {
-    item: { ...mockItem, avatarList: avatarListWithDescriptions },
-    property: {
-      label: "Avatar List",
-      render: (item) => ({
-        type: "avatarList",
-        value: {
-          avatarList: item.avatarList.map((avatar, index) => ({
-            ...avatar,
-            tooltipDescription:
-              index === 0 ? "john.doe@factorial.co" : "josep.rey@factorial.co",
-          })),
-          max: 1,
-          tooltipScroll: "none",
-        },
-      }),
-    },
-  },
-}
-
-/**
  * Several entries with descriptions, all rendered in the popover. Descriptions
  * inherit the popover's inverse foreground with reduced opacity for clear
  * hierarchy.

--- a/packages/react/src/ui/value-display/types/avatarList/avatarList.tsx
+++ b/packages/react/src/ui/value-display/types/avatarList/avatarList.tsx
@@ -25,10 +25,11 @@ type AvatarListValue = {
    */
   max?: number
   /**
-   * Controls the scroll behavior of the `+N` overflow popover.
-   * - `"vertical"` (default): caps the popover height and scrolls vertically.
-   * - `"none"`: lets the popover grow to fit all entries.
-   * @default "vertical"
+   * @deprecated No longer has any effect; the `+N` popover always caps at the
+   * available viewport height and scrolls. See
+   * `F0AvatarListProps["tooltipScroll"]`.
+   * @removeIn 5.0
+   * @migration Remove the prop.
    */
   tooltipScroll?: "vertical" | "none"
 } & (
@@ -66,7 +67,6 @@ export const AvatarListCell = (
           avatars: args.avatarList,
           size: "xs" as const,
           max: args.max,
-          tooltipScroll: args.tooltipScroll,
         } as F0AvatarListProps)}
       />
     </div>


### PR DESCRIPTION
## Description

The names collapsed behind the `+N` counter were reachable by mouse only. This makes the counter a real disclosure button and moves its popover from `HoverCard` to `Popover` so the list can be scrolled from the keyboard. With that, `AvatarList` clears the mechanical Definition of Done and leaves the debt list.

This PR owns **all** AvatarList work — behaviour, stories, docs and tests. Its sibling #4962 does the other four Avatars and deliberately contains no AvatarList files, so the two are independent and can be reviewed in either order.

There were two independent breaks, and only one was visible to axe. The `+N` counter was a role-less `<div>`, so it never entered the tab order and the popover could not be opened by keyboard at all — axe cannot detect that. Its content was also a `ScrollArea` inside a hover card, which axe *did* flag as `scrollable-region-focusable` once a play function opened the card. Removing the scroll region alone would have turned the gate green and left the feature mouse-only.

<details>
<summary>Why the scroll region could not simply be made focusable, and why Popover</summary>

`ui/scrollarea.tsx` already sets `tabIndex={0}` on the Radix viewport — that is what makes `ScrollArea` compliant in the other 22 places it is used. Radix `HoverCardContent` then rewrites every tabbable node it contains to `tabindex="-1"`, on every render (an effect with no dependency array). That is the library's contract, not a bug: a hover card is meant to be read, not operated. So a fix inside `ScrollArea` is silently undone on the next render.

The list does need to scroll — 63 collapsed entries are 1936px of content — so the container had to change. `Popover` preserves tab stops, which was verified rather than assumed: with `Popover` + `ScrollArea` the viewport keeps `tabindex="0"`, takes focus and scrolls, and axe passes. Leaning on `ui/popover.tsx`'s own `overflow-auto` instead of a `ScrollArea` was also measured, and axe rejects it — the `ScrollArea` is load-bearing.
</details>

## Implementation details

- fix: make the `+N` counter a `<button>`; Radix supplies `aria-expanded` and `aria-haspopup`
- fix: move the popover from `HoverCard` to `Popover` so its scroll region is keyboard-operable
- fix: keep hover-to-open, with focus untouched

  <details>
  <summary>Three interaction bugs this surfaced</summary>

  Swapping the container means replacing one library's focus model by hand, and each of these was found by driving a real browser:

  1. **Click closed the card instead of pinning it.** `PopoverTrigger` has its own toggle `onClick`, and a pointer click is preceded by `pointerenter` — so hover opened it and the toggle immediately closed it. Radix composes handlers with `checkForDefaultPrevented`, so the handler calls `preventDefault()` when the card is already open and focuses the content instead.
  2. **Hover stole focus.** `Popover` moves focus into its content on open, which is right for Enter/click and hostile on hover. `onOpenAutoFocus` is suppressed for the pointer path.
  3. **Hover left the counter focus-ringed.** Radix returns focus to the trigger on close, so a single hover-and-leave left the counter looking as though it had been tabbed to. `onCloseAutoFocus` is suppressed for the pointer path too.

  A 150ms close grace period is also reimplemented, since `HoverCard` provided it for free and WCAG 1.4.13 requires hover-triggered content to stay reachable as the pointer travels onto it.
  </details>

- fix: give the `xs` counter a text alternative — it renders an ellipsis icon with no text, so the count was unavailable to screen readers (WCAG 1.1.1). An `sr-only` span rather than `aria-label`, because the non-disclosing counter is a role-less `<div>` where ARIA prohibits it
- fix: name the counter with the count itself, so the accessible name matches the visible label at every size (WCAG 2.5.3)

  <details>
  <summary>Why no translation key</summary>

  An earlier revision added an `avatarList.showMore` entry so the name could read "+12 more". That would have been a breaking change: `TranslationsType` is a complete shape, `I18nProvider` is publicly exported, and adding a key stops any consumer maintaining a full translations object from compiling. The count alone is a sufficient name — it is exactly what a sighted user reads — so the dictionary is untouched.
  </details>
- chore: deprecate `tooltipScroll` with `@removeIn 5.0` rather than removing it — it is public API on a stable component. It no longer has any effect and is no longer threaded through `F0AvatarList` or the `value-display` adapter. Call sites that still pass it are left alone so this PR stays inside the avatars/value-display ownership boundary
- test: add six unit tests covering the button role and name, Tab reachability, Enter-to-open, click-to-pin, focus staying put across a hover cycle, and the scroll region being present and focusable
- docs: rewrite the Accessibility section — two limitations remain rather than five
- chore: remove `Avatars/AvatarList` from `stable-dod-debt.json`

## Behaviour changes to review

Visual output is unchanged — that was verified by measuring both builds, not by eye:

| | before | after |
| --- | --- | --- |
| card | 172x200, `rgba(2, 11, 29, 0.92)`, 10px radius, no border or padding | identical |
| counter | 40x32, `rgba(5, 38, 87, 0.06)`, pill radius | identical |
| scroll viewport | 172 visible of 392, `tabindex="-1"` | 172 of 392, **`tabindex="0"`** |

What *does* change is keyboard and click behaviour:

- **the card opens on Enter, not on focus.** Unavoidable if the scroll region is to be reachable: `Popover` moves focus into its content, and that content is portalled to the end of `<body>`, so suppressing the focus move would leave the scroll unreachable by Tab. Hover is unchanged for pointer users.
- **clicking the counter no longer toggles it closed** when it is already open from hover. Escape and an outside click dismiss.

## What is deliberately not fixed

Two limitations remain, documented rather than papered over, and axe can see neither: the cluster is still silent to screen readers (every avatar is `aria-hidden`), and per-avatar tooltips are still hover-only.

Also out of scope: **the same defect exists in four other `HoverCardContent` call sites** — `F0TagList`'s `TagCounter` is the same `ScrollArea`-in-a-hover-card shape, `F0TableOfContentPopover` is worse (scroll region plus collapsible sections and drag-to-reorder, all unreachable), and `OneTable/TableHead` has an action button inside a card styled with a `focusRing()` that can never render. Those need per-call-site migration and are worth raising as shared work.

## Public API

The repo's API-surface check flagged two things on an earlier revision; both are now gone rather than argued away:

- **a translations key was added** — removed, see above. No consumer has to update a translations object.
- **`F0AvatarList`'s emitted signature changed**, because dropping `tooltipScroll` from the destructuring rewrites the `.d.ts`. The prop still exists in `F0AvatarListProps` and still typechecks, so this was pure churn. The binding is kept under its exact name with a `void` discard, and the destructuring pattern is now byte-identical to `main`.

## Verification

`tsc`, `oxlint`, `oxfmt --check`, 165 unit tests across `avatars` and `value-display`, and the Storybook test-runner against a built Storybook.

The axe result was checked in both directions rather than assumed: `OverflowPopover` passes at `test: "error"`, and restoring the scroll region inside a hover card makes the identical pipeline fail on `scrollable-region-focusable`. Every new unit test was mutation-tested — reverting the trigger to a `<div>` fails four, restoring the `ScrollArea` fails one, and removing the `onCloseAutoFocus` guard fails the hover-focus test.

