### PR TITLE
fix(F0ClarifyingPanel): mark the custom answer row as selected on activation

### DIFF
--- a/packages/react/src/kits/ai/F0ClarifyingPanel/__tests__/F0ClarifyingPanel.test.tsx
+++ b/packages/react/src/kits/ai/F0ClarifyingPanel/__tests__/F0ClarifyingPanel.test.tsx
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from "vitest"
 import "@testing-library/jest-dom/vitest"
-
 import { zeroRender as render, screen, userEvent } from "@/testing/test-utils"
 
 import type { ClarifyingQuestionState } from "../types"
+
 import { F0ClarifyingPanel } from "../F0ClarifyingPanel"
 
 function buildState(
@@ -243,6 +243,47 @@ describe("F0ClarifyingPanel", () => {
       await Promise.resolve()
       expect(state.toggleOption).not.toHaveBeenCalled()
       expect(state.confirm).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("custom answer selection indicator", () => {
+    // The RadioIndicator is presentational (the textarea is the focusable
+    // control), so the selected state is asserted through its filled inner
+    // dot, which only renders when marked.
+    const getIndicator = () =>
+      screen.getByRole("textbox").previousElementSibling as HTMLElement
+
+    it("marks the custom answer row as soon as it is active, before any text", () => {
+      const state = buildState(
+        {},
+        { allowCustomAnswer: true, isCustomAnswerActive: true }
+      )
+      render(<F0ClarifyingPanel clarifyingQuestion={state} />)
+      expect(getIndicator().firstElementChild).not.toBeNull()
+    })
+
+    it("does not mark the custom answer row while a predefined option is selected", () => {
+      const state = buildState(
+        {},
+        {
+          allowCustomAnswer: true,
+          isCustomAnswerActive: true,
+          customAnswerText: "my answer",
+          selectedOptionIds: ["this-month"],
+        }
+      )
+      render(<F0ClarifyingPanel clarifyingQuestion={state} />)
+      expect(getIndicator().firstElementChild).toBeNull()
+    })
+
+    it("activates the custom answer when clicking the row, not just the textarea", async () => {
+      const state = buildState({}, { allowCustomAnswer: true })
+      render(<F0ClarifyingPanel clarifyingQuestion={state} />)
+      // Click lands on the radio indicator — outside the textarea — and must
+      // still focus the input and activate the custom answer.
+      await userEvent.click(getIndicator())
+      expect(state.activateCustomAnswer).toHaveBeenCalled()
+      expect(screen.getByRole("textbox")).toHaveFocus()
     })
   })
 

--- a/packages/react/src/kits/ai/F0ClarifyingPanel/components/CustomAnswerRow.tsx
+++ b/packages/react/src/kits/ai/F0ClarifyingPanel/components/CustomAnswerRow.tsx
@@ -61,9 +61,16 @@ export const CustomAnswerRow = ({
       textarea.scrollHeight > MAX_TEXTAREA_HEIGHT ? "auto" : "hidden"
   }, [customAnswerText])
 
+  // The row behaves like one more option: activating it (click or focus)
+  // marks the radio right away — not only once text has been typed — and a
+  // predefined selection always wins, so hosts that don't reset
+  // `isCustomAnswerActive` on option toggle can't show two marked radios.
+  const isMarkedSelected =
+    (isCustomAnswerActive || hasCustomText) && !hasSelection
+
   const indicator =
     mode === "single" ? (
-      <RadioIndicator isSelected={hasCustomText && !hasSelection} />
+      <RadioIndicator isSelected={isMarkedSelected} />
     ) : (
       <F0Checkbox
         checked={isCustomAnswerActive}
@@ -76,9 +83,13 @@ export const CustomAnswerRow = ({
   return (
     <div
       className={cn(
-        "flex items-start gap-2 rounded-md px-2 py-2",
+        "flex cursor-text items-start gap-2 rounded-md px-2 py-2",
         "transition-colors hover:bg-f1-background-hover"
       )}
+      // Clicking anywhere in the row (radio indicator, padding) activates the
+      // custom answer, mirroring how OptionRow selects on row click. Focusing
+      // the textarea fires `onActivate` via its own onFocus.
+      onClick={() => textareaRef.current?.focus()}
     >
       {indicator}
       <textarea


### PR DESCRIPTION
## What & why

In single-select mode, the free-text "Type your answer..." row of `F0ClarifyingPanel` never looked selected when the user clicked into it — its radio indicator only filled once text had been typed (`hasCustomText && !hasSelection`). Users read the row as a non-option: you could write in it, but it never appeared chosen (reported from the Shift Management business-rules co-creation flow in factorial).

## Changes

- Mark the custom answer radio as soon as the row is active (click or focus), not only after text exists: `(isCustomAnswerActive || hasCustomText) && !hasSelection`. A predefined option selection always wins, so hosts that don't reset `isCustomAnswerActive` can never show two marked radios.
- Make the whole row clickable (radio indicator and padding focus the textarea), mirroring how `OptionRow` selects on row click.

## Testing

- New unit tests: marked when active before any text; unmarked while a predefined option is selected; row click activates + focuses.
- `pnpm vitest run src/kits/ai/F0ClarifyingPanel` — 29/29 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)