### PR TITLE
feat(F0AnalyticsDashboard): honest empty states and chart→table fallback

### DIFF
--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.mdx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.mdx
@@ -124,6 +124,30 @@ const [filtersValue, setFiltersValue] = useState<FiltersState<typeof filters>>(
 - WHEN an item sets `useDashboardFilters=false` → THEN that item fetches with an empty filter object.
 - WHEN `items` is empty → THEN the filter bar remains usable without a grid item fetch.
 
+### Empty results
+
+Every item type reports an empty result rather than rendering an empty frame. No prop is required — set `emptyState` on an item to replace the shared default copy with something the reader can act on.
+
+```tsx
+{
+  id: "expenses-by-month",
+  type: "chart",
+  title: "Spend by month",
+  chart: { type: "bar" },
+  emptyState: {
+    title: "No expenses to show",
+    description: "Submit an expense to see it tracked here.",
+  },
+  fetchData,
+}
+```
+
+- WHEN a chart's data has no points → THEN the chart area shows the empty state, with the item's copy when it sets any.
+- WHEN a metric resolves without a usable number → THEN the tile shows the empty state instead of a blank body. A value of `0` is a metric, not an absence.
+- WHEN a collection loads zero rows → THEN it shows its own empty state, fed by the item's copy, instead of column headers over a blank body.
+- WHEN data has points the requested chart type cannot place (for example a heatmap fed one-dimensional series) → THEN the item renders that data as a table, and the chart-type menu still switches back.
+- WHEN an item sets `emptyState.disabled` → THEN its chart renders as-is, including the table fallback opt-out. It has no effect on metrics or collections.
+
 ### Usage examples
 
 Every example keeps the applied value visible above the report, so committed changes can be reviewed without inspecting component internals.

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__stories__/index.stories.tsx
@@ -7,7 +7,7 @@ import type { FiltersState } from "@/patterns/OneFilterPicker/types"
 
 import { withSnapshot } from "@/lib/storybook-utils/parameters"
 
-import type { DashboardItem } from "../types"
+import type { DashboardItem, DashboardMetricData } from "../types"
 
 import { F0AnalyticsDashboard } from "../index"
 import {
@@ -596,5 +596,156 @@ export const EmptyDashboard: Story = {
     await expect(await canvas.findAllByText("No data available")).toHaveLength(
       emptyItems.length
     )
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Per-item empty-state copy, the metric empty branch, and the table fallback
+// ---------------------------------------------------------------------------
+
+const perItemEmptyStateItems: DashboardItem<typeof dashboardFilters>[] = [
+  {
+    id: "empty-metric",
+    title: "Average salary",
+    type: "metric",
+    colSpan: 4,
+    x: 0,
+    y: 0,
+    itemHeight: 144,
+    format: { type: "currency", currency: "EUR" },
+    fetchData: async () => undefined as unknown as DashboardMetricData,
+  },
+  {
+    id: "empty-metric-custom-copy",
+    title: "Headcount",
+    type: "metric",
+    colSpan: 4,
+    x: 4,
+    y: 0,
+    itemHeight: 144,
+    emptyState: {
+      title: "Nobody on payroll yet",
+      description: "Add an employee to start tracking headcount.",
+    },
+    fetchData: async () => undefined as unknown as DashboardMetricData,
+  },
+  {
+    id: "empty-chart-custom-copy",
+    title: "Spend by month",
+    description: "Total spend by month.",
+    type: "chart",
+    colSpan: 4,
+    x: 8,
+    y: 0,
+    itemHeight: 336,
+    chart: { type: "bar" },
+    emptyState: {
+      title: "No expenses to show",
+      description: "Submit an expense to see it tracked here.",
+    },
+    fetchData: async () => ({ categories: [], series: [] }),
+  },
+  {
+    // A heatmap is the one chart the adapter cannot build from 1D series, so
+    // this tile renders its data as a table instead of an empty frame. The
+    // chart-type menu still switches it back to a chart.
+    id: "unbuildable-heatmap",
+    title: "Headcount by team",
+    description: "Requested as a heatmap, but the data is one-dimensional.",
+    type: "chart",
+    colSpan: 12,
+    x: 0,
+    y: 3,
+    itemHeight: 336,
+    chart: { type: "heatmap" },
+    fetchData: async () => ({
+      categories: ["Engineering", "Product", "Design"],
+      series: [{ name: "Headcount", data: [12, 7, 4] }],
+    }),
+  },
+  {
+    // Zero rows: the collection swaps its grid for an empty state rather than
+    // leaving column headers over a blank body. The per-item copy feeds it.
+    id: "empty-collection",
+    title: "Employee directory",
+    type: "collection",
+    colSpan: 12,
+    x: 0,
+    y: 10,
+    itemHeight: 336,
+    emptyState: {
+      title: "No employees to list",
+      description: "Nobody matches the current report filters.",
+    },
+    createSource: () => ({
+      dataAdapter: {
+        paginationType: "pages" as const,
+        perPage: 10,
+        fetchData: async () => ({
+          type: "pages" as const,
+          records: [] as { id: string; name: string }[],
+          total: 0,
+          currentPage: 1,
+          perPage: 10,
+          pagesCount: 0,
+        }),
+      },
+    }),
+    visualizations: [
+      {
+        type: "table" as const,
+        options: {
+          columns: [
+            {
+              id: "name",
+              label: "Name",
+              render: (item: { name: string }) => item.name,
+            },
+          ],
+        },
+      },
+    ],
+  },
+]
+
+/**
+ * Per-item `emptyState` copy on a metric, a chart and a collection, a metric
+ * with no value at all, and the automatic chart → table fallback for data the
+ * requested chart type cannot place.
+ */
+export const PerItemEmptyStates: Story = {
+  tags: ["no-sidebar"],
+  parameters: withSnapshot({
+    docs: {
+      description: {
+        story:
+          "Every widget here has nothing conventional to render. The two left metrics show the default copy and a per-item override; the chart shows a per-item override; the wide tile was configured as a heatmap but fed one-dimensional series, so it falls back to the table view of the same data rather than painting an empty frame.",
+      },
+    },
+  }),
+  render: () => (
+    <F0AnalyticsDashboard
+      filters={dashboardFilters}
+      items={perItemEmptyStateItems}
+      onTransformChart={() => {}}
+    />
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    // Default copy on the first metric, overrides on the other two items.
+    await expect(
+      await canvas.findByText("No data available")
+    ).toBeInTheDocument()
+    await expect(canvas.getByText("Nobody on payroll yet")).toBeInTheDocument()
+    await expect(canvas.getByText("No expenses to show")).toBeInTheDocument()
+
+    // The unbuildable heatmap fell back to the table view of its own data.
+    await expect(await canvas.findByText("Engineering")).toBeInTheDocument()
+
+    // The zero-row collection reports itself instead of showing bare headers.
+    await expect(
+      await canvas.findByText("No employees to list")
+    ).toBeInTheDocument()
   },
 }

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ChartItem.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/ChartItem.test.tsx
@@ -1,0 +1,214 @@
+import { userEvent } from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { screen, waitFor, zeroRender as render } from "@/testing/test-utils"
+
+import type { DashboardChartData, DashboardChartItem } from "../types"
+
+import { ChartItem } from "../components/ChartItem/ChartItem"
+
+// Canvas rendering is not testable in jsdom — the empty-state and table paths
+// under test render before ECharts is ever touched.
+vi.mock("echarts", () => ({
+  init: vi.fn(() => ({
+    setOption: vi.fn(),
+    resize: vi.fn(),
+    dispose: vi.fn(),
+    getDom: vi.fn(() => document.createElement("div")),
+    on: vi.fn(),
+    off: vi.fn(),
+  })),
+  use: vi.fn(),
+  getInstanceByDom: vi.fn(),
+  graphic: { LinearGradient: vi.fn() },
+}))
+
+vi.mock("echarts/components", () => ({ AriaComponent: {} }))
+
+/**
+ * The div ECharts mounts into — its presence is the signal that a chart, and
+ * not the empty state or the fallback table, is what got rendered.
+ */
+function chartCanvasHost(container: HTMLElement) {
+  return container.querySelector("[data-axis-hover]")
+}
+
+const barData: DashboardChartData = {
+  categories: ["Engineering", "Design"],
+  series: [{ name: "Headcount", data: [12, 4] }],
+}
+
+function chartItem(
+  overrides: Partial<DashboardChartItem> = {}
+): DashboardChartItem {
+  return {
+    id: "headcount-by-team",
+    type: "chart",
+    title: "Headcount by team",
+    chart: { type: "bar" },
+    fetchData: () => Promise.resolve(barData),
+    ...overrides,
+  }
+}
+
+describe("ChartItem empty states", () => {
+  it("shows the default copy when the item resolves without data", async () => {
+    render(
+      <ChartItem
+        item={chartItem({
+          fetchData: () =>
+            Promise.resolve(undefined as unknown as DashboardChartData),
+        })}
+        filters={{}}
+      />
+    )
+
+    expect(await screen.findByText("No data available")).toBeInTheDocument()
+    expect(
+      screen.getByText("Try a different date or fewer filters")
+    ).toBeInTheDocument()
+  })
+
+  it("prefers the per-item copy when the item resolves without data", async () => {
+    render(
+      <ChartItem
+        item={chartItem({
+          fetchData: () =>
+            Promise.resolve(undefined as unknown as DashboardChartData),
+          emptyState: {
+            title: "No headcount yet",
+            description: "Hire someone to see this chart.",
+          },
+        })}
+        filters={{}}
+      />
+    )
+
+    expect(await screen.findByText("No headcount yet")).toBeInTheDocument()
+    expect(
+      screen.getByText("Hire someone to see this chart.")
+    ).toBeInTheDocument()
+    expect(screen.queryByText("No data available")).not.toBeInTheDocument()
+  })
+
+  it("prefers the per-item copy for the in-chart empty state too", async () => {
+    // Data resolves, but with no points — `F0DataChart` renders the empty
+    // state itself here, so the override has to reach it through chartProps.
+    render(
+      <ChartItem
+        item={chartItem({
+          fetchData: () => Promise.resolve({ categories: [], series: [] }),
+          emptyState: { title: "No headcount yet" },
+        })}
+        filters={{}}
+      />
+    )
+
+    expect(await screen.findByText("No headcount yet")).toBeInTheDocument()
+  })
+
+  it("honours the per-item render escape hatch", async () => {
+    render(
+      <ChartItem
+        item={chartItem({
+          fetchData: () => Promise.resolve({ categories: [], series: [] }),
+          emptyState: { render: () => <div>Nothing to see</div> },
+        })}
+        filters={{}}
+      />
+    )
+
+    expect(await screen.findByText("Nothing to see")).toBeInTheDocument()
+  })
+})
+
+describe("ChartItem chart → table fallback", () => {
+  /** A heatmap is the one target the adapter cannot build from 1D series. */
+  const unbuildableItem = (overrides: Partial<DashboardChartItem> = {}) =>
+    chartItem({ chart: { type: "heatmap" }, ...overrides })
+
+  it("falls back to the table when the requested chart cannot be built", async () => {
+    render(<ChartItem item={unbuildableItem()} filters={{}} />)
+
+    // The tabular view of the same data, rendered instead of an empty frame.
+    expect(await screen.findByText("Engineering")).toBeInTheDocument()
+    expect(screen.getByText("Design")).toBeInTheDocument()
+    expect(screen.queryByText("No data available")).not.toBeInTheDocument()
+  })
+
+  it("keeps the empty state for genuinely empty data", async () => {
+    render(
+      <ChartItem
+        item={unbuildableItem({
+          fetchData: () => Promise.resolve({ categories: [], series: [] }),
+        })}
+        filters={{}}
+      />
+    )
+
+    expect(await screen.findByText("No data available")).toBeInTheDocument()
+  })
+
+  it("keeps the empty state when the data has categories but no points", async () => {
+    render(
+      <ChartItem
+        item={unbuildableItem({
+          fetchData: () =>
+            Promise.resolve({
+              categories: ["Engineering"],
+              series: [{ name: "Headcount", data: [] }],
+            }),
+        })}
+        filters={{}}
+      />
+    )
+
+    expect(await screen.findByText("No data available")).toBeInTheDocument()
+    expect(screen.queryByText("Engineering")).not.toBeInTheDocument()
+  })
+
+  it("does not fall back for a chart that renders fine", async () => {
+    const { container } = render(<ChartItem item={chartItem()} filters={{}} />)
+
+    await waitFor(() => expect(chartCanvasHost(container)).toBeInTheDocument())
+    expect(screen.queryByText("Engineering")).not.toBeInTheDocument()
+  })
+
+  it("stays on the chart when the consumer disables empty handling", async () => {
+    const { container } = render(
+      <ChartItem
+        item={unbuildableItem({ emptyState: { disabled: true } })}
+        filters={{}}
+      />
+    )
+
+    await waitFor(() => expect(chartCanvasHost(container)).toBeInTheDocument())
+    expect(screen.queryByText("Engineering")).not.toBeInTheDocument()
+  })
+
+  it("lets the user switch back to a chart from the fallback table", async () => {
+    const user = userEvent.setup()
+    const onTransformChart = vi.fn()
+
+    render(
+      <ChartItem
+        item={unbuildableItem()}
+        filters={{}}
+        onTransformChart={onTransformChart}
+      />
+    )
+
+    await screen.findByText("Engineering")
+    await user.click(screen.getByLabelText("Other actions"))
+    await user.click(await screen.findByRole("radio", { name: "Line" }))
+
+    expect(onTransformChart).toHaveBeenCalledWith(
+      "headcount-by-team",
+      "line",
+      undefined
+    )
+    await waitFor(() =>
+      expect(screen.queryByText("Engineering")).not.toBeInTheDocument()
+    )
+  })
+})

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/CollectionItem.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/CollectionItem.test.tsx
@@ -1,0 +1,124 @@
+import { userEvent } from "@testing-library/user-event"
+import { describe, expect, it, vi } from "vitest"
+
+import { screen, waitFor, zeroRender as render } from "@/testing/test-utils"
+
+import type { DashboardCollectionItem } from "../types"
+
+import { CollectionItem } from "../components/CollectionItem/CollectionItem"
+
+type Employee = { id: string; name: string }
+
+/** The grid is hidden — not unmounted — while an empty state is shown. */
+function isGridHidden(container: HTMLElement) {
+  return !!container.querySelector(".hidden table")
+}
+
+function pageOf(records: Employee[]) {
+  return {
+    type: "pages" as const,
+    records,
+    total: records.length,
+    currentPage: 1,
+    perPage: 10,
+    pagesCount: Math.max(1, records.length),
+  }
+}
+
+function collectionItem(
+  fetchData: () => Promise<ReturnType<typeof pageOf>>,
+  overrides: Partial<DashboardCollectionItem> = {}
+): DashboardCollectionItem {
+  return {
+    id: "employees",
+    type: "collection",
+    title: "Employees",
+    createSource: () => ({
+      dataAdapter: { paginationType: "pages" as const, perPage: 10, fetchData },
+    }),
+    visualizations: [
+      {
+        type: "table" as const,
+        options: {
+          columns: [
+            {
+              id: "name",
+              label: "Name",
+              render: (item: Employee) => item.name,
+            },
+          ],
+        },
+      },
+    ],
+    ...overrides,
+  }
+}
+
+describe("CollectionItem", () => {
+  it("renders the rows it was given", async () => {
+    render(
+      <CollectionItem
+        item={collectionItem(() =>
+          Promise.resolve(pageOf([{ id: "1", name: "Alice" }]))
+        )}
+        filters={{}}
+      />
+    )
+
+    expect(await screen.findByText("Alice")).toBeInTheDocument()
+  })
+
+  it("shows an empty state, not a header-only grid, when the query returns zero rows", async () => {
+    const { container } = render(
+      <CollectionItem
+        item={collectionItem(() => Promise.resolve(pageOf([])))}
+        filters={{}}
+      />
+    )
+
+    expect(await screen.findByText("No data")).toBeInTheDocument()
+    await waitFor(() => expect(isGridHidden(container)).toBe(true))
+  })
+
+  it("prefers the per-item copy for zero rows", async () => {
+    render(
+      <CollectionItem
+        item={collectionItem(() => Promise.resolve(pageOf([])), {
+          emptyState: {
+            title: "No employees yet",
+            description: "Invite someone to see them listed here.",
+          },
+        })}
+        filters={{}}
+      />
+    )
+
+    expect(await screen.findByText("No employees yet")).toBeInTheDocument()
+    expect(
+      screen.getByText("Invite someone to see them listed here.")
+    ).toBeInTheDocument()
+    expect(screen.queryByText("No data")).not.toBeInTheDocument()
+  })
+
+  it("refetches on retry and lands on the zero-row empty state", async () => {
+    // The collection's own retry re-applies the current filters, which never
+    // change for a dashboard item — without a real refetch the cleared error
+    // uncovers the header-only grid this asserts against.
+    const fetchData = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValue(pageOf([]))
+
+    const { container } = render(
+      <CollectionItem item={collectionItem(fetchData)} filters={{}} />
+    )
+
+    await userEvent
+      .setup()
+      .click(await screen.findByRole("button", { name: "Retry" }))
+
+    expect(await screen.findByText("No data")).toBeInTheDocument()
+    expect(fetchData).toHaveBeenCalledTimes(2)
+    expect(isGridHidden(container)).toBe(true)
+  })
+})

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/MetricItem.test.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/MetricItem.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { zeroRender as render, screen } from "@/testing/test-utils"
 
-import type { DashboardMetricItem } from "../types"
+import type { DashboardMetricData, DashboardMetricItem } from "../types"
 
 import { MetricItem, MetricValue } from "../components/MetricItem/MetricItem"
 
@@ -170,6 +170,88 @@ describe("MetricItem", () => {
     await waitFor(() =>
       expect(currentContainer).toHaveAttribute("tabindex", "0")
     )
+  })
+
+  describe("empty state", () => {
+    const noData = () =>
+      metricItem({
+        fetchData: () =>
+          Promise.resolve(undefined as unknown as DashboardMetricData),
+      })
+
+    it("shows the default copy instead of a blank tile", async () => {
+      render(<MetricItem item={noData()} filters={{}} />)
+
+      expect(await screen.findByText("No data available")).toBeInTheDocument()
+      expect(
+        screen.getByText("Try a different date or fewer filters")
+      ).toBeInTheDocument()
+    })
+
+    it("prefers the per-item copy", async () => {
+      render(
+        <MetricItem
+          item={metricItem({
+            fetchData: () =>
+              Promise.resolve(undefined as unknown as DashboardMetricData),
+            emptyState: {
+              title: "No salaries yet",
+              description: "Add a contract to see this metric.",
+            },
+          })}
+          filters={{}}
+        />
+      )
+
+      expect(await screen.findByText("No salaries yet")).toBeInTheDocument()
+      expect(
+        screen.getByText("Add a contract to see this metric.")
+      ).toBeInTheDocument()
+      expect(screen.queryByText("No data available")).not.toBeInTheDocument()
+    })
+
+    it("honours the render escape hatch", async () => {
+      render(
+        <MetricItem
+          item={metricItem({
+            fetchData: () =>
+              Promise.resolve(undefined as unknown as DashboardMetricData),
+            emptyState: { render: () => <div>Nothing to report</div> },
+          })}
+          filters={{}}
+        />
+      )
+
+      expect(await screen.findByText("Nothing to report")).toBeInTheDocument()
+    })
+
+    it.each([NaN, Infinity])(
+      "treats %s as empty rather than formatting it",
+      async (value) => {
+        render(
+          <MetricItem
+            item={metricItem({ fetchData: () => Promise.resolve({ value }) })}
+            filters={{}}
+          />
+        )
+
+        expect(await screen.findByText("No data available")).toBeInTheDocument()
+        expect(screen.queryByText("NaN")).not.toBeInTheDocument()
+        expect(screen.queryByText("∞")).not.toBeInTheDocument()
+      }
+    )
+
+    it("still renders a zero value — 0 is a metric, not an absence", async () => {
+      render(
+        <MetricItem
+          item={metricItem({ fetchData: () => Promise.resolve({ value: 0 }) })}
+          filters={{}}
+        />
+      )
+
+      expect(await screen.findByText("0")).toBeInTheDocument()
+      expect(screen.queryByText("No data available")).not.toBeInTheDocument()
+    })
   })
 
   it("rechecks overflow when the same metric is resized", async () => {

--- a/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/chartRenderability.test.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/__tests__/chartRenderability.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest"
+
+import type { F0DataChartProps } from "@/kits/F0DataChart"
+
+import type { DashboardChartData } from "../types"
+
+import { canRenderChart, hasChartDataPoints } from "../utils/chartRenderability"
+
+describe("hasChartDataPoints", () => {
+  it.each<[string, DashboardChartData]>([
+    [
+      "bar/line series",
+      { categories: ["Q1"], series: [{ name: "A", data: [1] }] },
+    ],
+    [
+      "a zero-valued series (zero is a value)",
+      { categories: ["Q1"], series: [{ name: "A", data: [0] }] },
+    ],
+    [
+      "funnel/pie series",
+      { series: { name: "Pipeline", data: [{ name: "Lead", value: 3 }] } },
+    ],
+    [
+      "radar series",
+      {
+        indicators: [{ name: "Speed", max: 10 }],
+        series: [{ name: "A", data: [4] }],
+      },
+    ],
+    ["a gauge value", { series: { value: 12 } }],
+    ["a zero gauge value", { series: { value: 0 } }],
+    [
+      "heatmap points",
+      { xCategories: ["Mon"], yCategories: ["AM"], data: [[0, 0, 5]] },
+    ],
+  ])("reports data points for %s", (_label, data) => {
+    expect(hasChartDataPoints(data)).toBe(true)
+  })
+
+  it.each<[string, DashboardChartData]>([
+    ["nothing at all", {}],
+    ["no series", { categories: ["Q1", "Q2"] }],
+    ["an empty series list", { categories: ["Q1"], series: [] }],
+    [
+      "series that carry no points",
+      { categories: ["Q1"], series: [{ name: "A", data: [] }] },
+    ],
+    ["an empty funnel series", { series: { name: "Pipeline", data: [] } }],
+    [
+      "a heatmap with axes but no points",
+      { xCategories: ["Mon"], yCategories: ["AM"], data: [] },
+    ],
+  ])("reports no data points for %s", (_label, data) => {
+    expect(hasChartDataPoints(data)).toBe(false)
+  })
+})
+
+describe("canRenderChart", () => {
+  it("accepts a chart that has both points and somewhere to put them", () => {
+    expect(
+      canRenderChart({
+        type: "bar",
+        categories: ["Q1"],
+        series: [{ name: "A", data: [1] }],
+      })
+    ).toBe(true)
+  })
+
+  it.each<[string, F0DataChartProps]>([
+    ["bar", { type: "bar", categories: [], series: [] }],
+    ["line", { type: "line", categories: [], series: [] }],
+    ["pie", { type: "pie", series: { name: "", data: [] } }],
+    ["funnel", { type: "funnel", series: { name: "", data: [] } }],
+    ["radar", { type: "radar", indicators: [], series: [] }],
+    ["gauge", { type: "gauge" } as F0DataChartProps],
+    [
+      "heatmap",
+      { type: "heatmap", xCategories: [], yCategories: [], data: [] },
+    ],
+  ])("rejects an empty %s chart", (_label, props) => {
+    expect(canRenderChart(props)).toBe(false)
+  })
+
+  it("rejects bar/line data with no category axis to place it on", () => {
+    expect(
+      canRenderChart({
+        type: "bar",
+        categories: [],
+        series: [{ name: "A", data: [1, 2, 3] }],
+      })
+    ).toBe(false)
+  })
+
+  it("rejects radar data with no indicators", () => {
+    expect(
+      canRenderChart({
+        type: "radar",
+        indicators: [],
+        series: [{ name: "A", data: [1, 2, 3] }],
+      })
+    ).toBe(false)
+  })
+
+  it("rejects a heatmap missing either axis", () => {
+    expect(
+      canRenderChart({
+        type: "heatmap",
+        xCategories: ["Mon"],
+        yCategories: [],
+        data: [[0, 0, 5]],
+      })
+    ).toBe(false)
+    expect(
+      canRenderChart({
+        type: "heatmap",
+        xCategories: [],
+        yCategories: ["AM"],
+        data: [[0, 0, 5]],
+      })
+    ).toBe(false)
+  })
+
+  it("accepts funnel, pie and gauge without any axis — they label themselves", () => {
+    expect(
+      canRenderChart({
+        type: "pie",
+        series: { name: "Split", data: [{ name: "A", value: 1 }] },
+      })
+    ).toBe(true)
+    expect(
+      canRenderChart({
+        type: "funnel",
+        series: { name: "Pipeline", data: [{ name: "Lead", value: 1 }] },
+      })
+    ).toBe(true)
+    expect(canRenderChart({ type: "gauge", value: 0 })).toBe(true)
+  })
+})

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/ChartItem/ChartItem.tsx
@@ -47,6 +47,10 @@ import {
   toCanonical,
 } from "../../utils/chartDataAdapter"
 import { chartDataToTabular } from "../../utils/chartDataToTabular"
+import {
+  canRenderChart,
+  hasChartDataPoints,
+} from "../../utils/chartRenderability"
 import { DashboardItem } from "../DashboardItem/DashboardItem"
 
 // ---------------------------------------------------------------------------
@@ -317,6 +321,21 @@ function buildNativeChartProps(
 // Table view — renders chart data as a OneDataCollection table
 // ---------------------------------------------------------------------------
 
+/**
+ * The config the tabular converter should run with. After a chart type
+ * transform `config.type` may not match the actual data shape, so the shape
+ * detected from the data wins — that is what picks the right converter.
+ */
+function tabularConfig(
+  config: DashboardChartConfig,
+  data: DashboardChartData
+): DashboardChartConfig {
+  const dataShape = detectDataShape(data, config.type)
+  return dataShape !== config.type
+    ? ({ ...config, type: dataShape } as DashboardChartConfig)
+    : config
+}
+
 function ChartTableView({
   config,
   data,
@@ -324,17 +343,9 @@ function ChartTableView({
   config: DashboardChartConfig
   data: DashboardChartData
 }) {
-  // After a chart type transform, item.chart.type may not match the actual
-  // data shape. Use detectDataShape to pick the right tabular converter.
-  const dataShape = detectDataShape(data, config.type)
-  const effectiveConfig =
-    dataShape !== config.type
-      ? ({ ...config, type: dataShape } as DashboardChartConfig)
-      : config
-
   const tabular = useMemo(
-    () => chartDataToTabular(effectiveConfig, data),
-    [effectiveConfig, data]
+    () => chartDataToTabular(tabularConfig(config, data), data),
+    [config, data]
   )
 
   const sourceDefinition = useMemo(
@@ -409,7 +420,15 @@ export function ChartItem<Filters extends FiltersDefinition>({
   onFullscreenChange,
 }: ChartItemProps<Filters>) {
   const translations = useI18n()
-  const [viewMode, setViewMode] = useState<"chart" | "table">("chart")
+  /**
+   * The view the user picked from the chart-type menu. `null` means they have
+   * not picked one, which leaves the choice to the automatic table fallback
+   * below. Once set it wins forever — an explicit "show me the chart" is not
+   * overridden by our own heuristics.
+   */
+  const [userViewMode, setUserViewMode] = useState<"chart" | "table" | null>(
+    null
+  )
 
   const enabled = item.useDashboardFilters !== false
   const { data, isLoading, error, retry } = useDashboardItemData<
@@ -442,11 +461,36 @@ export function ChartItem<Filters extends FiltersDefinition>({
   // re-renders. Fresh props objects would rebuild the ECharts options and
   // trigger a full `setOption(notMerge)` — which recreates the tooltip and
   // hides it mid-hover — on every parent render.
-  const chartProps = useMemo(
-    () =>
-      data ? buildChartProps(item as DashboardChartItem, data) : undefined,
-    [item, data]
-  )
+  const chartProps = useMemo(() => {
+    if (!data) return undefined
+    const props = buildChartProps(item as DashboardChartItem, data)
+    // Threaded so the in-chart empty state (data present but with no points)
+    // reads the same copy as the wrapper-level one below.
+    return item.emptyState ? { ...props, emptyState: item.emptyState } : props
+  }, [item, data])
+
+  /**
+   * Data came back with points, but the requested chart type cannot place
+   * them — a heatmap fed one-dimensional series is the case the adapter
+   * itself admits it cannot build. Rather than paint an empty frame we show
+   * the same data as a table, which `chartDataToTabular` can always produce.
+   *
+   * Deliberately conservative: it needs data points (empty results stay with
+   * the empty state), a table that would actually have rows, and no
+   * `emptyState.disabled` — that flag means the consumer wants the chart
+   * rendered as-is and no second-guessing from us.
+   */
+  const fallsBackToTable = useMemo(() => {
+    if (!data || !chartProps) return false
+    if (item.emptyState?.disabled) return false
+    if (!hasChartDataPoints(data)) return false
+    if (canRenderChart(chartProps)) return false
+    return (
+      chartDataToTabular(tabularConfig(item.chart, data), data).rows.length > 0
+    )
+  }, [chartProps, data, item.chart, item.emptyState?.disabled])
+
+  const viewMode = userViewMode ?? (fallsBackToTable ? "table" : "chart")
 
   // Determine which chart type options are available for this chart
   const currentOrientation =
@@ -495,9 +539,9 @@ export function ChartItem<Filters extends FiltersDefinition>({
           isActive,
           onSelect: () => {
             if (isTable) {
-              setViewMode("table")
+              setUserViewMode("table")
             } else {
-              setViewMode("chart")
+              setUserViewMode("chart")
               if (
                 item.chart.type !== opt.type ||
                 (opt.type === "bar" && currentOrientation !== opt.orientation)
@@ -537,7 +581,10 @@ export function ChartItem<Filters extends FiltersDefinition>({
         )
       ) : !isLoading ? (
         <div className="h-full w-full px-4 py-3">
-          <DataChartEmptyStateView chartType={item.chart.type} />
+          <DataChartEmptyStateView
+            chartType={item.chart.type}
+            emptyState={item.emptyState}
+          />
         </div>
       ) : null}
     </DashboardItem>

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/CollectionItem/CollectionItem.tsx
@@ -7,6 +7,7 @@ import type {
 import type { DropdownItem } from "@/experimental/Navigation/Dropdown"
 import type { RecordType } from "@/hooks/datasource"
 
+import { useI18n } from "@/lib/providers/i18n"
 import { OneDataCollection } from "@/patterns/OneDataCollection"
 import { useDataCollectionSource } from "@/patterns/OneDataCollection/hooks/useDataCollectionSource"
 
@@ -44,20 +45,61 @@ export function CollectionItem<Filters extends FiltersDefinition>({
 }: CollectionItemProps<Filters>) {
   const enabled = item.useDashboardFilters !== false
   const effectiveFilters = enabled ? filters : ({} as FiltersState<Filters>)
+  const translations = useI18n()
+
+  /**
+   * Bumped by the error state's retry action. `OneDataCollection`'s built-in
+   * retry re-applies the current filters to trigger a refetch, which is a
+   * no-op for a dashboard collection: its source declares no filters of its
+   * own (the dashboard bakes them in), so the "changed" filters compare equal,
+   * nothing is refetched, and clearing the error uncovers a header-only grid
+   * with no message. Rebuilding the source from here forces the fetch.
+   */
+  const [retryNonce, setRetryNonce] = useState(0)
 
   // Memoize the source definition to avoid re-creating on every render.
-  // Re-creates when filters change (JSON key).
+  // Re-creates when filters change (JSON key) or on an explicit retry.
   const filtersKey = JSON.stringify(effectiveFilters)
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const sourceDefinition = useMemo(
     () => item.createSource(effectiveFilters),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [filtersKey]
+    [filtersKey, retryNonce]
   )
 
   const source = useDataCollectionSource<RecordType>(sourceDefinition, [
     filtersKey,
+    retryNonce,
   ])
+
+  /**
+   * The collection already detects "loaded, but zero rows" and swaps the grid
+   * for an empty state; this only feeds it the per-item copy and the working
+   * retry. `emptyState.render` / `disabled` have no counterpart here — see the
+   * per-type notes on `DashboardItemBase.emptyState`.
+   */
+  const emptyStates = useMemo(() => {
+    const copy = {
+      ...(item.emptyState?.title ? { title: item.emptyState.title } : {}),
+      ...(item.emptyState?.description
+        ? { description: item.emptyState.description }
+        : {}),
+    }
+
+    return {
+      "no-data": copy,
+      "no-results": copy,
+      error: {
+        actions: [
+          {
+            label: translations.collections.emptyStates.error.retry,
+            onClick: () => setRetryNonce((nonce) => nonce + 1),
+            variant: "neutral" as const,
+          },
+        ],
+      },
+    }
+  }, [item.emptyState?.description, item.emptyState?.title, translations])
 
   // We capture the current table visualization settings (hidden columns +
   // user-chosen order) via OneDataCollection's `onStateChange` callback so
@@ -132,6 +174,7 @@ export function CollectionItem<Filters extends FiltersDefinition>({
         fullHeight
         source={source}
         visualizations={item.visualizations}
+        emptyStates={emptyStates}
         // We deliberately do NOT enable `csvExport` here — the dashboard
         // surface already exposes Excel + CSV downloads from the
         // DashboardItem 3-dot menu (`downloadActions` above) and both

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardEmptyState/DashboardEmptyState.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/DashboardEmptyState/DashboardEmptyState.tsx
@@ -1,0 +1,41 @@
+import type { F0DataChartEmptyStateProps } from "@/kits/F0DataChart"
+
+import { useI18n } from "@/lib/providers/i18n"
+
+/**
+ * Text-only empty state for dashboard widgets that have no chart to hand the
+ * job to.
+ *
+ * Chart items delegate to the kit's `DataChartEmptyStateView` so they inherit
+ * whatever it renders; that component draws a chart-type skeleton behind the
+ * message, which is meaningless on a KPI tile. This resolves the same
+ * `F0DataChartEmptyStateProps` contract — identical default copy, same
+ * `render` escape hatch — and renders the message alone.
+ */
+export function DashboardEmptyState({
+  emptyState,
+}: {
+  emptyState?: F0DataChartEmptyStateProps
+}) {
+  const i18n = useI18n()
+
+  if (emptyState?.render) return <>{emptyState.render()}</>
+
+  const defaults = i18n.dataChart.emptyState
+  const description = emptyState?.description ?? defaults.description
+
+  return (
+    <div className="flex h-full w-full items-center justify-center px-4 pb-4">
+      <div className="flex flex-col items-center gap-1 text-center">
+        <p className="text-lg font-medium text-f1-foreground">
+          {emptyState?.title ?? defaults.title}
+        </p>
+        {description && (
+          <p className="text-md max-w-sm text-f1-foreground-secondary">
+            {description}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/packages/react/src/patterns/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/components/MetricItem/MetricItem.tsx
@@ -17,6 +17,7 @@ import type {
 } from "../../types"
 
 import { useDashboardItemData } from "../../hooks/useDashboardItemData"
+import { DashboardEmptyState } from "../DashboardEmptyState/DashboardEmptyState"
 import { DashboardItem } from "../DashboardItem/DashboardItem"
 import { MetricSkeleton } from "../DashboardItem/DashboardItemSkeleton"
 
@@ -194,7 +195,16 @@ export function MetricItem<Filters extends FiltersDefinition>({
     DashboardMetricData
   >(item.fetchData, filters, enabled)
 
-  const trend = data ? computeTrend(data.value, data.previousValue) : undefined
+  // A metric with nothing to show reads as an empty state, not a blank tile.
+  // `DashboardItem` only renders children once loading has finished and no
+  // error is set, so reaching here without a usable number means the query
+  // came back without one. Non-finite values are treated the same way — they
+  // would otherwise format as "NaN".
+  const value =
+    data !== undefined && Number.isFinite(data.value) ? data.value : undefined
+
+  const trend =
+    value !== undefined ? computeTrend(value, data?.previousValue) : undefined
 
   return (
     <DashboardItem
@@ -210,15 +220,17 @@ export function MetricItem<Filters extends FiltersDefinition>({
       handleDelete={handleDelete}
       itemId={item.id}
     >
-      {data && (
+      {value !== undefined ? (
         <MetricValue
           value={
             item.valueFormatter
-              ? item.valueFormatter(data.value)
-              : formatValue(data.value, item.format, item.decimals)
+              ? item.valueFormatter(value)
+              : formatValue(value, item.format, item.decimals)
           }
           trend={trend}
         />
+      ) : (
+        <DashboardEmptyState emptyState={item.emptyState} />
       )}
     </DashboardItem>
   )

--- a/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/types.ts
@@ -1,6 +1,7 @@
 import type {
   ChartColorToken,
   F0DataChartBarSeries,
+  F0DataChartEmptyStateProps,
   F0DataChartFunnelSeries,
   F0DataChartLineSeries,
   F0DataChartPieSeries,
@@ -214,6 +215,23 @@ export interface DashboardItemBase {
    * @default true
    */
   useDashboardFilters?: boolean
+  /**
+   * Customize the empty state shown when this item has no data to show.
+   *
+   * Same contract as the `F0DataChart` prop of the same name. `title` /
+   * `description` override the default copy everywhere; support for the rest
+   * depends on what the item renders:
+   *
+   * - **chart** — full support. `render` replaces the UI, and `disabled` keeps
+   *   the chart rendered when its data has no points, which also opts the item
+   *   out of the automatic chart → table fallback.
+   * - **metric** — `render` is honoured. `disabled` is not: a metric with no
+   *   value always shows its empty state, since there is nothing to render in
+   *   its place.
+   * - **collection** — the copy feeds the collection's own "no data" and "no
+   *   results" states. `render` and `disabled` do not apply.
+   */
+  emptyState?: F0DataChartEmptyStateProps
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/react/src/patterns/F0AnalyticsDashboard/utils/chartRenderability.ts
+++ b/packages/react/src/patterns/F0AnalyticsDashboard/utils/chartRenderability.ts
@@ -1,0 +1,74 @@
+import type { F0DataChartProps } from "@/kits/F0DataChart"
+
+import type { DashboardChartData } from "../types"
+
+import { isDataChartEmpty } from "@/kits/F0DataChart/utils/isDataChartEmpty"
+
+import { detectDataShape } from "./chartDataAdapter"
+
+/**
+ * Whether the raw data returned by `fetchData` carries any data point at all,
+ * judged against the shape the data actually has rather than the chart type
+ * the item asked for.
+ *
+ * This mirrors `isDataChartEmpty` (the kit's check, which runs on already-built
+ * `F0DataChart` props) one step earlier in the pipeline: it distinguishes "the
+ * query returned nothing" from "the query returned rows the requested chart
+ * cannot place". The first is the empty state's job; only the second is worth
+ * falling back to a table for.
+ */
+export function hasChartDataPoints(data: DashboardChartData): boolean {
+  switch (detectDataShape(data)) {
+    case "heatmap":
+      return (data.data?.length ?? 0) > 0
+    case "gauge":
+      return (
+        typeof (data.series as { value?: unknown } | undefined)?.value ===
+        "number"
+      )
+    case "funnel":
+    case "pie": {
+      const series = data.series as { data?: unknown[] } | undefined
+      return Array.isArray(series?.data) && series.data.length > 0
+    }
+    case "bar":
+    case "line":
+    case "radar":
+      return (
+        Array.isArray(data.series) &&
+        data.series.some(
+          (series) =>
+            Array.isArray((series as { data?: unknown[] })?.data) &&
+            (series as { data: unknown[] }).data.length > 0
+        )
+      )
+  }
+}
+
+/**
+ * Whether `F0DataChart` can actually draw these props.
+ *
+ * `isDataChartEmpty` answers "are there data points?"; this adds the
+ * structural preconditions needed to *place* those points — a category axis
+ * for bar/line, indicators for radar, both axes for a heatmap. Fail either and
+ * the chart paints its frame and nothing else, which is what makes a
+ * shape-mismatched widget look broken rather than empty. Funnel, pie and gauge
+ * label themselves from the series, so they have no extra requirement.
+ */
+export function canRenderChart(props: F0DataChartProps): boolean {
+  if (isDataChartEmpty(props)) return false
+
+  switch (props.type) {
+    case "bar":
+    case "line":
+      return props.categories.length > 0
+    case "radar":
+      return props.indicators.length > 0
+    case "heatmap":
+      return props.xCategories.length > 0 && props.yCategories.length > 0
+    case "funnel":
+    case "pie":
+    case "gauge":
+      return true
+  }
+}


### PR DESCRIPTION
## What

Analytics dashboard widgets stop looking broken when there is nothing (or nothing chartable) to show:

- **Per-item empty-state copy** — `DashboardItemBase.emptyState` (same contract as the `F0DataChart` prop) lets the dashboard builder say *"No roles currently exceed a 5% pay gap"* instead of generic copy. Threaded into both the wrapper-level and in-chart empty paths, the metric tile, and the collection's no-data/no-results states; per-type support documented on the type.
- **Metric empty state** — a KPI tile with no value (or a non-finite one) now renders a text-only empty state instead of a blank card (or `NaN`). `0` still renders as `0`.
- **Automatic chart → table fallback** — when data has points but the requested chart type structurally cannot place them (e.g. a heatmap fed one-dimensional series — the one case the adapter itself admits defeat on), the item renders the existing table view instead of an empty chart frame. Guarded four ways: data points present (empty results keep the empty state), the built props fail `canRenderChart`, the table would actually have rows, and `emptyState.disabled` opts out. An explicit view choice from the chart-type menu always wins.
- **Collection retry actually refetches** — reproduced the "Retry uncovers a header-only blank grid" bug: the built-in retry re-applies current filters, which is a no-op for dashboard collections (they declare no filters of their own), so nothing refetched. The item now rebuilds its source on retry, landing on rows or an honest empty state.

Motivated by product validation of AI-generated pay-equity dashboards (widgets rendering as broken/blank when queries return zero rows or shape-incompatible data).

## How

New pure `utils/chartRenderability.ts` (`hasChartDataPoints` judged against the *detected* data shape, `canRenderChart` = kit emptiness + structural axis/indicator preconditions). `ChartItem` derives `viewMode` (`userViewMode ?? (fallsBackToTable ? "table" : "chart")`) — no effects, no loops. `MetricItem` gains an explicit empty branch via a small text-only `DashboardEmptyState` resolver. `CollectionItem` bumps a `retryNonce` folded into its source deps. No kit changes.

## Proof

- 45 new/extended tests: renderability matrix (25), ChartItem (10 — copy override both paths, fallback fires on shape mismatch, does NOT fire on empty data / categories-without-points / renderable charts / `disabled`, toggle-back), CollectionItem (4, incl. a retry regression guard proving 2 fetch calls where main makes 1), MetricItem (+6). Story `PerItemEmptyStates` covers all four behaviors in one dashboard; docs section added.
- Full suite: **5381 passed / 0 failed** (450 files). `tsc`, `oxlint`, `oxfmt` clean (3 pre-existing display-name errors in an untouched test file).
- Composition: no conflict with #4947; one mechanical one-line overlap with #4946 (`ChartItem.tsx` empty-state call — both edit the same line; resolution is additive). Chart items inherit #4946's text-only visual automatically since the kit is untouched.

## Consumer impact

Everything is opt-in or a strict improvement with zero consumer changes: blank metric tiles start saying "No data available", shape-mismatched charts show a table, collection Retry works. No new i18n keys (`TranslationsType` unchanged).

## Residuals (handed off, out of scope)

- The underlying `OneDataCollection` retry is broken for *any* filter-less collection; a real fix needs a refetch primitive in `hooks/datasource/useData.ts` (repo-wide blast radius).
- `onTotalItemsChange` on `OneDataCollectionProps` is declared but never invoked (dead prop).
- Bar/line/radar data with points but no category labels stays a blank chart (its table would be empty too — fallback would not improve it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)