### PR TITLE
fix(DatePickerPopup): render the calendar in the dialog container so its dropdowns stay clickable

### DIFF
--- a/packages/react/src/ui/DatePickerPopup/DatePickerPopup.tsx
+++ b/packages/react/src/ui/DatePickerPopup/DatePickerPopup.tsx
@@ -86,14 +86,10 @@ export function DatePickerPopup({
   const effectiveWeekStartsOn =
     weekStartsOn ?? l10n.date?.weekStartsOn ?? WeekStartDay.Monday
 
-  // Auto-detect if we're inside a dialog and use its portal container.
-  // The calendar header's year and month dropdowns are selects, and selects already
-  // portal into the dialog's container, which is a stacking context. Leaving the
-  // calendar in `document.body` puts it after that container in document order, so at
-  // the shared z-index it paints over the whole dialog subtree — including the very
-  // dropdowns it owns, which become unclickable. Sharing the container puts both
-  // layers in one stacking context, where the dropdown opened last wins.
-  // Side panels (left/right) keep rendering in body to prevent clipping.
+  // The calendar's year/month dropdowns are selects that portal into the dialog's
+  // container — a stacking context. A calendar left in `document.body` would paint over
+  // that subtree and cover the dropdowns it owns, so share the container instead.
+  // Side panels (left/right) stay in body to prevent clipping.
   const dialogContext = useContext(F0DialogContext)
   const shouldUseDialogContainer =
     dialogContext.portalContainer &&

--- a/packages/react/src/ui/DatePickerPopup/DatePickerPopup.tsx
+++ b/packages/react/src/ui/DatePickerPopup/DatePickerPopup.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react"
+import { useContext, useEffect, useMemo, useState } from "react"
 
 import { F0Button } from "@/components/F0Button"
 import { F0Select } from "@/components/F0Select"
@@ -13,6 +13,7 @@ import {
 import { ChevronLeft } from "@/icons/app"
 import { useI18n } from "@/lib/providers/i18n"
 import { useL10n } from "@/lib/providers/l10n"
+import { F0DialogContext } from "@/patterns/F0Dialog"
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover"
 
 import { getCompareToValue } from "./compareTo"
@@ -84,6 +85,23 @@ export function DatePickerPopup({
 
   const effectiveWeekStartsOn =
     weekStartsOn ?? l10n.date?.weekStartsOn ?? WeekStartDay.Monday
+
+  // Auto-detect if we're inside a dialog and use its portal container.
+  // The calendar header's year and month dropdowns are selects, and selects already
+  // portal into the dialog's container, which is a stacking context. Leaving the
+  // calendar in `document.body` puts it after that container in document order, so at
+  // the shared z-index it paints over the whole dialog subtree — including the very
+  // dropdowns it owns, which become unclickable. Sharing the container puts both
+  // layers in one stacking context, where the dropdown opened last wins.
+  // Side panels (left/right) keep rendering in body to prevent clipping.
+  const dialogContext = useContext(F0DialogContext)
+  const shouldUseDialogContainer =
+    dialogContext.portalContainer &&
+    (dialogContext.position === "center" ||
+      dialogContext.position === "fullscreen")
+  const portalContainer = shouldUseDialogContainer
+    ? dialogContext.portalContainer
+    : undefined
 
   useEffect(() => {
     if (!isSameDatePickerValue(value, localValue)) {
@@ -245,7 +263,11 @@ export function DatePickerPopup({
   return (
     <Popover open={props.open} onOpenChange={props.onOpenChange}>
       <PopoverTrigger asChild={asChild}>{children}</PopoverTrigger>
-      <PopoverContent className="w-full overflow-auto" align="start">
+      <PopoverContent
+        className="w-full overflow-auto"
+        align="start"
+        container={portalContainer}
+      >
         {showPresets ? (
           <PresetList
             presets={presets}

--- a/packages/react/src/ui/DatePickerPopup/__tests__/DatePickerPopupDialogPortal.test.tsx
+++ b/packages/react/src/ui/DatePickerPopup/__tests__/DatePickerPopupDialogPortal.test.tsx
@@ -1,0 +1,74 @@
+import { screen } from "@testing-library/react"
+import { userEvent } from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { DialogPosition, F0DialogContext } from "@/patterns/F0Dialog"
+import { zeroRender as render } from "@/testing/test-utils"
+
+import { DatePickerPopup } from "../DatePickerPopup"
+
+// The calendar header's year and month dropdowns are selects, and selects portal
+// into the dialog's container. If the calendar itself stays in `document.body` it
+// sits after that container in document order and, at the shared z-index, paints
+// over the dropdowns it owns — leaving the year unpickable (FCT-59810).
+const renderInDialog = (position: DialogPosition) => {
+  const portalContainer = document.createElement("div")
+  document.body.appendChild(portalContainer)
+
+  render(
+    <F0DialogContext.Provider
+      value={{
+        open: true,
+        onClose: vi.fn(),
+        shownBottomSheet: false,
+        position,
+        portalContainer,
+      }}
+    >
+      <DatePickerPopup onSelect={vi.fn()} asChild>
+        <button>Trigger</button>
+      </DatePickerPopup>
+    </F0DialogContext.Provider>
+  )
+
+  return portalContainer
+}
+
+describe("DatePickerPopup portal container", () => {
+  it.each(["center", "fullscreen"] as const)(
+    "renders the calendar inside the dialog container for %s dialogs",
+    async (position) => {
+      const user = userEvent.setup()
+      const portalContainer = renderInDialog(position)
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }))
+
+      expect(portalContainer).toContainElement(screen.getByRole("dialog"))
+    }
+  )
+
+  it.each(["left", "right"] as const)(
+    "keeps the calendar in the body for %s panels, which have no focus trap to escape",
+    async (position) => {
+      const user = userEvent.setup()
+      const portalContainer = renderInDialog(position)
+
+      await user.click(screen.getByRole("button", { name: "Trigger" }))
+
+      expect(portalContainer).not.toContainElement(screen.getByRole("dialog"))
+    }
+  )
+
+  it("keeps the calendar in the body when there is no dialog", async () => {
+    const user = userEvent.setup()
+    render(
+      <DatePickerPopup onSelect={vi.fn()} asChild>
+        <button>Trigger</button>
+      </DatePickerPopup>
+    )
+
+    await user.click(screen.getByRole("button", { name: "Trigger" }))
+
+    expect(screen.getByRole("dialog").closest("body")).toBe(document.body)
+  })
+})


### PR DESCRIPTION
## Description

Inside a center/fullscreen `F0Dialog`, the date picker's **year and month dropdowns open behind the calendar**, so no other year can be picked — a click where `2027` is drawn lands on the day grid instead.

Reported from production as a P1 (partner tenant): Factorial `FCT-59810` / `FCS-137145`, hit on Workplaces → Holidays → Add custom holiday, but the defect is in this package and affects **every** date field rendered inside a dialog (~20 `fieldType: 'date'` schemas and ~50 `F0DatePicker` call sites in the monolith, including the generic dynamic-forms adapter).

## Type of change

- [x] Bug fix

## Root cause

Three layers, **all at `z-index: 50`**:

| Layer | Where | Portals to |
|---|---|---|
| Dialog content | `ui/Dialog/components/DialogContent.tsx:63` (`fixed inset-0 z-50`) | is itself `F0DialogContext.portalContainer` |
| Calendar popover | `ui/DatePickerPopup/DatePickerPopup.tsx` → `ui/popover.tsx:26` | **`document.body`** — no `container` was passed |
| Year/month dropdown | `OneCalendar` → `CalendarHeaderDropdowns` → `F0Select` → `ui/Select/components/SelectContent.tsx:110-121` | **the dialog's container**, by existing auto-detect |

The dialog's content element is `position: fixed` *with* a z-index, so it forms a **stacking context** and clamps every descendant inside it — including the select's own `z-50`. The calendar popover, left in `document.body`, is a later sibling of that container. Equal z-index ⇒ document order decides ⇒ the popover paints above the whole dialog subtree, and therefore above the dropdowns it owns.

Note this rules out the obvious fix: **raising the dropdown's z-index cannot work**, because a descendant cannot escape its ancestor's stacking context at any value. The two layers must share one context.

Introduced by #4736, which added the dropdowns to the calendar header — before that the header had arrows only, so there was nothing to be covered.

## Implementation details

Apply the same auto-detection `OneFilterPicker` already uses (`patterns/OneFilterPicker/components/FiltersControls.tsx:97-104,502`) and pass the dialog's container to `PopoverContent`. Calendar and dropdown then live in one stacking context, where the dropdown — opened last — wins.

`PopoverContent` already accepted and forwarded `container`, so no plumbing was needed.

Behaviour deliberately unchanged elsewhere:
- **Side panels** (`left`/`right`) keep rendering in the body, where the clipping trade-off still favours it — same condition `SelectContent` uses.
- **No dialog** → unchanged (both layers in body; the dropdown already mounted later and won).
- No public API change; nothing added to `DatePickerPopupProps` or `F0DatePickerProps`.

## Testing

New `__tests__/DatePickerPopupDialogPortal.test.tsx` (5 cases): the calendar renders inside the dialog container for `center` and `fullscreen`, and stays in the body for `left`, `right`, and no-dialog.

Verified the test actually guards the regression — with `container={portalContainer}` removed, the two dialog cases fail while the three control cases still pass:

```
× renders the calendar inside the dialog container for center dialogs
× renders the calendar inside the dialog container for fullscreen dialogs
✓ keeps the calendar in the body for left panels
✓ keeps the calendar in the body for right panels
✓ keeps the calendar in the body when there is no dialog
```

With the fix, `DatePickerPopup`, `F0DatePicker`, `OneCalendar`, `F0Dialog`, `F0Select`, `ui/Select` and `OneFilterPicker` are all green: **472 passed, 3 skipped, 0 failed** (37 files). `oxlint` clean on both files; `tsc` adds no new errors (the 36 on this branch are pre-existing, mostly cascading from an unbuilt `@factorialco/f0-core`).

## Screenshots

A center `F0Dialog` containing a single date field, with the **year dropdown open** in both shots. Same viewport, same clicks — the only difference is the one-line `container={portalContainer}`.

### Before — year dropdown open but covered by the calendar

Note the year trigger's chevron is flipped **up**, so the list *is* open. The calendar covers it entirely; only a sliver of the list's right edge and the selected-item check bleed through. Clicking where `2027` should be lands on a day cell.

<img src="https://raw.githubusercontent.com/factorialco/f0/d40e581e65491b313f67d2b19d0c61e7750b236a/.github/assets/fct-59810/before_fix.png" width="640" alt="Before: the year dropdown is open but hidden behind the calendar" />

### After — year dropdown on top and usable

<img src="https://raw.githubusercontent.com/factorialco/f0/d40e581e65491b313f67d2b19d0c61e7750b236a/.github/assets/fct-59810/after_fix.png" width="640" alt="After: the year dropdown renders above the calendar with 2024-2029 visible and selectable" />

Both were captured by the same Playwright script, which also hit-tests `document.elementFromPoint` at the centre of the year list to record which layer actually receives the click:

| | Before | After |
|---|---|---|
| Year list receives the click at its own centre | ❌ `false` | ✅ `true` |
| Calendar covers the year list | ❌ `true` | ✅ `false` |
| Calendar portals to `document.body` | `true` | `false` (dialog container) |

The year options rendered in both runs (`2034 … 2029`), confirming the list mounts either way — before the fix it is simply unreachable.

> Screenshots are hosted on the `assets/fct-59810-screenshots` branch to keep them out of this PR's diff; that branch can be deleted once this merges.

## Follow-up found while investigating (not fixed here)

`components/dialog-alike/F0Dialog/index.tsx:8-10` re-exports `DialogWrapperContext` **aliased as `F0DialogContext`** — a *different* context object from the `@/patterns/F0Dialog` one that `F0Select`/`SelectContent` (and now `DatePickerPopup`) import. Inside a `dialog-alike` dialog these consumers therefore see no container and fall back to the body, so this fix will not reach that path. Worth a separate look by whoever owns the dialog-alike migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
