### PR TITLE
feat(SurveyFormBuilder): configurable title placeholders + skipDefaultSection

### DIFF
--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Context.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Context.tsx
@@ -23,6 +23,7 @@ import {
   SectionElement,
   SurveyDatasets,
   SurveyFormBuilderPlaceholders,
+  SurveyFormBuilderLabels,
 } from "./types"
 
 type SurveyFormBuilderContextType = SurveyFormBuilderCallbacks & {
@@ -42,6 +43,8 @@ type SurveyFormBuilderContextType = SurveyFormBuilderCallbacks & {
   useUpload?: UseFileUpload
   datasets?: SurveyDatasets
   placeholders?: SurveyFormBuilderPlaceholders
+  labels?: SurveyFormBuilderLabels
+  hideAnswerPreview?: boolean
 }
 
 const SurveyFormBuilderContext = createContext<
@@ -61,7 +64,9 @@ type SurveyFormBuilderProviderProps = {
   useUpload?: UseFileUpload
   datasets?: SurveyDatasets
   placeholders?: SurveyFormBuilderPlaceholders
+  labels?: SurveyFormBuilderLabels
   skipDefaultSection?: boolean
+  hideAnswerPreview?: boolean
 }
 
 export function SurveyFormBuilderProvider({
@@ -77,7 +82,9 @@ export function SurveyFormBuilderProvider({
   useUpload,
   datasets,
   placeholders,
+  labels,
   skipDefaultSection,
+  hideAnswerPreview,
 }: SurveyFormBuilderProviderProps) {
   const elementsRef = useRef(elements)
   elementsRef.current = elements
@@ -449,6 +456,8 @@ export function SurveyFormBuilderProvider({
       useUpload,
       datasets,
       placeholders,
+      labels,
+      hideAnswerPreview,
     }),
     [
       handleQuestionChange,
@@ -469,6 +478,8 @@ export function SurveyFormBuilderProvider({
       useUpload,
       datasets,
       placeholders,
+      labels,
+      hideAnswerPreview,
     ]
   )
 

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Context.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Context.tsx
@@ -22,6 +22,7 @@ import {
   QuestionType,
   SectionElement,
   SurveyDatasets,
+  SurveyFormBuilderPlaceholders,
 } from "./types"
 
 type SurveyFormBuilderContextType = SurveyFormBuilderCallbacks & {
@@ -40,6 +41,7 @@ type SurveyFormBuilderContextType = SurveyFormBuilderCallbacks & {
   onFieldBlur?: (questionId: string) => void
   useUpload?: UseFileUpload
   datasets?: SurveyDatasets
+  placeholders?: SurveyFormBuilderPlaceholders
 }
 
 const SurveyFormBuilderContext = createContext<
@@ -58,6 +60,8 @@ type SurveyFormBuilderProviderProps = {
   onFieldBlur?: (questionId: string) => void
   useUpload?: UseFileUpload
   datasets?: SurveyDatasets
+  placeholders?: SurveyFormBuilderPlaceholders
+  skipDefaultSection?: boolean
 }
 
 export function SurveyFormBuilderProvider({
@@ -72,6 +76,8 @@ export function SurveyFormBuilderProvider({
   onFieldBlur,
   useUpload,
   datasets,
+  placeholders,
+  skipDefaultSection,
 }: SurveyFormBuilderProviderProps) {
   const elementsRef = useRef(elements)
   elementsRef.current = elements
@@ -402,14 +408,14 @@ export function SurveyFormBuilderProvider({
   useEffect(() => {
     if (isFirstRender.current) {
       isFirstRender.current = false
-      if (isEmpty && !disabled && !answering) {
+      if (isEmpty && !disabled && !answering && !skipDefaultSection) {
         handleAddNewElement({
           type: "section",
         })
       }
       return
     }
-  }, [isEmpty, handleAddNewElement, disabled])
+  }, [isEmpty, handleAddNewElement, disabled, answering, skipDefaultSection])
 
   const isQuestionTypeAllowed = useCallback(
     (questionType: QuestionType) => {
@@ -442,6 +448,7 @@ export function SurveyFormBuilderProvider({
       onFieldBlur,
       useUpload,
       datasets,
+      placeholders,
     }),
     [
       handleQuestionChange,
@@ -461,6 +468,7 @@ export function SurveyFormBuilderProvider({
       onFieldBlur,
       useUpload,
       datasets,
+      placeholders,
     ]
   )
 

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Context.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Context.tsx
@@ -44,7 +44,6 @@ type SurveyFormBuilderContextType = SurveyFormBuilderCallbacks & {
   datasets?: SurveyDatasets
   placeholders?: SurveyFormBuilderPlaceholders
   labels?: SurveyFormBuilderLabels
-  hideAnswerPreview?: boolean
 }
 
 const SurveyFormBuilderContext = createContext<
@@ -66,7 +65,6 @@ type SurveyFormBuilderProviderProps = {
   placeholders?: SurveyFormBuilderPlaceholders
   labels?: SurveyFormBuilderLabels
   skipDefaultSection?: boolean
-  hideAnswerPreview?: boolean
 }
 
 export function SurveyFormBuilderProvider({
@@ -84,7 +82,6 @@ export function SurveyFormBuilderProvider({
   placeholders,
   labels,
   skipDefaultSection,
-  hideAnswerPreview,
 }: SurveyFormBuilderProviderProps) {
   const elementsRef = useRef(elements)
   elementsRef.current = elements
@@ -457,7 +454,6 @@ export function SurveyFormBuilderProvider({
       datasets,
       placeholders,
       labels,
-      hideAnswerPreview,
     }),
     [
       handleQuestionChange,
@@ -479,7 +475,6 @@ export function SurveyFormBuilderProvider({
       datasets,
       placeholders,
       labels,
-      hideAnswerPreview,
     ]
   )
 

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Form/AddButton/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Form/AddButton/index.tsx
@@ -21,12 +21,20 @@ import { useSurveyFormBuilderContext } from "../../Context"
 import { QuestionType } from "../../types"
 
 export const AddButton = () => {
-  const { disabled, answering, onAddNewElement, isQuestionTypeAllowed } =
-    useSurveyFormBuilderContext()
+  const {
+    disabled,
+    answering,
+    onAddNewElement,
+    isQuestionTypeAllowed,
+    labels,
+  } = useSurveyFormBuilderContext()
   const [open, setOpen] = useState(false)
 
   const questionTypes = useQuestionTypes()
   const { t } = useI18n()
+
+  const addQuestionLabel =
+    labels?.addQuestion ?? t("surveyFormBuilder.actions.addQuestion")
 
   const handleAddNewQuestion = (type: QuestionType, datasetKey?: string) => {
     onAddNewElement?.({ type, datasetKey })
@@ -53,7 +61,7 @@ export const AddButton = () => {
         <DropdownMenuTrigger asChild>
           <F0Button
             icon={Add}
-            label={t("surveyFormBuilder.actions.addQuestion")}
+            label={addQuestionLabel}
             size="md"
             variant="outline"
             hideLabel

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Form/__tests__/index.test.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Form/__tests__/index.test.tsx
@@ -378,28 +378,38 @@ describe("SurveyFormBuilder — custom action labels", () => {
   })
 })
 
-describe("SurveyFormBuilder — hideAnswerPreview", () => {
-  it("shows the answer preview by default", () => {
+describe("SurveyFormBuilder — description & answer placeholders", () => {
+  it("overrides the question description placeholder", () => {
     render(
       <SurveyFormBuilder
-        elements={[makeQuestion("q1", "Q1")]}
+        elements={[makeQuestion("q1", "")]}
         onChange={vi.fn()}
+        placeholders={{ questionDescription: "Explain this field" }}
       />
     )
 
-    expect(screen.getByLabelText("Answer")).toBeInTheDocument()
+    expect(
+      screen.getByPlaceholderText("Explain this field")
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByPlaceholderText("Describe the question in a few words")
+    ).not.toBeInTheDocument()
   })
 
-  it("hides the answer preview when hideAnswerPreview is set", () => {
-    render(
+  it("overrides the answer preview placeholder while keeping the input", () => {
+    const { container } = render(
       <SurveyFormBuilder
-        elements={[makeQuestion("q1", "Q1")]}
+        elements={[makeQuestion("q1", "")]}
         onChange={vi.fn()}
-        hideAnswerPreview
+        placeholders={{ answer: "Custom answer hint" }}
       />
     )
 
-    expect(screen.queryByLabelText("Answer")).not.toBeInTheDocument()
+    // The answer preview input stays rendered…
+    expect(screen.getByLabelText("Answer")).toBeInTheDocument()
+    // …with the overridden placeholder text, not the i18n default.
+    expect(container.innerHTML).toContain("Custom answer hint")
+    expect(container.innerHTML).not.toContain("Type your answer")
   })
 })
 

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Form/__tests__/index.test.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Form/__tests__/index.test.tsx
@@ -363,6 +363,46 @@ describe("SurveyFormBuilder — custom placeholders", () => {
   })
 })
 
+describe("SurveyFormBuilder — custom action labels", () => {
+  it("overrides the add-question button label", () => {
+    render(
+      <SurveyFormBuilder
+        elements={[makeQuestion("q1", "Q1")]}
+        onChange={vi.fn()}
+        labels={{ addQuestion: "New field" }}
+      />
+    )
+
+    expect(screen.getAllByLabelText("New field").length).toBeGreaterThan(0)
+    expect(screen.queryByLabelText("Add question")).not.toBeInTheDocument()
+  })
+})
+
+describe("SurveyFormBuilder — hideAnswerPreview", () => {
+  it("shows the answer preview by default", () => {
+    render(
+      <SurveyFormBuilder
+        elements={[makeQuestion("q1", "Q1")]}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByLabelText("Answer")).toBeInTheDocument()
+  })
+
+  it("hides the answer preview when hideAnswerPreview is set", () => {
+    render(
+      <SurveyFormBuilder
+        elements={[makeQuestion("q1", "Q1")]}
+        onChange={vi.fn()}
+        hideAnswerPreview
+      />
+    )
+
+    expect(screen.queryByLabelText("Answer")).not.toBeInTheDocument()
+  })
+})
+
 // --- Dataset question tests ---
 
 const mockDataSource = {

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Form/__tests__/index.test.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Form/__tests__/index.test.tsx
@@ -304,6 +304,65 @@ describe("SurveyFormBuilder", () => {
   })
 })
 
+describe("SurveyFormBuilder — skipDefaultSection", () => {
+  it("auto-inserts a default section on mount when empty (default behaviour)", () => {
+    const onChange = vi.fn()
+
+    render(<SurveyFormBuilder elements={[]} onChange={onChange} />)
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.arrayContaining([expect.objectContaining({ type: "section" })])
+    )
+  })
+
+  it("does not auto-insert a section when skipDefaultSection is set", () => {
+    const onChange = vi.fn()
+
+    render(
+      <SurveyFormBuilder elements={[]} onChange={onChange} skipDefaultSection />
+    )
+
+    expect(onChange).not.toHaveBeenCalled()
+  })
+})
+
+describe("SurveyFormBuilder — custom placeholders", () => {
+  it("overrides the empty question title placeholder", () => {
+    render(
+      <SurveyFormBuilder
+        elements={[makeQuestion("q1", "")]}
+        onChange={vi.fn()}
+        placeholders={{ questionTitle: "Field name" }}
+      />
+    )
+
+    expect(screen.getByPlaceholderText("Field name")).toBeInTheDocument()
+  })
+
+  it("overrides the empty section title placeholder", () => {
+    render(
+      <SurveyFormBuilder
+        elements={[makeSection("s1", "", [{ id: "q1", title: "Q1" }])]}
+        onChange={vi.fn()}
+        placeholders={{ sectionTitle: "Group name" }}
+      />
+    )
+
+    expect(screen.getByPlaceholderText("Group name")).toBeInTheDocument()
+  })
+
+  it("falls back to the i18n default placeholder when not provided", () => {
+    render(
+      <SurveyFormBuilder
+        elements={[makeQuestion("q1", "")]}
+        onChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByPlaceholderText("Question title")).toBeInTheDocument()
+  })
+})
+
 // --- Dataset question tests ---
 
 const mockDataSource = {

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Form/index.stories.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Form/index.stories.tsx
@@ -494,15 +494,20 @@ export const WithLockedQuestions: Story = {
 
 /**
  * Consumers that model something other than a "survey" can relabel the empty-state
- * placeholders per instance (falling back to the i18n defaults when omitted) and
- * opt out of the auto-inserted default section to start from a blank form.
+ * placeholders and action labels per instance (falling back to the i18n defaults
+ * when omitted), opt out of the auto-inserted default section to start from a blank
+ * form, and hide the read-only answer preview when the builder defines fields.
  */
 export const BlankStartWithCustomPlaceholders: Story = {
   args: {
     skipDefaultSection: true,
+    hideAnswerPreview: true,
     placeholders: {
       questionTitle: "Field name",
       sectionTitle: "Group name",
+    },
+    labels: {
+      addQuestion: "New field",
     },
     elements: [
       {

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Form/index.stories.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Form/index.stories.tsx
@@ -493,18 +493,19 @@ export const WithLockedQuestions: Story = {
 }
 
 /**
- * Consumers that model something other than a "survey" can relabel the empty-state
- * placeholders and action labels per instance (falling back to the i18n defaults
- * when omitted), opt out of the auto-inserted default section to start from a blank
- * form, and hide the read-only answer preview when the builder defines fields.
+ * Consumers that model something other than a "survey" can relabel the placeholders
+ * and action labels per instance (falling back to the i18n defaults when omitted) and
+ * opt out of the auto-inserted default section to start from a blank form. Passing an
+ * empty string blanks a placeholder without removing its input.
  */
 export const BlankStartWithCustomPlaceholders: Story = {
   args: {
     skipDefaultSection: true,
-    hideAnswerPreview: true,
     placeholders: {
       questionTitle: "Field name",
       sectionTitle: "Group name",
+      questionDescription: "",
+      answer: "",
     },
     labels: {
       addQuestion: "New field",

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Form/index.stories.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Form/index.stories.tsx
@@ -491,3 +491,42 @@ export const WithLockedQuestions: Story = {
     ],
   },
 }
+
+/**
+ * Consumers that model something other than a "survey" can relabel the empty-state
+ * placeholders per instance (falling back to the i18n defaults when omitted) and
+ * opt out of the auto-inserted default section to start from a blank form.
+ */
+export const BlankStartWithCustomPlaceholders: Story = {
+  args: {
+    skipDefaultSection: true,
+    placeholders: {
+      questionTitle: "Field name",
+      sectionTitle: "Group name",
+    },
+    elements: [
+      {
+        type: "question",
+        question: {
+          id: "field-1",
+          title: "",
+          type: "text" as const,
+        },
+      },
+      {
+        type: "section",
+        section: {
+          id: "group-1",
+          title: "",
+          questions: [
+            {
+              id: "field-2",
+              title: "",
+              type: "text" as const,
+            },
+          ],
+        },
+      },
+    ],
+  },
+}

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Form/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Form/index.tsx
@@ -48,6 +48,8 @@ const _SurveyFormBuilder = ({
   applyingChanges,
   useUpload,
   datasets,
+  placeholders,
+  skipDefaultSection,
 }: SurveyFormBuilderProps) => {
   const shouldShowAddButton = !disabled
 
@@ -151,6 +153,8 @@ const _SurveyFormBuilder = ({
       allowedQuestionTypes={allowedQuestionTypes}
       useUpload={useUpload}
       datasets={datasets}
+      placeholders={placeholders}
+      skipDefaultSection={skipDefaultSection}
     >
       <DragProvider>
         <DragSelectGuard>

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Form/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Form/index.tsx
@@ -49,7 +49,9 @@ const _SurveyFormBuilder = ({
   useUpload,
   datasets,
   placeholders,
+  labels,
   skipDefaultSection,
+  hideAnswerPreview,
 }: SurveyFormBuilderProps) => {
   const shouldShowAddButton = !disabled
 
@@ -154,7 +156,9 @@ const _SurveyFormBuilder = ({
       useUpload={useUpload}
       datasets={datasets}
       placeholders={placeholders}
+      labels={labels}
       skipDefaultSection={skipDefaultSection}
+      hideAnswerPreview={hideAnswerPreview}
     >
       <DragProvider>
         <DragSelectGuard>

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Form/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Form/index.tsx
@@ -51,7 +51,6 @@ const _SurveyFormBuilder = ({
   placeholders,
   labels,
   skipDefaultSection,
-  hideAnswerPreview,
 }: SurveyFormBuilderProps) => {
   const shouldShowAddButton = !disabled
 
@@ -158,7 +157,6 @@ const _SurveyFormBuilder = ({
       placeholders={placeholders}
       labels={labels}
       skipDefaultSection={skipDefaultSection}
-      hideAnswerPreview={hideAnswerPreview}
     >
       <DragProvider>
         <DragSelectGuard>

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
@@ -54,7 +54,6 @@ export const BaseQuestion = ({
     isQuestionTypeAllowed,
     placeholders,
     labels,
-    hideAnswerPreview,
   } = useSurveyFormBuilderContext()
 
   const containingSection = getSectionContainingQuestion(id)
@@ -78,6 +77,10 @@ export const BaseQuestion = ({
 
   const addQuestionLabel =
     labels?.addQuestion ?? t("surveyFormBuilder.actions.addQuestion")
+
+  const descriptionPlaceholder =
+    placeholders?.questionDescription ??
+    t("surveyFormBuilder.labels.questionDescriptionPlaceholder")
 
   const handleChangeTitle = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     onQuestionChange?.({
@@ -285,9 +288,7 @@ export const BaseQuestion = ({
           <textarea
             value={description}
             aria-label={t("surveyFormBuilder.labels.description")}
-            placeholder={t(
-              "surveyFormBuilder.labels.questionDescriptionPlaceholder"
-            )}
+            placeholder={descriptionPlaceholder}
             onChange={handleChangeDescription}
             disabled={inputDisabled}
             className={cn(
@@ -298,7 +299,7 @@ export const BaseQuestion = ({
           />
         ) : null}
       </div>
-      {(answering || !hideAnswerPreview) && children}
+      {children}
       {answering && (
         <FormMessage
           className="-mt-2"

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
@@ -52,6 +52,7 @@ export const BaseQuestion = ({
     getIsSingleQuestionInSection,
     getSectionContainingQuestion,
     isQuestionTypeAllowed,
+    placeholders,
   } = useSurveyFormBuilderContext()
 
   const containingSection = getSectionContainingQuestion(id)
@@ -68,6 +69,10 @@ export const BaseQuestion = ({
 
   const { isDragging } = useDragContext()
   const { t } = useI18n()
+
+  const titlePlaceholder =
+    placeholders?.questionTitle ??
+    t("surveyFormBuilder.labels.titlePlaceholder")
 
   const handleChangeTitle = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     onQuestionChange?.({
@@ -171,7 +176,7 @@ export const BaseQuestion = ({
           <div className="relative w-full">
             {answering ? (
               <div className="w-full whitespace-pre-wrap break-words px-2 py-1 text-lg font-semibold text-f1-foreground">
-                {title || t("surveyFormBuilder.labels.titlePlaceholder")}
+                {title || titlePlaceholder}
                 {required && (
                   <span className="text-f1-foreground-critical"> *</span>
                 )}
@@ -182,7 +187,7 @@ export const BaseQuestion = ({
                   ref={titleRef}
                   value={title}
                   aria-label={t("surveyFormBuilder.labels.title")}
-                  placeholder={t("surveyFormBuilder.labels.titlePlaceholder")}
+                  placeholder={titlePlaceholder}
                   onChange={handleChangeTitle}
                   disabled={inputDisabled}
                   className={cn(
@@ -192,9 +197,7 @@ export const BaseQuestion = ({
                   style={TEXT_AREA_STYLE}
                 />
                 <div className="textarea-overlay pointer-events-none absolute left-0 top-0 h-full w-full whitespace-pre-wrap break-words px-2 py-1 text-lg font-semibold">
-                  <span className="opacity-0">
-                    {title || t("surveyFormBuilder.labels.titlePlaceholder")}
-                  </span>
+                  <span className="opacity-0">{title || titlePlaceholder}</span>
                   {required && (
                     <span
                       className={cn(

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/BaseQuestion/index.tsx
@@ -53,6 +53,8 @@ export const BaseQuestion = ({
     getSectionContainingQuestion,
     isQuestionTypeAllowed,
     placeholders,
+    labels,
+    hideAnswerPreview,
   } = useSurveyFormBuilderContext()
 
   const containingSection = getSectionContainingQuestion(id)
@@ -73,6 +75,9 @@ export const BaseQuestion = ({
   const titlePlaceholder =
     placeholders?.questionTitle ??
     t("surveyFormBuilder.labels.titlePlaceholder")
+
+  const addQuestionLabel =
+    labels?.addQuestion ?? t("surveyFormBuilder.actions.addQuestion")
 
   const handleChangeTitle = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     onQuestionChange?.({
@@ -293,7 +298,7 @@ export const BaseQuestion = ({
           />
         ) : null}
       </div>
-      {children}
+      {(answering || !hideAnswerPreview) && children}
       {answering && (
         <FormMessage
           className="-mt-2"
@@ -318,7 +323,7 @@ export const BaseQuestion = ({
             <DropdownMenuTrigger asChild>
               <F0Button
                 icon={Add}
-                label={t("surveyFormBuilder.actions.addQuestion")}
+                label={addQuestionLabel}
                 size="sm"
                 variant="outline"
                 hideLabel

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/TextQuestion/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/QuestionTypes/TextQuestion/index.tsx
@@ -27,13 +27,15 @@ export const TextQuestion = ({
   value,
   ...baseQuestionComponentProps
 }: TextQuestionProps) => {
-  const { onQuestionChange, answering } = useSurveyFormBuilderContext()
+  const { onQuestionChange, answering, placeholders } =
+    useSurveyFormBuilderContext()
 
   const disabled = useQuestionDisabled(baseQuestionComponentProps)
 
   const { t } = useI18n()
 
-  const placeholder = t("surveyFormBuilder.answer.textPlaceholder")
+  const placeholder =
+    placeholders?.answer ?? t("surveyFormBuilder.answer.textPlaceholder")
 
   const field: F0Field = useMemo(
     () =>

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/Section/index.tsx
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/Section/index.tsx
@@ -34,10 +34,15 @@ export const Section = ({
     answering,
     deleteElement,
     onDuplicateElement,
+    placeholders,
   } = useSurveyFormBuilderContext()
 
   const [actionsDropdownOpen, setActionsDropdownOpen] = useState(false)
   const { t } = useI18n()
+
+  const sectionTitlePlaceholder =
+    placeholders?.sectionTitle ??
+    t("surveyFormBuilder.labels.sectionTitlePlaceholder")
 
   const baseOnChangeParams: OnChangeSectionParams = useMemo(
     () => ({
@@ -138,9 +143,7 @@ export const Section = ({
                   type="text"
                   aria-label={t("surveyFormBuilder.labels.title")}
                   value={title}
-                  placeholder={t(
-                    "surveyFormBuilder.labels.sectionTitlePlaceholder"
-                  )}
+                  placeholder={sectionTitlePlaceholder}
                   onChange={handleChangeTitle}
                   disabled={inputDisabled}
                   className={cn(

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/types.ts
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/types.ts
@@ -226,6 +226,11 @@ export type SurveyFormBuilderPlaceholders = {
   sectionTitle?: string
 }
 
+export type SurveyFormBuilderLabels = {
+  /** Overrides the label/tooltip of the "add" buttons (default: "Add question"). */
+  addQuestion?: string
+}
+
 export type SurveyFormBuilderProps = {
   elements: SurveyFormBuilderElement[]
   onChange: (elements: SurveyFormBuilderElement[]) => void
@@ -237,10 +242,18 @@ export type SurveyFormBuilderProps = {
   datasets?: SurveyDatasets
   /** Per-instance overrides for the builder's title placeholders. Falls back to i18n defaults. */
   placeholders?: SurveyFormBuilderPlaceholders
+  /** Per-instance overrides for the builder's action labels. Falls back to i18n defaults. */
+  labels?: SurveyFormBuilderLabels
   /**
    * When true, an empty builder does NOT auto-insert a default section on mount,
    * letting the consumer start from a blank form. Defaults to the legacy behaviour
    * (a section is created).
    */
   skipDefaultSection?: boolean
+  /**
+   * When true, the read-only answer-widget preview rendered under each question in
+   * edit mode is hidden. Useful when the builder defines fields rather than a form
+   * to be answered. Does not affect answering mode. Defaults to showing the preview.
+   */
+  hideAnswerPreview?: boolean
 }

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/types.ts
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/types.ts
@@ -224,6 +224,10 @@ export type SurveyFormBuilderPlaceholders = {
   questionTitle?: string
   /** Overrides the default "Section title" placeholder shown on empty sections. */
   sectionTitle?: string
+  /** Overrides the default question description placeholder (pass "" to hide the hint). */
+  questionDescription?: string
+  /** Overrides the default text-answer preview placeholder (pass "" to hide the hint). */
+  answer?: string
 }
 
 export type SurveyFormBuilderLabels = {
@@ -250,10 +254,4 @@ export type SurveyFormBuilderProps = {
    * (a section is created).
    */
   skipDefaultSection?: boolean
-  /**
-   * When true, the read-only answer-widget preview rendered under each question in
-   * edit mode is hidden. Useful when the builder defines fields rather than a form
-   * to be answered. Does not affect answering mode. Defaults to showing the preview.
-   */
-  hideAnswerPreview?: boolean
 }

--- a/packages/react/src/kits/surveys/SurveyFormBuilder/types.ts
+++ b/packages/react/src/kits/surveys/SurveyFormBuilder/types.ts
@@ -219,6 +219,13 @@ export type SurveyFormBuilderCallbacks = {
   onDuplicateElement?: (params: OnDuplicateElementParams) => void
 }
 
+export type SurveyFormBuilderPlaceholders = {
+  /** Overrides the default "Question title" placeholder shown on empty questions. */
+  questionTitle?: string
+  /** Overrides the default "Section title" placeholder shown on empty sections. */
+  sectionTitle?: string
+}
+
 export type SurveyFormBuilderProps = {
   elements: SurveyFormBuilderElement[]
   onChange: (elements: SurveyFormBuilderElement[]) => void
@@ -228,4 +235,12 @@ export type SurveyFormBuilderProps = {
   applyingChanges?: boolean
   useUpload?: UseFileUpload
   datasets?: SurveyDatasets
+  /** Per-instance overrides for the builder's title placeholders. Falls back to i18n defaults. */
+  placeholders?: SurveyFormBuilderPlaceholders
+  /**
+   * When true, an empty builder does NOT auto-insert a default section on mount,
+   * letting the consumer start from a blank form. Defaults to the legacy behaviour
+   * (a section is created).
+   */
+  skipDefaultSection?: boolean
 }


### PR DESCRIPTION
## What

Two additive, per-instance customization props on `SurveyFormBuilder`:

- **`placeholders`** — override the empty-state title placeholders (`questionTitle`, `sectionTitle`). Falls back to the i18n defaults when omitted, so nothing changes for current consumers.
- **`skipDefaultSection`** — opt out of the section that is auto-inserted on mount when the builder is empty, letting a consumer start from a truly blank form. Defaults to the legacy behaviour (a section is created).

## Why

The builder is reused outside classic "surveys" (e.g. custom field builders that model *fields* and *groups*, not *questions* and *sections*). Today those consumers can't relabel the placeholders per-instance (only globally via the i18n provider) and always get a forced default section they don't want. These props make both configurable without affecting existing usage.

## How

- New `SurveyFormBuilderPlaceholders` type + `placeholders` / `skipDefaultSection` props on `SurveyFormBuilderProps`.
- Threaded through `Form` → `SurveyFormBuilderProvider` (Context). `placeholders` is exposed on the context and consumed in `BaseQuestion` / `Section` as `placeholders?.x ?? t(...)`. `skipDefaultSection` gates the empty-mount auto-section effect.

## Tests / stories

- 5 new unit tests: default auto-section vs. `skipDefaultSection`; both placeholder overrides; i18n fallback. Full file 25/25 green.
- New story `BlankStartWithCustomPlaceholders` demonstrating both.
- `build:types`, oxlint, oxfmt all clean.

### Testing

New form empty:

<img width="915" height="309" alt="image" src="https://github.com/user-attachments/assets/f27ed11d-4009-4af7-bcb6-c1586b34474d" />

<img width="911" height="407" alt="image" src="https://github.com/user-attachments/assets/196f38ec-3561-42d7-a33d-3c9cacb4a277" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
