### PR TITLE
fix(OneDataCollection): stop the search preview jumping to the top when a page is appended

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/components/Search/Search.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/Search/Search.test.tsx
@@ -13,10 +13,21 @@ const rows = (count: number, offset = 0) =>
     title: `Person ${offset + index}`,
   }))
 
-// jsdom does not implement `scrollIntoView`, which the component calls when the
-// active row moves.
+/**
+ * Records the row each `scrollIntoView` call targeted — that is what decides
+ * where the dropdown ends up scrolled.
+ *
+ * The global setup already stubs this on `HTMLElement.prototype`, so it MUST be
+ * overridden there: a stub on `Element.prototype` sits further up the chain, is
+ * shadowed, and silently records nothing.
+ */
+const scrolledTo: string[] = []
+
 beforeEach(() => {
-  Element.prototype.scrollIntoView = vi.fn()
+  scrolledTo.length = 0
+  window.HTMLElement.prototype.scrollIntoView = vi.fn(function (this: Element) {
+    scrolledTo.push(this.textContent ?? "")
+  })
 })
 
 const searchProps = (results: ReturnType<typeof rows>, value: string) => ({
@@ -62,12 +73,16 @@ describe("Search preview pagination", () => {
     fireEvent.mouseOver(rowButtons()[PAGE_SIZE - 1])
     expect(highlightedRow()).toBe(PAGE_SIZE - 1)
 
+    scrolledTo.length = 0
     view.rerender(
       <Search {...searchProps([...firstPage, ...rows(10, PAGE_SIZE)], "mar")} />
     )
 
-    // The appended page must not move the highlight off the row being read.
+    // The appended page must not move the highlight off the row being read...
     expect(highlightedRow()).toBe(PAGE_SIZE - 1)
+    // ...because that scrolls the first row into view, yanking the reader back to
+    // the top of the dropdown just as they reach the bottom.
+    expect(scrolledTo).toEqual([])
   })
 
   it("highlights the first row when a new query replaces the results", async () => {

--- a/packages/react/src/patterns/OneDataCollection/components/Search/Search.test.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/Search/Search.test.tsx
@@ -1,0 +1,86 @@
+import { userEvent } from "@testing-library/user-event"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import { fireEvent, zeroRender as render, screen } from "@/testing/test-utils"
+
+import { Search } from "./Search"
+
+const PAGE_SIZE = 25
+
+const rows = (count: number, offset = 0) =>
+  Array.from({ length: count }, (_, index) => ({
+    id: `${offset + index}`,
+    title: `Person ${offset + index}`,
+  }))
+
+// jsdom does not implement `scrollIntoView`, which the component calls when the
+// active row moves.
+beforeEach(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+})
+
+const searchProps = (results: ReturnType<typeof rows>, value: string) => ({
+  value,
+  onChange: vi.fn(),
+  results,
+  hasMore: true,
+  onLoadMore: vi.fn(),
+  onResultSelect: vi.fn(),
+})
+
+/** Opens the collapsed search and types a query, so the preview dropdown shows. */
+const openPreview = async (results: ReturnType<typeof rows>) => {
+  const user = userEvent.setup()
+  const view = render(<Search {...searchProps(results, "")} />)
+
+  await user.click(screen.getAllByRole("button", { name: /search/i })[0])
+  await user.type(screen.getByRole("textbox"), "mar")
+
+  // `value` is controlled by the parent, so re-render with it set — the dropdown
+  // only shows while `value` is non-empty.
+  view.rerender(<Search {...searchProps(results, "mar")} />)
+
+  return { user, view }
+}
+
+const rowButtons = () => screen.getAllByRole("button", { name: /Person/ })
+
+// `classList` matches exact tokens — a substring check would also hit the
+// always-present `hover:bg-f1-background-secondary` on every row.
+const highlightedRow = () =>
+  rowButtons().findIndex((button) =>
+    button.classList.contains("bg-f1-background-secondary")
+  )
+
+describe("Search preview pagination", () => {
+  it("keeps the reading position when a further page is appended", async () => {
+    const firstPage = rows(PAGE_SIZE)
+    const { view } = await openPreview(firstPage)
+
+    // Scrolling the dropdown drags rows under a stationary cursor, so the
+    // pointer lands on a row near the bottom — that is what sets the active row.
+    fireEvent.mouseOver(rowButtons()[PAGE_SIZE - 1])
+    expect(highlightedRow()).toBe(PAGE_SIZE - 1)
+
+    view.rerender(
+      <Search {...searchProps([...firstPage, ...rows(10, PAGE_SIZE)], "mar")} />
+    )
+
+    // The appended page must not move the highlight off the row being read.
+    expect(highlightedRow()).toBe(PAGE_SIZE - 1)
+  })
+
+  it("highlights the first row when a new query replaces the results", async () => {
+    const { view } = await openPreview(rows(PAGE_SIZE))
+
+    fireEvent.mouseOver(rowButtons()[3])
+    expect(highlightedRow()).toBe(3)
+
+    // A different query replaces the rows outright — row 0 should lead again so
+    // a plain Enter picks the top match.
+    view.rerender(<Search {...searchProps(rows(5, 100), "marta")} />)
+
+    expect(screen.getByText("Person 100")).toBeInTheDocument()
+    expect(highlightedRow()).toBe(0)
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/components/Search/Search.tsx
+++ b/packages/react/src/patterns/OneDataCollection/components/Search/Search.tsx
@@ -72,6 +72,9 @@ export const Search = ({
   const ref = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const activeItemRef = useRef<HTMLButtonElement>(null)
+  // Rows loaded on the previous render, to tell an appended page (keep the
+  // highlight) from a replaced result set (move it back to the top).
+  const previousResultsRef = useRef<SearchResultItem[]>([])
   const i18n = useI18n()
 
   // Render every loaded row; growth is bounded by paginated loading, not a cap.
@@ -90,10 +93,23 @@ export const Search = ({
     }
   }
 
-  // Highlight the first row whenever results change, so a plain Enter jumps to
-  // the top match without the user having to arrow down or click first.
+  // Highlight the first row whenever the result set is REPLACED, so a plain Enter
+  // jumps to the top match without the user having to arrow down or click first.
+  // An appended page must be exempt: it leaves the rows the user is reading in
+  // place, so resetting the highlight there sends Enter to the top match instead
+  // of the row they had reached by scrolling.
   useEffect(() => {
-    setActiveIndex((results ?? []).length > 0 ? 0 : -1)
+    const next = results ?? []
+    const previous = previousResultsRef.current
+    previousResultsRef.current = next
+
+    const isAppendedPage =
+      previous.length > 0 &&
+      next.length > previous.length &&
+      previous.every((result, index) => result.id === next[index]?.id)
+    if (isAppendedPage) return
+
+    setActiveIndex(next.length > 0 ? 0 : -1)
   }, [results])
 
   // Keep the highlighted row visible as the user arrows past the fold.


### PR DESCRIPTION
## What

The search preview dropdown jumps back to the **top** every time infinite scroll pulls a page. The results do keep accumulating, so nothing is permanently unreachable — but you are thrown to row 1 each time you reach the bottom, so getting to the tail of a long result set means re-scrolling the whole list once per page.

Regression in #4833, which added the pagination.

## The mechanism

Two effects, both introduced in #4833:

1. `useEffect(..., [results])` moved the highlight to row 0 on **every** change of the results array — including an appended page, where the rows the user is reading stay in place.
2. `useEffect(..., [activeIndex])` calls `activeItemRef.current?.scrollIntoView({ block: "nearest" })`.

The active row also tracks the **hovered** row (`onMouseEnter`). Scrolling the dropdown drags rows under a stationary cursor, so by the time you hit the bottom `activeIndex` is some row near the end. The append then resets it to 0, and effect 2 scrolls row 0 into view.

That is why the bug looks intermittent: if the cursor is not over a row, `activeIndex` is already 0, `setActiveIndex(0)` is a no-op, and nothing scrolls.

## How

One effect. Tell an appended page from a replaced result set by the row prefix — if every already-loaded row is still at its index and the set grew, the highlight stays put:

```ts
const isAppendedPage =
  previous.length > 0 &&
  next.length > previous.length &&
  previous.every((result, index) => result.id === next[index]?.id)
```

- `previous.length > 0` keeps the **first** page resetting to row 0, so Enter-to-select the top match (the point of #4833) still works.
- A replaced set (different prefix, or fewer rows) still resets; a cleared set still goes to `-1`.
- O(loaded rows), and only when the `results` identity changes.

## Verified in a real browser

Driven against a live consumer (factorial#107450, a 105-match query, 25 per page). Scrolls issued programmatically and the highlight set via a synthetic `mouseover`, so no physical pointer influenced the run. `top` = the dropdown's `scrollTop`, `hi` = highlighted row index.

**Before — this branch's parent (`main`, f0-react 4.65.1):**

| At the moment the page landed | Highlight | `top` before → after |
| --- | --- | --- |
| `hi = 30` | 30 → **0** | 2322 → **4** |
| `hi = 74` | 74 → **0** | 3618 → **4** |
| `hi = 0` | 0 → 0 | 4922 → 4922 (no jump) |
| `hi = 0` | 0 → 0 | 1022 → 1022 (no jump) |

`top = 4` is the `<ul>`'s `p-1` padding — exactly where `scrollIntoView({ block: "nearest" })` on row 0 leaves it.

**After — this branch's alpha build (`npm/alpha-pr-4965`, commit 16341ed), same app, same query:**

```
fresh   hi=0   rows=25   top=56
scroll  hi=0   rows=25   top=1022   <- at the bottom
mutate  hi=0   rows=50   top=1022   <- page appended, position held
scroll  hi=49  rows=50   top=2318   <- hover puts the highlight on row 49
mutate  hi=49  rows=75   top=2318   <- page appended, hi stays 49, position held
scroll  hi=49  rows=75   top=3622
mutate  hi=49  rows=100  top=3622   <- page appended, hi stays 49, position held
```

Three appends, two of them under the exact precondition that reproduced the jump on `main`. No jump, and the highlight is never reset.

## Testing

New `Search.test.tsx`, co-located like `useSearchPreview.test.ts`:

- **Appended page keeps the reading position** — asserts both the highlight and that nothing was scrolled. Verified as a real guard: **fails on `main`**, passes here.
- **A new query still highlights row 0** — guards the #4833 behaviour this must not undo.

`pnpm vitest run src/patterns/OneDataCollection/components/Search/` → **13 passed** (2 new + the 11 existing `useSearchPreview` tests). `pnpm lint` clean; `pnpm tsc` reports 0 errors under `components/Search/` (the 36 it does report are pre-existing in this worktree — an unbuilt `@factorialco/f0-core` plus unrelated `never` types in stories/mocks).

One trap worth flagging for anyone testing this component: the global setup stubs `scrollIntoView` on `HTMLElement.prototype`. A stub on `Element.prototype` is shadowed by it and records **nothing**, so the scroll silently looks like it never happens. The test overrides the former.

## Scope

Only the preview dropdown's highlight. No change to `useSearchPreview`, to the pagination driver, or to how rows are fetched. Consumer side of the pagination: factorial#107450.