### PR TITLE
feat(filters): add filter tag picker

### DIFF
--- a/packages/react/src/experimental/Forms/F0FilterTagPicker/F0FilterTagPicker.tsx
+++ b/packages/react/src/experimental/Forms/F0FilterTagPicker/F0FilterTagPicker.tsx
@@ -1,0 +1,1373 @@
+"use client"
+
+import type { Editor } from "@tiptap/react"
+
+import Placeholder from "@tiptap/extension-placeholder"
+import { Fragment, Slice, type Schema } from "@tiptap/pm/model"
+import { EditorContent, useEditor } from "@tiptap/react"
+import StarterKit from "@tiptap/starter-kit"
+import {
+  type ReactElement,
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
+
+import type { NewColor } from "@/components/tags/F0TagDot/types"
+
+import { DataTestIdWrapper } from "@/lib/data-testid"
+import { OneEllipsis } from "@/lib/OneEllipsis"
+import { useI18n } from "@/lib/providers/i18n"
+import { cn, focusRing } from "@/lib/utils"
+import { Popover, PopoverAnchor, PopoverContent } from "@/ui/popover"
+import { Skeleton } from "@/ui/skeleton"
+
+import type {
+  ActiveTextRange,
+  FilterTagNodeAttributes,
+  FilterTagOptionsState,
+  ResolvedFilterTagOption,
+} from "./internal-types"
+import type {
+  F0FilterTagPickerFiltersDefinition,
+  F0FilterTagPickerOptionValue,
+  F0FilterTagPickerProps,
+  F0FilterTagPickerValue,
+} from "./types"
+
+import { getCategoryDotStyle, getDefaultCategoryColors } from "./colorStyles"
+import {
+  CategoryFilterSelect,
+  decodeCategoryFilterSelection,
+  encodeCategoryFilterSelection,
+} from "./components/CategoryFilterSelect"
+import {
+  FilterOptionsLoader,
+  flattenOptions,
+} from "./components/FilterOptionsLoader"
+import { FilterTagNode } from "./components/FilterTagNode"
+import {
+  areFilterTagPickerValuesEqual,
+  editorDocumentToFilterTagPickerValue,
+  filterTagPickerValueToEditorContent,
+  normalizeFilterTagPickerValue,
+  normalizeFilterTagPickerValueForMode,
+} from "./value"
+
+const REMOTE_SEARCH_MIN_LENGTH = 2
+const REMOTE_SEARCH_DEBOUNCE_MS = 250
+const LEAF_PLACEHOLDER = "\ufffc"
+const ACTIVE_WORD_PATTERN = /[\p{L}\p{N}_'’-]+$/u
+const WORD_PATTERN = /[\p{L}\p{N}_'’-]+/gu
+
+function normalizeSearchText(value: string) {
+  return value
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLocaleLowerCase()
+}
+
+function optionIdentity(
+  filterKey: string,
+  value: F0FilterTagPickerOptionValue
+) {
+  return `${filterKey}:${typeof value}:${String(value)}`
+}
+
+function hasSource(definition: F0FilterTagPickerFiltersDefinition[string]) {
+  return "source" in definition.options
+}
+
+function getActiveTextRange(editor: Editor): ActiveTextRange | null {
+  const { selection } = editor.state
+  if (!selection.empty || !selection.$from.parent.isTextblock) return null
+
+  const textBefore = selection.$from.parent.textBetween(
+    0,
+    selection.$from.parentOffset,
+    "\n",
+    LEAF_PLACEHOLDER
+  )
+  const match = textBefore.match(ACTIVE_WORD_PATTERN)
+  if (!match?.[0]) return null
+
+  return {
+    from: selection.from - match[0].length,
+    query: match[0],
+    to: selection.from,
+  }
+}
+
+function getReplacementFrom(
+  editor: Editor,
+  activeRange: ActiveTextRange,
+  optionLabel: string
+) {
+  const { selection } = editor.state
+  const textBefore = selection.$from.parent.textBetween(
+    0,
+    selection.$from.parentOffset,
+    "\n",
+    LEAF_PLACEHOLDER
+  )
+  const words = Array.from(textBefore.matchAll(WORD_PATTERN))
+  const normalizedLabel = normalizeSearchText(optionLabel)
+
+  for (const word of words) {
+    const start = word.index
+    if (start === undefined) continue
+
+    const candidate = normalizeSearchText(textBefore.slice(start).trim())
+    if (
+      normalizedLabel === candidate ||
+      normalizedLabel.startsWith(candidate) ||
+      normalizedLabel.includes(candidate)
+    ) {
+      return selection.from - (textBefore.length - start)
+    }
+  }
+
+  return activeRange.from
+}
+
+function getCaretRect(editor: Editor | null): DOMRect | null {
+  if (!editor) return null
+
+  try {
+    const coordinates = editor.view.coordsAtPos(editor.state.selection.from)
+    return DOMRect.fromRect({
+      x: coordinates.left,
+      y: coordinates.top,
+      width: Math.max(1, coordinates.right - coordinates.left),
+      height: Math.max(1, coordinates.bottom - coordinates.top),
+    })
+  } catch {
+    return editor.view.dom.getBoundingClientRect()
+  }
+}
+
+function createPlainTextSlice(schema: Schema, text: string) {
+  const content = text.split("\n").flatMap((line, index, lines) => {
+    const nodes = line ? [schema.text(line)] : []
+    if (index < lines.length - 1) {
+      nodes.push(schema.nodes.hardBreak.create())
+    }
+    return nodes
+  })
+
+  return new Slice(Fragment.fromArray(content), 0, 0)
+}
+
+function optionScore(option: ResolvedFilterTagOption, query: string) {
+  const label = normalizeSearchText(option.displayLabel)
+  const category = normalizeSearchText(option.categoryLabel)
+
+  if (label === query) return 0
+  if (label.startsWith(query)) return 1
+  if (label.includes(query)) return 2
+  if (category === query) return 3
+  if (category.startsWith(query)) return 4
+  if (category.includes(query)) return 5
+  return null
+}
+
+type PopupRow =
+  | { kind: "option"; option: ResolvedFilterTagOption }
+  | { categoryLabel: string; filterKey: string; kind: "retry" }
+  | {
+      categoryLabel: string
+      filterKey: string
+      kind: "loadMore"
+      loadMore: () => void
+    }
+
+function _F0FilterTagPicker<
+  Filters extends F0FilterTagPickerFiltersDefinition,
+>({
+  filters,
+  value,
+  onChange,
+  label,
+  mode = "mixed",
+  placeholder,
+  categoryColors,
+  disabled = false,
+  dataTestId,
+}: F0FilterTagPickerProps<Filters>) {
+  const i18n = useI18n()
+  const editorId = useId()
+  const labelId = useId()
+  const listboxId = useId()
+  const keyboardHintId = useId()
+  const [activeTextRange, setActiveTextRange] =
+    useState<ActiveTextRange | null>(null)
+  const [activeRowIndex, setActiveRowIndex] = useState(0)
+  const [announcement, setAnnouncement] = useState("")
+  const [dismissedSignature, setDismissedSignature] = useState<string | null>(
+    null
+  )
+  const [editorFocused, setEditorFocused] = useState(false)
+  const [optionStates, setOptionStates] = useState<
+    Record<string, FilterTagOptionsState>
+  >({})
+  const [loaderRevisions, setLoaderRevisions] = useState<
+    Record<string, number>
+  >({})
+  const [remoteSearch, setRemoteSearch] = useState("")
+  const [selectedLabelOverrides, setSelectedLabelOverrides] = useState<
+    Record<string, string>
+  >({})
+  const [categorySelectValues, setCategorySelectValues] = useState<
+    Record<string, string[]>
+  >({})
+  const [openCategorySelectKeys, setOpenCategorySelectKeys] = useState<
+    string[]
+  >([])
+  const caretRectRef = useRef<DOMRect | null>(null)
+  const categorySelectValuesRef = useRef<Record<string, string[]>>({})
+  const isComposingRef = useRef(false)
+  const isApplyingEditorChangeRef = useRef(false)
+  const editorInstanceRef = useRef<Editor | null>(null)
+  const valueRef = useRef(normalizeFilterTagPickerValueForMode(value, mode))
+  const onChangeRef = useRef(onChange)
+  const handleEditorActivityRef = useRef<(editor: Editor) => void>(() => {})
+  const handleEditorUpdateRef = useRef<(editor: Editor) => void>(() => {})
+  const handleEditorBlurRef = useRef<() => void>(() => {})
+  const handleEditorKeyDownRef = useRef<(event: KeyboardEvent) => boolean>(
+    () => false
+  )
+
+  const filterEntries = useMemo(
+    () => Object.entries(filters) as [string, Filters[keyof Filters]][],
+    [filters]
+  )
+  const filterOrder = useMemo(
+    () =>
+      new Map(filterEntries.map(([filterKey], index) => [filterKey, index])),
+    [filterEntries]
+  )
+  const validFilterKeys = useMemo(
+    () => new Set(filterEntries.map(([filterKey]) => filterKey)),
+    [filterEntries]
+  )
+  const defaultCategoryColors = useMemo(
+    () =>
+      getDefaultCategoryColors(filterEntries.map(([filterKey]) => filterKey)),
+    [filterEntries]
+  )
+  const getCategoryColor = useCallback(
+    (filterKey: string): NewColor =>
+      categoryColors?.[filterKey as keyof Filters] ??
+      defaultCategoryColors.get(filterKey)!,
+    [categoryColors, defaultCategoryColors]
+  )
+
+  const handleOptionsStateChange = useCallback(
+    (filterKey: string, state: FilterTagOptionsState) => {
+      setOptionStates((current) => ({ ...current, [filterKey]: state }))
+    },
+    []
+  )
+
+  const optionLabels = useMemo(() => {
+    const labels = new Map<string, ResolvedFilterTagOption>()
+
+    for (const [filterKey, definition] of filterEntries) {
+      if (
+        "options" in definition.options &&
+        Array.isArray(definition.options.options)
+      ) {
+        const resolvedOptions = flattenOptions(definition.options.options, {
+          categoryKey: filterKey,
+          categoryLabel: definition.label,
+          filterKey,
+          ancestors: [],
+        })
+
+        for (const option of resolvedOptions) {
+          labels.set(optionIdentity(option.filterKey, option.value), option)
+        }
+      }
+    }
+
+    for (const state of Object.values(optionStates)) {
+      for (const option of state.options) {
+        labels.set(optionIdentity(option.filterKey, option.value), option)
+      }
+    }
+
+    return labels
+  }, [filterEntries, optionStates])
+
+  const staticCategorySelectOptions = useMemo(() => {
+    return Object.fromEntries(
+      filterEntries.map(([filterKey, definition]) => {
+        if (
+          "options" in definition.options &&
+          Array.isArray(definition.options.options)
+        ) {
+          return [
+            filterKey,
+            flattenOptions(definition.options.options, {
+              categoryKey: filterKey,
+              categoryLabel: definition.label,
+              filterKey,
+              ancestors: [],
+            }),
+          ]
+        }
+
+        return [filterKey, null]
+      })
+    ) as Record<string, ResolvedFilterTagOption[] | null>
+  }, [filterEntries])
+
+  const categorySelectOptions = useMemo(
+    () =>
+      Object.fromEntries(
+        filterEntries.map(([filterKey]) => [
+          filterKey,
+          staticCategorySelectOptions[filterKey] ??
+            optionStates[filterKey]?.options ??
+            [],
+        ])
+      ) as Record<string, ResolvedFilterTagOption[]>,
+    [filterEntries, optionStates, staticCategorySelectOptions]
+  )
+
+  const getTagAttributes = useCallback(
+    (
+      filterKey: string,
+      optionValue: F0FilterTagPickerOptionValue
+    ): FilterTagNodeAttributes => {
+      const identity = optionIdentity(filterKey, optionValue)
+      const resolved = optionLabels.get(identity)
+      const categoryKey = resolved?.categoryKey ?? filterKey
+      const definition = filters[categoryKey] ?? filters[filterKey]
+
+      return {
+        filterKey,
+        value: optionValue,
+        categoryKey,
+        categoryLabel:
+          resolved?.categoryLabel ?? definition?.label ?? filterKey,
+        color: getCategoryColor(categoryKey),
+        label:
+          resolved?.displayLabel ??
+          selectedLabelOverrides[identity] ??
+          String(optionValue),
+      }
+    },
+    [filters, getCategoryColor, optionLabels, selectedLabelOverrides]
+  )
+
+  const selectedCategoryValues = useMemo(() => {
+    const selections: Record<string, string[]> = {}
+
+    for (const token of value) {
+      if (token.type !== "filter") continue
+
+      const resolved = optionLabels.get(
+        optionIdentity(token.filterKey, token.value)
+      )
+      const categoryKey = resolved?.categoryKey ?? token.filterKey
+      if (!filters[categoryKey]) continue
+
+      const encoded = encodeCategoryFilterSelection({
+        filterKey: token.filterKey,
+        value: token.value,
+      })
+      selections[categoryKey] = [...(selections[categoryKey] ?? []), encoded]
+    }
+
+    return selections
+  }, [filters, optionLabels, value])
+
+  useEffect(() => {
+    setCategorySelectValues((current) => {
+      const next: Record<string, string[]> = {}
+      for (const [filterKey] of filterEntries) {
+        next[filterKey] = selectedCategoryValues[filterKey] ?? []
+      }
+      if (JSON.stringify(current) === JSON.stringify(next)) return current
+
+      categorySelectValuesRef.current = next
+      return next
+    })
+  }, [filterEntries, selectedCategoryValues])
+
+  const commitCategorySelection = useCallback(
+    (categoryKey: string) => {
+      const decodedSelections = (
+        categorySelectValuesRef.current[categoryKey] ??
+        selectedCategoryValues[categoryKey] ??
+        []
+      )
+        .map(decodeCategoryFilterSelection)
+        .filter(
+          (selection): selection is NonNullable<typeof selection> =>
+            selection !== null && validFilterKeys.has(selection.filterKey)
+        )
+      const selectedIdentities = new Set(
+        decodedSelections.map((selection) =>
+          optionIdentity(selection.filterKey, selection.value)
+        )
+      )
+      const nextValue = valueRef.current.filter((token) => {
+        if (token.type !== "filter") return true
+
+        const identity = optionIdentity(token.filterKey, token.value)
+        const resolved = optionLabels.get(identity)
+        const tokenCategoryKey = resolved?.categoryKey ?? token.filterKey
+        return (
+          tokenCategoryKey !== categoryKey || selectedIdentities.has(identity)
+        )
+      })
+      const existingIdentities = new Set(
+        nextValue.flatMap((token) =>
+          token.type === "filter"
+            ? [optionIdentity(token.filterKey, token.value)]
+            : []
+        )
+      )
+
+      for (const selection of decodedSelections) {
+        const identity = optionIdentity(selection.filterKey, selection.value)
+        if (existingIdentities.has(identity)) continue
+
+        nextValue.push({
+          type: "filter",
+          filterKey: selection.filterKey,
+          value: selection.value,
+        } as F0FilterTagPickerValue<Filters>[number])
+        existingIdentities.add(identity)
+      }
+
+      const normalizedValue = normalizeFilterTagPickerValueForMode(
+        normalizeFilterTagPickerValue(nextValue),
+        mode
+      )
+      if (areFilterTagPickerValuesEqual(valueRef.current, normalizedValue)) {
+        return
+      }
+
+      valueRef.current = normalizedValue
+      onChangeRef.current(normalizedValue)
+    },
+    [mode, optionLabels, selectedCategoryValues, validFilterKeys]
+  )
+
+  const handleCategorySelectOpenChange = useCallback(
+    (filterKey: string, open: boolean) => {
+      if (open) {
+        setOpenCategorySelectKeys((current) =>
+          current.includes(filterKey) ? current : [...current, filterKey]
+        )
+        const currentSelection = selectedCategoryValues[filterKey] ?? []
+        categorySelectValuesRef.current = {
+          ...categorySelectValuesRef.current,
+          [filterKey]: currentSelection,
+        }
+        setCategorySelectValues((current) => ({
+          ...current,
+          [filterKey]: currentSelection,
+        }))
+        return
+      }
+
+      setOpenCategorySelectKeys((current) =>
+        current.filter((key) => key !== filterKey)
+      )
+      commitCategorySelection(filterKey)
+    },
+    [commitCategorySelection, selectedCategoryValues]
+  )
+
+  const extensions = useMemo(
+    () => [
+      StarterKit.configure({
+        blockquote: false,
+        bold: false,
+        bulletList: false,
+        code: false,
+        codeBlock: false,
+        dropcursor: false,
+        gapcursor: false,
+        heading: false,
+        history: false,
+        horizontalRule: false,
+        italic: false,
+        listItem: false,
+        orderedList: false,
+        strike: false,
+      }),
+      Placeholder.configure({
+        placeholder:
+          placeholder ??
+          (mode === "tags"
+            ? i18n.filters.tagPicker.tagsPlaceholder
+            : i18n.filters.tagPicker.searchPlaceholder),
+      }),
+      FilterTagNode,
+    ],
+    [
+      i18n.filters.tagPicker.searchPlaceholder,
+      i18n.filters.tagPicker.tagsPlaceholder,
+      mode,
+      placeholder,
+    ]
+  )
+
+  const editor = useEditor(
+    {
+      extensions,
+      content: filterTagPickerValueToEditorContent(
+        normalizeFilterTagPickerValueForMode(value, mode),
+        getTagAttributes
+      ),
+      editable: !disabled,
+      immediatelyRender: false,
+      shouldRerenderOnTransaction: false,
+      editorProps: {
+        attributes: {
+          id: editorId,
+          role: "combobox",
+          "aria-autocomplete": "list",
+          "aria-expanded": "false",
+          "aria-labelledby": labelId,
+          "aria-disabled": String(Boolean(disabled)),
+        },
+        handleDOMEvents: {
+          compositionstart: () => {
+            isComposingRef.current = true
+            return false
+          },
+          compositionend: () => {
+            isComposingRef.current = false
+            queueMicrotask(() => {
+              const currentEditor = editorInstanceRef.current
+              if (currentEditor) handleEditorActivityRef.current(currentEditor)
+            })
+            return false
+          },
+        },
+        handleKeyDown: (_view, event) => handleEditorKeyDownRef.current(event),
+        handlePaste: (view, event) => {
+          const text = event.clipboardData?.getData("text/plain")
+          if (text === undefined) return false
+
+          event.preventDefault()
+          const plainText =
+            mode === "tags" ? text.replace(/\r?\n|\r/gu, " ") : text
+          view.dispatch(
+            view.state.tr
+              .replaceSelection(
+                createPlainTextSlice(view.state.schema, plainText)
+              )
+              .scrollIntoView()
+          )
+          return true
+        },
+      },
+      onCreate: ({ editor: currentEditor }) => {
+        editorInstanceRef.current = currentEditor
+        handleEditorActivityRef.current(currentEditor)
+      },
+      onDestroy: () => {
+        editorInstanceRef.current = null
+      },
+      onFocus: ({ editor: currentEditor }) => {
+        setEditorFocused(true)
+        handleEditorActivityRef.current(currentEditor)
+      },
+      onBlur: () => handleEditorBlurRef.current(),
+      onSelectionUpdate: ({ editor: currentEditor }) => {
+        handleEditorActivityRef.current(currentEditor)
+      },
+      onUpdate: ({ editor: currentEditor }) => {
+        handleEditorUpdateRef.current(currentEditor)
+        handleEditorActivityRef.current(currentEditor)
+      },
+    },
+    [extensions, mode]
+  )
+
+  onChangeRef.current = onChange
+
+  handleEditorActivityRef.current = (currentEditor) => {
+    if (isComposingRef.current) return
+    setActiveTextRange(getActiveTextRange(currentEditor))
+    caretRectRef.current = getCaretRect(currentEditor)
+  }
+
+  handleEditorBlurRef.current = () => {
+    setEditorFocused(false)
+    setActiveTextRange(null)
+
+    if (mode === "tags" && editor) {
+      const editorValue = editorDocumentToFilterTagPickerValue<Filters>(
+        editor.state.doc,
+        validFilterKeys
+      )
+      if (editorValue.some((token) => token.type === "text")) {
+        const tagsOnlyValue = normalizeFilterTagPickerValueForMode(
+          editorValue,
+          mode
+        )
+        isApplyingEditorChangeRef.current = true
+        editor.commands.setContent(
+          filterTagPickerValueToEditorContent(tagsOnlyValue, getTagAttributes),
+          false
+        )
+        isApplyingEditorChangeRef.current = false
+        valueRef.current = tagsOnlyValue
+      }
+    }
+  }
+
+  handleEditorUpdateRef.current = (currentEditor) => {
+    if (isApplyingEditorChangeRef.current) return
+
+    const nextValue = normalizeFilterTagPickerValueForMode(
+      editorDocumentToFilterTagPickerValue<Filters>(
+        currentEditor.state.doc,
+        validFilterKeys
+      ),
+      mode
+    )
+    if (areFilterTagPickerValuesEqual(valueRef.current, nextValue)) return
+
+    const nextFilterIdentities = new Set(
+      nextValue.flatMap((token) =>
+        token.type === "filter"
+          ? [optionIdentity(token.filterKey, token.value)]
+          : []
+      )
+    )
+    const removedToken = valueRef.current.find(
+      (token) =>
+        token.type === "filter" &&
+        !nextFilterIdentities.has(optionIdentity(token.filterKey, token.value))
+    )
+    if (removedToken?.type === "filter") {
+      const metadata = getTagAttributes(
+        removedToken.filterKey,
+        removedToken.value
+      )
+      setAnnouncement(
+        i18n.t("filters.tagPicker.removed", {
+          value: metadata.label,
+          category: metadata.categoryLabel,
+        })
+      )
+    }
+
+    valueRef.current = nextValue
+    onChangeRef.current(nextValue)
+  }
+
+  useEffect(() => {
+    if (!editor) return
+
+    const normalizedValue = normalizeFilterTagPickerValueForMode(value, mode)
+    valueRef.current = normalizedValue
+    const editorValue = normalizeFilterTagPickerValueForMode(
+      editorDocumentToFilterTagPickerValue<Filters>(
+        editor.state.doc,
+        validFilterKeys
+      ),
+      mode
+    )
+    if (areFilterTagPickerValuesEqual(editorValue, normalizedValue)) return
+
+    const previousSelection = editor.state.selection.from
+    isApplyingEditorChangeRef.current = true
+    editor.commands.setContent(
+      filterTagPickerValueToEditorContent(normalizedValue, getTagAttributes),
+      false
+    )
+    const documentEnd = editor.state.doc.content.size
+    editor.commands.setTextSelection(Math.min(previousSelection, documentEnd))
+    isApplyingEditorChangeRef.current = false
+    handleEditorActivityRef.current(editor)
+  }, [editor, getTagAttributes, mode, validFilterKeys, value])
+
+  useEffect(() => {
+    editor?.setEditable(!disabled)
+  }, [disabled, editor])
+
+  useEffect(() => {
+    if (!editor) return
+
+    const editorElement = editor.view.dom
+    editorElement.setAttribute("aria-describedby", keyboardHintId)
+    editorElement.setAttribute("aria-labelledby", labelId)
+    editorElement.setAttribute("aria-disabled", String(Boolean(disabled)))
+  }, [disabled, editor, keyboardHintId, labelId])
+
+  useEffect(() => {
+    if (!editor) return
+
+    const transaction = editor.state.tr
+    let changed = false
+
+    editor.state.doc.descendants((node, position) => {
+      if (node.type.name !== "filterTag") return true
+
+      const current = node.attrs as FilterTagNodeAttributes
+      const next = getTagAttributes(current.filterKey, current.value)
+      if (JSON.stringify(current) !== JSON.stringify(next)) {
+        transaction.setNodeMarkup(position, undefined, next)
+        changed = true
+      }
+      return false
+    })
+
+    if (changed) {
+      isApplyingEditorChangeRef.current = true
+      editor.view.dispatch(transaction)
+      isApplyingEditorChangeRef.current = false
+    }
+  }, [editor, getTagAttributes])
+
+  useEffect(() => {
+    let cancelled = false
+
+    const resolveSelectedLabels = async () => {
+      const resolved: Record<string, string> = {}
+
+      await Promise.all(
+        value.flatMap((token) => {
+          if (token.type !== "filter") return []
+
+          const definition = filters[token.filterKey]
+          if (!definition?.options.getLabel) return []
+
+          const identity = optionIdentity(token.filterKey, token.value)
+          if (optionLabels.has(identity) || selectedLabelOverrides[identity]) {
+            return []
+          }
+
+          return [
+            Promise.resolve(definition.options.getLabel(token.value))
+              .then((resolvedLabel) => {
+                resolved[identity] = resolvedLabel
+              })
+              .catch(() => undefined),
+          ]
+        })
+      )
+
+      if (!cancelled && Object.keys(resolved).length > 0) {
+        setSelectedLabelOverrides((current) => ({ ...current, ...resolved }))
+      }
+    }
+
+    void resolveSelectedLabels()
+
+    return () => {
+      cancelled = true
+    }
+  }, [filters, optionLabels, selectedLabelOverrides, value])
+
+  const query = activeTextRange?.query ?? ""
+  const normalizedQuery = normalizeSearchText(query)
+  const querySignature = activeTextRange
+    ? `${activeTextRange.from}:${activeTextRange.to}:${normalizedQuery}`
+    : null
+
+  useEffect(() => {
+    if (normalizedQuery.length < REMOTE_SEARCH_MIN_LENGTH) {
+      setRemoteSearch("")
+      return
+    }
+
+    const timeout = window.setTimeout(
+      () => setRemoteSearch(query),
+      REMOTE_SEARCH_DEBOUNCE_MS
+    )
+    return () => window.clearTimeout(timeout)
+  }, [normalizedQuery, query])
+
+  const remoteSearchIsCurrent =
+    normalizedQuery.length >= REMOTE_SEARCH_MIN_LENGTH &&
+    normalizeSearchText(remoteSearch) === normalizedQuery
+  const selectedIdentities = useMemo(
+    () =>
+      new Set(
+        value.flatMap((token) =>
+          token.type === "filter"
+            ? [optionIdentity(token.filterKey, token.value)]
+            : []
+        )
+      ),
+    [value]
+  )
+  const visibleOptions = useMemo(() => {
+    if (!normalizedQuery) return []
+
+    return filterEntries
+      .flatMap(([filterKey, definition]) => {
+        if (hasSource(definition) && !remoteSearchIsCurrent) return []
+
+        return (optionStates[filterKey]?.options ?? []).flatMap((option) => {
+          if (!validFilterKeys.has(option.filterKey)) return []
+
+          if (
+            selectedIdentities.has(
+              optionIdentity(option.filterKey, option.value)
+            )
+          ) {
+            return []
+          }
+
+          const score = optionScore(option, normalizedQuery)
+          return score === null ? [] : [{ option, score }]
+        })
+      })
+      .sort(
+        (first, second) =>
+          first.score - second.score ||
+          (filterOrder.get(first.option.categoryKey) ?? 0) -
+            (filterOrder.get(second.option.categoryKey) ?? 0)
+      )
+      .map(({ option }) => option)
+  }, [
+    filterEntries,
+    filterOrder,
+    normalizedQuery,
+    optionStates,
+    remoteSearchIsCurrent,
+    selectedIdentities,
+    validFilterKeys,
+  ])
+
+  const popupRows = useMemo<PopupRow[]>(() => {
+    if (!normalizedQuery) return []
+
+    const rows: PopupRow[] = visibleOptions.map((option) => ({
+      kind: "option",
+      option,
+    }))
+
+    for (const [filterKey, definition] of filterEntries) {
+      if (hasSource(definition) && !remoteSearchIsCurrent) continue
+      const state = optionStates[filterKey]
+
+      if (state?.error) {
+        rows.push({
+          kind: "retry",
+          filterKey,
+          categoryLabel: definition.label,
+        })
+      }
+      if (state?.hasMore && state.loadMore) {
+        rows.push({
+          kind: "loadMore",
+          filterKey,
+          categoryLabel: definition.label,
+          loadMore: state.loadMore,
+        })
+      }
+    }
+
+    return rows
+  }, [
+    filterEntries,
+    normalizedQuery,
+    optionStates,
+    remoteSearchIsCurrent,
+    visibleOptions,
+  ])
+
+  const isLoading = filterEntries.some(([filterKey, definition]) => {
+    if (hasSource(definition) && !remoteSearchIsCurrent) return false
+    return optionStates[filterKey]?.isLoading
+  })
+  const failedCategoryLabels = filterEntries.flatMap(
+    ([filterKey, definition]) => {
+      if (hasSource(definition) && !remoteSearchIsCurrent) return []
+      return optionStates[filterKey]?.error ? [definition.label] : []
+    }
+  )
+  const isOpen = Boolean(
+    !disabled &&
+    editorFocused &&
+    querySignature &&
+    (isLoading || popupRows.length > 0) &&
+    querySignature !== dismissedSignature
+  )
+  const activeRow = popupRows[activeRowIndex]
+  const activeDescendantId = isOpen
+    ? activeRow
+      ? `${listboxId}-row-${activeRowIndex}`
+      : undefined
+    : undefined
+
+  useEffect(() => {
+    setActiveRowIndex(0)
+  }, [querySignature])
+
+  useEffect(() => {
+    setActiveRowIndex((current) =>
+      popupRows.length === 0 ? 0 : Math.min(current, popupRows.length - 1)
+    )
+  }, [popupRows.length])
+
+  useEffect(() => {
+    if (!activeDescendantId) return
+    document
+      .getElementById(activeDescendantId)
+      ?.scrollIntoView?.({ block: "nearest" })
+  }, [activeDescendantId])
+
+  useEffect(() => {
+    if (!editor) return
+
+    const editorElement = editor.view.dom
+    editorElement.setAttribute("aria-expanded", String(isOpen))
+    if (isOpen) {
+      editorElement.setAttribute("aria-controls", listboxId)
+    } else {
+      editorElement.removeAttribute("aria-controls")
+    }
+    if (activeDescendantId) {
+      editorElement.setAttribute("aria-activedescendant", activeDescendantId)
+    } else {
+      editorElement.removeAttribute("aria-activedescendant")
+    }
+  }, [activeDescendantId, editor, isOpen, listboxId])
+
+  const handleRetry = useCallback((filterKey: string) => {
+    setOptionStates((current) => {
+      const next = { ...current }
+      delete next[filterKey]
+      return next
+    })
+    setLoaderRevisions((current) => ({
+      ...current,
+      [filterKey]: (current[filterKey] ?? 0) + 1,
+    }))
+  }, [])
+
+  const handleSelectOption = useCallback(
+    (option: ResolvedFilterTagOption) => {
+      if (!editor || !activeTextRange) return
+
+      const replacementFrom = getReplacementFrom(
+        editor,
+        activeTextRange,
+        option.displayLabel
+      )
+      const { selection } = editor.state
+      const nextCharacter = selection.$from.parent.textBetween(
+        selection.$from.parentOffset,
+        Math.min(
+          selection.$from.parentOffset + 1,
+          selection.$from.parent.content.size
+        )
+      )
+      const shouldAddSpace =
+        !nextCharacter || !/^[\s.,;:!?)]/u.test(nextCharacter)
+      const content = [
+        {
+          type: "filterTag",
+          attrs: getTagAttributes(option.filterKey, option.value),
+        },
+        ...(shouldAddSpace ? [{ type: "text", text: " " }] : []),
+      ]
+
+      editor
+        .chain()
+        .focus()
+        .insertContentAt(
+          { from: replacementFrom, to: activeTextRange.to },
+          content
+        )
+        .run()
+      setActiveRowIndex(0)
+      setAnnouncement(
+        i18n.t("filters.tagPicker.added", {
+          value: option.displayLabel,
+          category: option.categoryLabel,
+        })
+      )
+    },
+    [activeTextRange, editor, getTagAttributes, i18n]
+  )
+
+  const activateRow = useCallback(
+    (row: PopupRow | undefined) => {
+      if (!row) return
+      if (row.kind === "option") {
+        handleSelectOption(row.option)
+      } else if (row.kind === "retry") {
+        handleRetry(row.filterKey)
+      } else {
+        row.loadMore()
+      }
+    },
+    [handleRetry, handleSelectOption]
+  )
+
+  handleEditorKeyDownRef.current = (event) => {
+    if (isComposingRef.current || event.isComposing) return false
+
+    if (
+      editor &&
+      editor.state.selection.empty &&
+      (event.key === "Backspace" || event.key === "Delete")
+    ) {
+      const { selection } = editor.state
+      const adjacentNode =
+        event.key === "Backspace"
+          ? selection.$from.nodeBefore
+          : selection.$from.nodeAfter
+
+      if (adjacentNode?.type.name === "filterTag") {
+        event.preventDefault()
+        const from =
+          event.key === "Backspace"
+            ? selection.from - adjacentNode.nodeSize
+            : selection.from
+        editor.commands.deleteRange({
+          from,
+          to: from + adjacentNode.nodeSize,
+        })
+        return true
+      }
+    }
+
+    if (event.key === "Escape" && isOpen) {
+      event.preventDefault()
+      setDismissedSignature(querySignature)
+      return true
+    }
+
+    if (event.shiftKey && event.key === "Enter") {
+      if (mode === "tags") {
+        event.preventDefault()
+        return true
+      }
+      return false
+    }
+
+    if (event.key === "ArrowDown" && isOpen && popupRows.length > 0) {
+      event.preventDefault()
+      setActiveRowIndex((current) =>
+        current >= popupRows.length - 1 ? 0 : current + 1
+      )
+      return true
+    }
+
+    if (event.key === "ArrowUp" && isOpen && popupRows.length > 0) {
+      event.preventDefault()
+      setActiveRowIndex((current) =>
+        current <= 0 ? popupRows.length - 1 : current - 1
+      )
+      return true
+    }
+
+    if (event.key === "Enter" && isOpen && activeRow) {
+      event.preventDefault()
+      activateRow(activeRow)
+      return true
+    }
+
+    if (event.key === "Enter" && mode === "tags") {
+      event.preventDefault()
+      return true
+    }
+
+    return false
+  }
+
+  const virtualAnchorRef = useRef({
+    getBoundingClientRect: () =>
+      caretRectRef.current ?? new DOMRect(0, 0, 1, 1),
+  })
+
+  return (
+    <DataTestIdWrapper dataTestId={dataTestId}>
+      <div className="flex w-full flex-col gap-2 @container">
+        {filterEntries.map(([filterKey, definition]) => {
+          const sourceBased = hasSource(definition)
+          const categorySelectIsOpen =
+            openCategorySelectKeys.includes(filterKey)
+          if (sourceBased && !remoteSearchIsCurrent && !categorySelectIsOpen) {
+            return null
+          }
+
+          const loaderSearch = remoteSearchIsCurrent ? remoteSearch : undefined
+
+          return (
+            <FilterOptionsLoader
+              key={`${filterKey}-${sourceBased ? (loaderSearch ?? "browse") : "local"}-${loaderRevisions[filterKey] ?? 0}`}
+              filterKey={filterKey}
+              definition={definition}
+              search={sourceBased ? loaderSearch : undefined}
+              onStateChange={handleOptionsStateChange}
+            />
+          )
+        })}
+
+        <span
+          id={labelId}
+          className="text-base font-medium text-f1-foreground"
+          onMouseDown={(event) => {
+            event.preventDefault()
+            editor?.commands.focus()
+          }}
+        >
+          {label}
+        </span>
+
+        <Popover
+          open={isOpen}
+          onOpenChange={(open) => {
+            if (!open) setDismissedSignature(querySignature)
+          }}
+        >
+          <PopoverAnchor virtualRef={virtualAnchorRef} />
+          <div
+            className={cn(
+              "relative min-h-20 max-h-60 w-full cursor-text overflow-y-auto rounded-xl border border-solid border-f1-border-secondary bg-f1-background transition-colors",
+              editorFocused &&
+                !disabled &&
+                "border-f1-border-selected ring-1 ring-f1-special-ring",
+              disabled &&
+                "cursor-not-allowed border-f1-border bg-f1-background-disabled"
+            )}
+            onMouseDown={(event) => {
+              if (event.target === event.currentTarget) {
+                event.preventDefault()
+                editor?.commands.focus("end")
+              }
+            }}
+          >
+            <EditorContent
+              editor={editor}
+              className={cn(
+                "min-h-20 w-full p-2.5 text-base text-f1-foreground",
+                "[&_.ProseMirror]:min-h-[3.75rem] [&_.ProseMirror]:whitespace-pre-wrap [&_.ProseMirror]:break-words [&_.ProseMirror]:outline-none",
+                "[&_.is-editor-empty:first-child]:before:pointer-events-none [&_.is-editor-empty:first-child]:before:float-left [&_.is-editor-empty:first-child]:before:h-0 [&_.is-editor-empty:first-child]:before:text-f1-foreground-secondary [&_.is-editor-empty:first-child]:before:content-[attr(data-placeholder)]",
+                disabled && "text-f1-foreground-disabled"
+              )}
+            />
+          </div>
+
+          <PopoverContent
+            align="start"
+            side="top"
+            sideOffset={6}
+            collisionPadding={8}
+            className="max-h-60 w-64 max-w-[var(--radix-popover-content-available-width)] overflow-hidden rounded-lg border border-solid border-f1-border-secondary p-1 shadow-md motion-reduce:animate-none"
+            onOpenAutoFocus={(event) => event.preventDefault()}
+            onCloseAutoFocus={(event) => event.preventDefault()}
+          >
+            <div
+              id={listboxId}
+              role="listbox"
+              aria-label={i18n.filters.tagPicker.availableOptions}
+              aria-busy={isLoading}
+              className="max-h-[calc(15rem-0.5rem)] overflow-y-auto"
+            >
+              {popupRows.map((row, rowIndex) => {
+                const isActive = rowIndex === activeRowIndex
+                const rowId = `${listboxId}-row-${rowIndex}`
+
+                if (row.kind === "option") {
+                  return (
+                    <button
+                      key={row.option.id}
+                      id={rowId}
+                      type="button"
+                      role="option"
+                      aria-selected="false"
+                      tabIndex={-1}
+                      className={cn(
+                        "flex w-full cursor-pointer items-center gap-2 rounded border-0 bg-transparent p-2 text-left transition-colors",
+                        isActive
+                          ? "bg-f1-background-secondary ring-1 ring-inset ring-f1-border-selected"
+                          : "hover:bg-f1-background-secondary-hover",
+                        focusRing("focus-visible:ring-inset")
+                      )}
+                      onMouseEnter={() => setActiveRowIndex(rowIndex)}
+                      onMouseDown={(event) => {
+                        event.preventDefault()
+                      }}
+                      onClick={() => {
+                        activateRow(row)
+                      }}
+                    >
+                      <span
+                        aria-hidden
+                        className="h-2 w-2 shrink-0 rounded-full"
+                        style={getCategoryDotStyle(
+                          getCategoryColor(row.option.categoryKey)
+                        )}
+                      />
+                      <OneEllipsis className="min-w-0 flex-1 text-base font-medium text-f1-foreground">
+                        {row.option.displayLabel}
+                      </OneEllipsis>
+                      <span className="shrink-0 text-sm text-f1-foreground-secondary">
+                        {row.option.categoryLabel}
+                      </span>
+                    </button>
+                  )
+                }
+
+                const label =
+                  row.kind === "retry"
+                    ? i18n.t("filters.tagPicker.retryCategory", {
+                        category: row.categoryLabel,
+                      })
+                    : i18n.t("filters.tagPicker.loadMoreCategory", {
+                        category: row.categoryLabel,
+                      })
+
+                return (
+                  <button
+                    key={`${row.kind}-${row.filterKey}`}
+                    id={rowId}
+                    type="button"
+                    role="option"
+                    aria-selected="false"
+                    tabIndex={-1}
+                    className={cn(
+                      "w-full rounded border-0 bg-transparent p-2 text-left text-base font-medium transition-colors",
+                      row.kind === "retry"
+                        ? "text-f1-foreground-critical"
+                        : "text-f1-foreground",
+                      isActive
+                        ? "bg-f1-background-secondary ring-1 ring-inset ring-f1-border-selected"
+                        : "hover:bg-f1-background-secondary-hover",
+                      focusRing("focus-visible:ring-inset")
+                    )}
+                    onMouseEnter={() => setActiveRowIndex(rowIndex)}
+                    onMouseDown={(event) => {
+                      event.preventDefault()
+                    }}
+                    onClick={() => {
+                      activateRow(row)
+                    }}
+                  >
+                    {label}
+                  </button>
+                )
+              })}
+            </div>
+
+            {isLoading && (
+              <div role="status" aria-live="polite">
+                <span className="sr-only">
+                  {i18n.filters.tagPicker.loadingOptions}
+                </span>
+                {visibleOptions.length === 0 &&
+                  Array.from({ length: 3 }, (_, index) => (
+                    <div
+                      key={index}
+                      aria-hidden
+                      className="flex items-center gap-2 p-2"
+                    >
+                      <Skeleton className="h-2 w-2 shrink-0 rounded-full" />
+                      <Skeleton
+                        className={cn(
+                          "h-4 rounded",
+                          index === 1 ? "w-24" : "w-32"
+                        )}
+                      />
+                    </div>
+                  ))}
+              </div>
+            )}
+          </PopoverContent>
+        </Popover>
+
+        <div className="grid w-full grid-cols-4 gap-2">
+          {filterEntries.map(([filterKey, definition]) => (
+            <CategoryFilterSelect
+              key={filterKey}
+              definition={definition}
+              disabled={disabled}
+              loading={optionStates[filterKey]?.isLoading ?? false}
+              options={categorySelectOptions[filterKey] ?? []}
+              value={
+                categorySelectValues[filterKey] ??
+                selectedCategoryValues[filterKey] ??
+                []
+              }
+              onChange={(nextValues, selectedOptions) => {
+                categorySelectValuesRef.current = {
+                  ...categorySelectValuesRef.current,
+                  [filterKey]: nextValues,
+                }
+                setCategorySelectValues((current) => ({
+                  ...current,
+                  [filterKey]: nextValues,
+                }))
+
+                const labelOverrides = Object.fromEntries(
+                  selectedOptions.flatMap((option) => {
+                    const selection = decodeCategoryFilterSelection(
+                      option.value
+                    )
+                    return selection
+                      ? [
+                          [
+                            optionIdentity(
+                              selection.filterKey,
+                              selection.value
+                            ),
+                            option.label,
+                          ],
+                        ]
+                      : []
+                  })
+                )
+                if (Object.keys(labelOverrides).length > 0) {
+                  setSelectedLabelOverrides((current) => ({
+                    ...current,
+                    ...labelOverrides,
+                  }))
+                }
+              }}
+              onOpenChange={(open) =>
+                handleCategorySelectOpenChange(filterKey, open)
+              }
+            />
+          ))}
+        </div>
+
+        <p id={keyboardHintId} className="text-xs text-f1-foreground-secondary">
+          {mode === "tags"
+            ? i18n.filters.tagPicker.keyboardHintTags
+            : i18n.filters.tagPicker.keyboardHint}
+        </p>
+        <span className="sr-only" aria-live="polite" aria-atomic="true">
+          {announcement}
+        </span>
+        {failedCategoryLabels.length > 0 && (
+          <span className="sr-only" role="status" aria-live="polite">
+            {failedCategoryLabels
+              .map((category) =>
+                i18n.t("filters.tagPicker.failedToLoad", { category })
+              )
+              .join(". ")}
+          </span>
+        )}
+      </div>
+    </DataTestIdWrapper>
+  )
+}
+
+_F0FilterTagPicker.displayName = "F0FilterTagPicker"
+
+export const F0FilterTagPicker = _F0FilterTagPicker as <
+  Filters extends F0FilterTagPickerFiltersDefinition,
+>(
+  props: F0FilterTagPickerProps<Filters>
+) => ReactElement

--- a/packages/react/src/experimental/Forms/F0FilterTagPicker/__stories__/F0FilterTagPicker.mdx
+++ b/packages/react/src/experimental/Forms/F0FilterTagPicker/__stories__/F0FilterTagPicker.mdx
@@ -1,0 +1,424 @@
+import { Canvas, Controls, Meta, Unstyled } from "@storybook/addon-docs/blocks"
+import { DoDonts } from "@/lib/storybook-utils/do-donts"
+import * as Stories from "./F0FilterTagPicker.stories"
+
+<Meta of={Stories} />
+
+# F0FilterTagPicker
+
+`F0FilterTagPicker` selects concrete employee filters as removable dot tags. It can either preserve natural-language intent alongside those tags or use typed text only as a transient search.
+
+## Anatomy
+
+<Canvas of={Stories.Default} />
+
+<Controls of={Stories.Default} />
+
+<Unstyled>
+  <table className="dark:text-f1-foreground-inverse/80 mb-8 w-full">
+    <thead>
+      <tr>
+        <th className="text-left">Prop</th>
+        <th className="text-left">Type</th>
+        <th className="text-left">Default</th>
+        <th className="text-left">Required</th>
+        <th className="text-left">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>filters</code>
+        </td>
+        <td>
+          <code>F0FilterTagPickerFiltersDefinition</code>
+        </td>
+        <td>—</td>
+        <td>Yes</td>
+        <td>
+          Option definitions restricted to <code>type: "in"</code>, including
+          local, asynchronous, hierarchical, and remote sources.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>value</code>
+        </td>
+        <td>
+          <code>F0FilterTagPickerValue&lt;Filters&gt;</code>
+        </td>
+        <td>—</td>
+        <td>Yes</td>
+        <td>Controlled sequence of free-text and filter tokens.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>onChange</code>
+        </td>
+        <td>
+          <code>(value: F0FilterTagPickerValue&lt;Filters&gt;) =&gt; void</code>
+        </td>
+        <td>—</td>
+        <td>Yes</td>
+        <td>
+          Receives the complete normalized token sequence after every edit.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>label</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>—</td>
+        <td>Yes</td>
+        <td>Visible label and accessible name for the editor.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>mode</code>
+        </td>
+        <td>
+          <code>"mixed" | "tags"</code>
+        </td>
+        <td>
+          <code>"mixed"</code>
+        </td>
+        <td>—</td>
+        <td>
+          Persists free text alongside tags or uses it only as a transient
+          search query.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>placeholder</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>Localized mode-specific prompt</td>
+        <td>—</td>
+        <td>Prompt displayed while the token document is empty.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>categoryColors</code>
+        </td>
+        <td>
+          <code>Partial&lt;Record&lt;keyof Filters, NewColor&gt;&gt;</code>
+        </td>
+        <td>Stable generated colors</td>
+        <td>—</td>
+        <td>Overrides the dot color for individual filter categories.</td>
+      </tr>
+      <tr>
+        <td>
+          <code>disabled</code>
+        </td>
+        <td>
+          <code>boolean</code>
+        </td>
+        <td>
+          <code>false</code>
+        </td>
+        <td>—</td>
+        <td>
+          Preserves content while preventing editing, searching, selection, and
+          removal.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>dataTestId</code>
+        </td>
+        <td>
+          <code>string</code>
+        </td>
+        <td>—</td>
+        <td>—</td>
+        <td>Adds a test identifier to the component root.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+### Modes
+
+<Canvas of={Stories.Modes} />
+
+<Unstyled>
+  <table className="dark:text-f1-foreground-inverse/80 mb-8 w-full">
+    <thead>
+      <tr>
+        <th className="text-left">Mode</th>
+        <th className="text-left">Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <code>mixed</code> (default)
+        </td>
+        <td>
+          Keeps free text, line breaks, and tags in the ordered controlled
+          value.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <code>tags</code>
+        </td>
+        <td>
+          Uses typed text only to find options. Emits filter tokens and clears
+          unfinished text when focus leaves the editor.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+### States
+
+<Canvas of={Stories.Disabled} />
+
+<Unstyled>
+  <table className="dark:text-f1-foreground-inverse/80 mb-8 w-full">
+    <thead>
+      <tr>
+        <th className="text-left">State</th>
+        <th className="text-left">Description</th>
+        <th className="text-left">Visual indicator</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Focused</td>
+        <td>
+          Edits text and searches the fragment immediately before the caret.
+        </td>
+        <td>Selected border and focus ring.</td>
+      </tr>
+      <tr>
+        <td>Loading</td>
+        <td>Keeps resolved options usable while another provider loads.</td>
+        <td>Skeleton rows and a live loading announcement.</td>
+      </tr>
+      <tr>
+        <td>Error</td>
+        <td>
+          Keeps healthy sources usable and retries only the failed category.
+        </td>
+        <td>Flat critical retry row named after the category.</td>
+      </tr>
+      <tr>
+        <td>Disabled</td>
+        <td>Displays the token document without allowing changes.</td>
+        <td>Disabled surface and remove controls.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+## Guidelines
+
+### Design best practices
+
+**When to use**
+
+<Unstyled>
+  <table className="dark:text-f1-foreground-inverse/80 mb-8 w-full">
+    <thead>
+      <tr>
+        <th className="text-left">Situation</th>
+        <th className="text-left">Use F0FilterTagPicker when</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Employee audience definition</td>
+        <td>Recognizable attributes and explanatory text need to coexist.</td>
+      </tr>
+      <tr>
+        <td>Large mixed catalogs</td>
+        <td>
+          Teams, workplaces, locations, and roles should be searched from one
+          field.
+        </td>
+      </tr>
+      <tr>
+        <td>Future interpretation</td>
+        <td>
+          Free text must remain available alongside today&apos;s structured
+          filters.
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+**When not to use**
+
+<Unstyled>
+  <table className="dark:text-f1-foreground-inverse/80 mb-8 w-full">
+    <thead>
+      <tr>
+        <th className="text-left">Situation</th>
+        <th className="text-left">Use instead</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Date, number range, or custom filter editors</td>
+        <td>
+          <code>F0FilterPickerContent</code>
+        </td>
+      </tr>
+      <tr>
+        <td>Advanced nested AND/OR rules</td>
+        <td>A query-builder pattern</td>
+      </tr>
+      <tr>
+        <td>One short option list without free text</td>
+        <td>
+          <code>F0Select</code> in multiple-selection mode
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+**Do&apos;s and don&apos;ts**
+
+<DoDonts
+  do={{
+    description:
+      "Combine recognizable intent and values, such as ‘People in [Madrid] who work as [Engineer]’.",
+  }}
+  dont={{
+    description:
+      "Expose operators or backend identifiers, such as ‘location_id IN 42’.",
+  }}
+/>
+
+### Content best practices
+
+- Use a label that names the audience or records being defined.
+- Keep category and option labels concise enough to scan inside tags.
+- Use employee-facing language rather than database terminology.
+  - **Correct:** “Software engineer”, “Barcelona”, “Remote”
+  - **Incorrect:** “role_id: 12”, “location_eq”, “workplace_flag”
+
+<DoDonts
+  do={{
+    description: "Use employee-facing labels such as ‘Customer support agent’.",
+  }}
+  dont={{
+    description:
+      "Expose implementation labels such as ‘role_id: support_agent’.",
+  }}
+/>
+
+### Behavior
+
+- `Filters` preserves each filter key&apos;s option-value type. `value` and `onChange: (value: F0FilterTagPickerValue<Filters>) => void` use the same generic definition.
+- WHEN `mode="mixed"` → THEN `onChange` receives the full ordered sequence, with adjacent text merged, empty text removed, and line breaks preserved as `\n`.
+- WHEN `mode="tags"` → THEN typed text remains a transient query, `onChange` emits only filter tokens, Enter never inserts a line break, and unfinished text clears on blur.
+- WHEN `filterTagPickerValueToFiltersState(value)` runs → THEN it omits text, groups selected values by filter key, and removes duplicates.
+- WHEN the active fragment has two or more characters → THEN every remote source is queried after a 250 ms debounce; local and asynchronous providers are filtered immediately.
+- WHEN a suggestion is selected → THEN the longest matching phrase immediately before the caret becomes a tag.
+- TipTap is an internal editor implementation; HTML is not part of the public API and pasted external content becomes plain text.
+
+### Usage examples
+
+**Employee audience with mixed text and filters**
+
+The story combines Teams, Workplace, Location, and Role and displays both the canonical token JSON and derived `FiltersState`.
+
+<Canvas of={Stories.MixedTextAndFilters} />
+
+**Remote people search**
+
+Type at least two characters, such as `gr`, to query the remote source. Existing remote values resolve through `getLabel` without storing display metadata in the token.
+
+<Canvas of={Stories.RemoteSource} />
+
+**Hierarchical office selection**
+
+Type `floor` to reveal child options. A selected child keeps its parent path in the tag and writes to the child&apos;s declared `filterKey`.
+
+<Canvas of={Stories.HierarchicalOptions} />
+
+**Loading and retry**
+
+Type any team fragment in the loading story to reveal its live loading state. Type `team` in the error story to reveal the flat `Retry Teams` action.
+
+<Canvas of={Stories.Loading} />
+
+<Canvas of={Stories.ErrorAndRetry} />
+
+## Accessibility
+
+The editable surface uses a combobox linked to a flat listbox. Option rows include visible category text in addition to their colored dots, and tags expose their category in their accessible name. Additions, removals, loading, and source failures use live announcements.
+
+### Keyboard interaction
+
+<Unstyled>
+  <table className="dark:text-f1-foreground-inverse/80 mb-8 w-full">
+    <thead>
+      <tr>
+        <th className="text-left">Key</th>
+        <th className="text-left">Action</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>
+          <kbd>Arrow Down</kbd> / <kbd>Arrow Up</kbd>
+        </td>
+        <td>Move through suggestion, retry, and pagination rows.</td>
+      </tr>
+      <tr>
+        <td>
+          <kbd>Enter</kbd>
+        </td>
+        <td>
+          Select the active row. Without an active row, insert a line break in
+          mixed mode or keep the transient query unchanged in tags mode.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <kbd>Shift</kbd> + <kbd>Enter</kbd>
+        </td>
+        <td>Insert a line break in mixed mode. Tags mode does not add one.</td>
+      </tr>
+      <tr>
+        <td>
+          <kbd>Escape</kbd>
+        </td>
+        <td>Close suggestions without deleting free text.</td>
+      </tr>
+      <tr>
+        <td>
+          <kbd>Backspace</kbd> / <kbd>Delete</kbd>
+        </td>
+        <td>Remove an adjacent filter tag or edit ordinary text.</td>
+      </tr>
+      <tr>
+        <td>
+          <kbd>Tab</kbd>
+        </td>
+        <td>Move focus without trapping it in the editor.</td>
+      </tr>
+    </tbody>
+  </table>
+</Unstyled>
+
+### Screen reader behavior
+
+- `aria-expanded`, `aria-controls`, and `aria-activedescendant` expose the current suggestion state while focus stays in the editor.
+- Each option announces its display label and category; already-selected options are omitted.
+- The disabled editor exposes `aria-disabled="true"` and every remove action is disabled.
+- Loading, filter additions and removals, and individual source failures are announced without moving focus.

--- a/packages/react/src/experimental/Forms/F0FilterTagPicker/__stories__/F0FilterTagPicker.stories.tsx
+++ b/packages/react/src/experimental/Forms/F0FilterTagPicker/__stories__/F0FilterTagPicker.stories.tsx
@@ -1,0 +1,436 @@
+import type { Meta, StoryObj } from "@storybook/react-vite"
+
+import { useState } from "react"
+import { fn } from "storybook/test"
+
+import { createDataSourceDefinition } from "@/hooks/datasource"
+import { withSnapshot } from "@/lib/storybook-utils/parameters"
+
+import type {
+  F0FilterTagPickerFiltersDefinition,
+  F0FilterTagPickerMode,
+  F0FilterTagPickerProps,
+  F0FilterTagPickerValue,
+} from "../types"
+
+import {
+  F0FilterTagPicker,
+  f0FilterTagPickerModes,
+  filterTagPickerValueToFiltersState,
+} from "../index"
+
+const filters = {
+  location: {
+    type: "in",
+    label: "Location",
+    options: {
+      options: [
+        { value: "barcelona", label: "Barcelona" },
+        { value: "madrid", label: "Madrid" },
+        { value: "london", label: "London" },
+        { value: "lisbon", label: "Lisbon" },
+      ],
+    },
+  },
+  team: {
+    type: "in",
+    label: "Teams",
+    options: {
+      options: async () => [
+        { value: "people", label: "People" },
+        { value: "platform", label: "Platform" },
+        { value: "payroll", label: "Payroll" },
+      ],
+    },
+  },
+  role: {
+    type: "in",
+    label: "Role",
+    options: {
+      options: [
+        { value: "software-engineer", label: "Software engineer" },
+        { value: "product-designer", label: "Product designer" },
+        { value: "support-agent", label: "Customer support agent" },
+        { value: "people-partner", label: "People partner" },
+      ],
+    },
+  },
+  workplace: {
+    type: "in",
+    label: "Workplace",
+    options: {
+      options: [
+        { value: "office", label: "Office based" },
+        { value: "hybrid", label: "Hybrid" },
+        { value: "remote", label: "Remote" },
+      ],
+    },
+  },
+} satisfies F0FilterTagPickerFiltersDefinition
+
+type Filters = typeof filters
+type StoryProps = F0FilterTagPickerProps<Filters>
+
+const mixedValue = [
+  { type: "text", value: "People in " },
+  { type: "filter", filterKey: "location", value: "madrid" },
+  { type: "text", value: " or " },
+  { type: "filter", filterKey: "location", value: "barcelona" },
+  { type: "text", value: " who work as " },
+  { type: "filter", filterKey: "role", value: "software-engineer" },
+  { type: "text", value: " in the " },
+  { type: "filter", filterKey: "team", value: "platform" },
+  { type: "text", value: " team with a " },
+  { type: "filter", filterKey: "workplace", value: "hybrid" },
+  { type: "text", value: " setup." },
+] satisfies F0FilterTagPickerValue<Filters>
+
+function PickerDemo<Definition extends F0FilterTagPickerFiltersDefinition>({
+  filters: pickerFilters,
+  initialValue,
+  label,
+  mode = "mixed",
+  disabled,
+  categoryColors,
+  placeholder,
+  dataTestId,
+  onChange,
+}: {
+  filters: Definition
+  initialValue: F0FilterTagPickerValue<Definition>
+  label: string
+  mode?: F0FilterTagPickerMode
+  disabled?: boolean
+  categoryColors?: F0FilterTagPickerProps<Definition>["categoryColors"]
+  placeholder?: string
+  dataTestId?: string
+  onChange?: F0FilterTagPickerProps<Definition>["onChange"]
+}) {
+  const [currentValue, setCurrentValue] =
+    useState<F0FilterTagPickerValue<Definition>>(initialValue)
+
+  return (
+    <div className="flex w-full max-w-3xl flex-col gap-4">
+      <F0FilterTagPicker
+        filters={pickerFilters}
+        value={currentValue}
+        onChange={(nextValue) => {
+          setCurrentValue(nextValue)
+          onChange?.(nextValue)
+        }}
+        label={label}
+        mode={mode}
+        disabled={disabled}
+        categoryColors={categoryColors}
+        placeholder={placeholder}
+        dataTestId={dataTestId}
+      />
+      <div className="grid gap-3 @xl:grid-cols-2">
+        <div className="rounded-lg bg-f1-background-secondary p-3">
+          <div className="mb-1 text-xs font-medium text-f1-foreground-secondary">
+            Ordered tokens
+          </div>
+          <pre className="m-0 whitespace-pre-wrap text-xs">
+            {JSON.stringify(currentValue, null, 2)}
+          </pre>
+        </div>
+        <div className="rounded-lg bg-f1-background-secondary p-3">
+          <div className="mb-1 text-xs font-medium text-f1-foreground-secondary">
+            Derived FiltersState
+          </div>
+          <pre className="m-0 whitespace-pre-wrap text-xs">
+            {JSON.stringify(
+              filterTagPickerValueToFiltersState(currentValue),
+              null,
+              2
+            )}
+          </pre>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const meta = {
+  title: "F0FilterTagPicker",
+  component: F0FilterTagPicker,
+  tags: ["experimental", "!autodocs"],
+  parameters: {
+    layout: "centered",
+    docs: {
+      story: { inline: false, height: "640px" },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex min-h-[560px] w-[min(780px,calc(100vw-48px))] items-start bg-f1-background pt-32">
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    filters,
+    value: [],
+    onChange: fn(),
+    label: "Who should belong to this team?",
+    mode: "mixed",
+  },
+  argTypes: {
+    filters: {
+      control: false,
+      description: 'Filter definitions restricted to type: "in".',
+    },
+    value: {
+      control: "object",
+      description: "Controlled ordered text and filter tokens.",
+    },
+    onChange: {
+      control: false,
+      description: "Called immediately after every document change.",
+    },
+    mode: {
+      control: "inline-radio",
+      options: f0FilterTagPickerModes,
+      description:
+        "Persists free text in mixed mode or uses it only for searching in tags mode.",
+    },
+    categoryColors: {
+      control: "object",
+      description: "Optional stable color overrides by filter key.",
+    },
+    placeholder: {
+      control: "text",
+      description: "Optional free-text and search prompt.",
+    },
+    dataTestId: {
+      control: "text",
+      description: "Optional test identifier for the component root.",
+    },
+  },
+  render: (args) => (
+    <PickerDemo
+      filters={args.filters}
+      initialValue={args.value}
+      label={args.label}
+      mode={args.mode}
+      disabled={args.disabled}
+      categoryColors={args.categoryColors}
+      placeholder={args.placeholder}
+      dataTestId={args.dataTestId}
+      onChange={args.onChange}
+    />
+  ),
+} satisfies Meta<StoryProps>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+export const Default: Story = {}
+
+export const MixedTextAndFilters: Story = {
+  tags: ["no-sidebar"],
+  args: { value: mixedValue },
+}
+
+const tagsOnlyValue = mixedValue.filter(
+  (token) => token.type === "filter"
+) satisfies F0FilterTagPickerValue<Filters>
+
+export const Modes: Story = {
+  tags: ["no-sidebar"],
+  args: {},
+  render: () => (
+    <div className="flex w-full flex-col gap-8">
+      <PickerDemo
+        filters={filters}
+        initialValue={mixedValue}
+        label="Mixed text and tags"
+        mode="mixed"
+      />
+      <PickerDemo
+        filters={filters}
+        initialValue={tagsOnlyValue}
+        label="Tags only"
+        mode="tags"
+      />
+    </div>
+  ),
+}
+
+type Employee = { id: number; name: string }
+const people = [
+  { id: 1, name: "Ada Lovelace" },
+  { id: 2, name: "Grace Hopper" },
+  { id: 3, name: "Margaret Hamilton" },
+]
+const remoteFilters = {
+  person: {
+    type: "in",
+    label: "Person",
+    options: {
+      source: createDataSourceDefinition<Employee>({
+        dataAdapter: {
+          fetchData: async ({ search }) => ({
+            records: people.filter((person) =>
+              person.name.toLowerCase().includes(search?.toLowerCase() ?? "")
+            ),
+          }),
+        },
+      }),
+      mapOptions: (person: Employee) => ({
+        value: person.id,
+        label: person.name,
+      }),
+      getLabel: (value: unknown) =>
+        people.find((person) => person.id === value)?.name ?? String(value),
+    },
+  },
+} satisfies F0FilterTagPickerFiltersDefinition
+
+export const RemoteSource: Story = {
+  tags: ["no-sidebar"],
+  args: {},
+  render: () => (
+    <PickerDemo
+      filters={remoteFilters}
+      initialValue={[
+        { type: "text", value: "Invite " },
+        { type: "filter", filterKey: "person", value: 1 },
+        { type: "text", value: " and " },
+      ]}
+      label="Add specific people"
+    />
+  ),
+}
+
+const failingFilters = {
+  team: {
+    type: "in",
+    label: "Teams",
+    options: {
+      options: async () => {
+        throw new Error("Could not load teams")
+      },
+    },
+  },
+} satisfies F0FilterTagPickerFiltersDefinition
+
+export const ErrorAndRetry: Story = {
+  tags: ["no-sidebar"],
+  args: {},
+  render: () => (
+    <PickerDemo
+      filters={failingFilters}
+      initialValue={[]}
+      label="Employee filters"
+    />
+  ),
+}
+
+const loadingFilters = {
+  team: {
+    type: "in",
+    label: "Teams",
+    options: {
+      options: () =>
+        new Promise<Array<{ value: string; label: string }>>(() => {}),
+    },
+  },
+} satisfies F0FilterTagPickerFiltersDefinition
+
+export const Loading: Story = {
+  tags: ["no-sidebar"],
+  args: {},
+  render: () => (
+    <PickerDemo
+      filters={loadingFilters}
+      initialValue={[]}
+      label="Employee filters"
+    />
+  ),
+}
+
+const hierarchicalFilters = {
+  office: {
+    type: "in",
+    label: "Office",
+    options: {
+      options: [
+        {
+          value: "barcelona-hq",
+          label: "Barcelona HQ",
+          children: {
+            filterKey: "space",
+            options: [
+              { value: "floor-1", label: "Floor 1" },
+              { value: "floor-2", label: "Floor 2" },
+            ],
+          },
+        },
+      ],
+    },
+  },
+  space: {
+    type: "in",
+    label: "Space",
+    options: { options: [] },
+  },
+} satisfies F0FilterTagPickerFiltersDefinition
+
+export const HierarchicalOptions: Story = {
+  tags: ["no-sidebar"],
+  args: {},
+  render: () => (
+    <PickerDemo
+      filters={hierarchicalFilters}
+      initialValue={[]}
+      label="Choose an office or space"
+    />
+  ),
+}
+
+export const Disabled: Story = {
+  tags: ["no-sidebar"],
+  args: {
+    value: mixedValue,
+    disabled: true,
+  },
+}
+
+export const Snapshot: Story = {
+  tags: ["no-sidebar"],
+  args: {},
+  parameters: withSnapshot({}),
+  render: () => (
+    <div className="flex w-[740px] flex-col gap-8">
+      <PickerDemo
+        filters={filters}
+        initialValue={mixedValue}
+        label="Mixed employee intent"
+      />
+      <PickerDemo
+        filters={filters}
+        initialValue={mixedValue}
+        label="Custom category colors"
+        categoryColors={{
+          team: "viridian",
+          workplace: "yellow",
+          location: "malibu",
+          role: "purple",
+        }}
+      />
+      <PickerDemo
+        filters={filters}
+        initialValue={tagsOnlyValue}
+        label="Tags only"
+        mode="tags"
+      />
+      <PickerDemo
+        filters={filters}
+        initialValue={mixedValue}
+        label="Disabled employee intent"
+        disabled
+      />
+    </div>
+  ),
+}

--- a/packages/react/src/experimental/Forms/F0FilterTagPicker/__tests__/F0FilterTagPicker.test.tsx
+++ b/packages/react/src/experimental/Forms/F0FilterTagPicker/__tests__/F0FilterTagPicker.test.tsx
@@ -1,0 +1,1273 @@
+import { useState } from "react"
+import { describe, expect, it, vi } from "vitest"
+
+import { createDataSourceDefinition } from "@/hooks/datasource"
+import {
+  act,
+  fireEvent,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+  zeroRender as render,
+} from "@/testing/test-utils"
+
+import type {
+  F0FilterTagPickerFiltersDefinition,
+  F0FilterTagPickerMode,
+  F0FilterTagPickerValue,
+} from "../types"
+
+import { getCategoryDotStyle } from "../colorStyles"
+import { F0FilterTagPicker } from "../F0FilterTagPicker"
+import { filterTagPickerValueToFiltersState } from "../types"
+import { normalizeFilterTagPickerValue } from "../value"
+
+Object.defineProperty(window, "scrollBy", {
+  configurable: true,
+  value: () => {},
+})
+Object.defineProperty(document, "elementFromPoint", {
+  configurable: true,
+  value: () => document.activeElement,
+})
+global.ResizeObserver = class MockResizeObserver {
+  observe = vi.fn()
+  unobserve = vi.fn()
+  disconnect = vi.fn()
+} as typeof ResizeObserver
+Object.defineProperty(HTMLElement.prototype, "offsetHeight", {
+  configurable: true,
+  value: 800,
+})
+Object.defineProperty(HTMLElement.prototype, "offsetWidth", {
+  configurable: true,
+  value: 800,
+})
+vi.spyOn(Element.prototype, "getBoundingClientRect").mockImplementation(() => ({
+  width: 120,
+  height: 120,
+  top: 0,
+  left: 0,
+  bottom: 0,
+  right: 0,
+  x: 0,
+  y: 0,
+  toJSON: () => {},
+}))
+
+const filters = {
+  location: {
+    type: "in",
+    label: "Location",
+    options: {
+      options: [
+        { value: "barcelona", label: "Barcelona" },
+        { value: "madrid", label: "Madrid" },
+        { value: "malaga", label: "Málaga" },
+      ],
+    },
+  },
+  role: {
+    type: "in",
+    label: "Role",
+    options: {
+      options: [
+        { value: "engineer", label: "Engineer" },
+        { value: "designer", label: "Product designer" },
+        { value: "support", label: "Customer support agent" },
+      ],
+    },
+  },
+} satisfies F0FilterTagPickerFiltersDefinition
+
+type Filters = typeof filters
+
+function ControlledPicker({
+  initialValue = [],
+  mode = "mixed",
+  onChange = () => {},
+}: {
+  initialValue?: F0FilterTagPickerValue<Filters>
+  mode?: F0FilterTagPickerMode
+  onChange?: (value: F0FilterTagPickerValue<Filters>) => void
+}) {
+  const [value, setValue] =
+    useState<F0FilterTagPickerValue<Filters>>(initialValue)
+
+  return (
+    <>
+      <F0FilterTagPicker
+        filters={filters}
+        value={value}
+        onChange={(nextValue) => {
+          setValue(nextValue)
+          onChange(nextValue)
+        }}
+        label="Who should belong to this team?"
+        mode={mode}
+      />
+      <output data-testid="picker-value">{JSON.stringify(value)}</output>
+      <output data-testid="filters-state">
+        {JSON.stringify(filterTagPickerValueToFiltersState(value))}
+      </output>
+    </>
+  )
+}
+
+async function getEditor(name = "Who should belong to this team?") {
+  return screen.findByRole("combobox", { name })
+}
+
+function moveCaretToEnd(editor: HTMLElement) {
+  const range = document.createRange()
+  range.selectNodeContents(editor)
+  range.collapse(false)
+  const selection = window.getSelection()
+  selection?.removeAllRanges()
+  selection?.addRange(range)
+  fireEvent(document, new Event("selectionchange"))
+}
+
+function moveCaretToStart(editor: HTMLElement) {
+  const range = document.createRange()
+  range.selectNodeContents(editor)
+  range.collapse(true)
+  const selection = window.getSelection()
+  selection?.removeAllRanges()
+  selection?.addRange(range)
+  fireEvent(document, new Event("selectionchange"))
+}
+
+describe("F0FilterTagPicker value", () => {
+  it("merges adjacent text, removes empty text, and derives unique filters", () => {
+    const value: F0FilterTagPickerValue<Filters> = [
+      { type: "text", value: "People " },
+      { type: "text", value: "in " },
+      { type: "text", value: "" },
+      { type: "filter", filterKey: "location", value: "madrid" },
+      { type: "filter", filterKey: "location", value: "madrid" },
+      { type: "filter", filterKey: "role", value: "engineer" },
+    ]
+
+    expect(normalizeFilterTagPickerValue(value)).toEqual([
+      { type: "text", value: "People in " },
+      { type: "filter", filterKey: "location", value: "madrid" },
+      { type: "filter", filterKey: "location", value: "madrid" },
+      { type: "filter", filterKey: "role", value: "engineer" },
+    ])
+    expect(filterTagPickerValueToFiltersState(value)).toEqual({
+      location: ["madrid"],
+      role: ["engineer"],
+    })
+  })
+})
+
+describe("F0FilterTagPicker", () => {
+  it("uses a compact two-line editor by default", async () => {
+    render(<ControlledPicker />)
+
+    const editor = await getEditor()
+    expect(editor.parentElement).toHaveClass("min-h-20")
+    expect(editor.parentElement?.className).toContain(
+      "[&_.ProseMirror]:min-h-[3.75rem]"
+    )
+    expect(editor.parentElement?.parentElement).toHaveClass("min-h-20")
+  })
+
+  it("adds category selections as tags when Apply closes the select", async () => {
+    const user = userEvent.setup()
+    render(<ControlledPicker mode="tags" />)
+
+    await user.click(await screen.findByRole("combobox", { name: "Location" }))
+    fireEvent.animationStart(await screen.findByRole("listbox"))
+    await user.click(await screen.findByText("Madrid"))
+
+    expect(screen.getByTestId("filters-state")).toHaveTextContent("{}")
+
+    await user.click(screen.getByRole("button", { name: "Apply selection" }))
+
+    await waitFor(() => {
+      expect(screen.getByTestId("filters-state")).toHaveTextContent(
+        JSON.stringify({ location: ["madrid"] })
+      )
+    })
+    expect(
+      screen.getByRole("button", { name: "Remove Madrid from Location" })
+    ).toBeInTheDocument()
+  })
+
+  it("commits the draft selection when a category select closes", async () => {
+    const user = userEvent.setup()
+    render(<ControlledPicker mode="tags" />)
+
+    await user.click(await screen.findByRole("combobox", { name: "Role" }))
+    fireEvent.animationStart(await screen.findByRole("listbox"))
+    await user.click(await screen.findByText("Engineer"))
+    await user.keyboard("{Escape}")
+
+    await waitFor(() => {
+      expect(screen.getByTestId("filters-state")).toHaveTextContent(
+        JSON.stringify({ role: ["engineer"] })
+      )
+    })
+  })
+
+  it("emits free text immediately while preserving spaces and line breaks", async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<ControlledPicker onChange={onChange} />)
+
+    const editor = await getEditor()
+    expect(editor.querySelector("[data-placeholder]")).toHaveAttribute(
+      "data-placeholder",
+      "Describe people or type a location, role, team..."
+    )
+    expect(
+      screen.getByText(/Write freely\. Use arrow keys/)
+    ).toBeInTheDocument()
+    await user.click(editor)
+    await user.type(
+      editor,
+      "People in Europe{Shift>}{Enter}{/Shift}who work remotely"
+    )
+
+    expect(onChange).toHaveBeenCalled()
+    expect(screen.getByTestId("picker-value")).toHaveTextContent(
+      JSON.stringify([
+        { type: "text", value: "People in Europe\nwho work remotely" },
+      ])
+    )
+    expect(editor).toHaveFocus()
+  })
+
+  it("uses text only as a transient query in tags mode", async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<ControlledPicker mode="tags" onChange={onChange} />)
+
+    const editor = await getEditor()
+    expect(editor.querySelector("[data-placeholder]")).toHaveAttribute(
+      "data-placeholder",
+      "Search locations, roles, teams..."
+    )
+    expect(
+      screen.getByText(/Type to search\. Use arrow keys/)
+    ).toBeInTheDocument()
+    await user.click(editor)
+    await user.type(editor, "madrid")
+
+    expect(onChange).not.toHaveBeenCalled()
+    expect(
+      await screen.findByRole("option", { name: /Madrid/ })
+    ).toBeInTheDocument()
+    await user.keyboard("{Enter}")
+
+    const expectedValue = [
+      { type: "filter", filterKey: "location", value: "madrid" },
+    ]
+    expect(screen.getByTestId("picker-value")).toHaveTextContent(
+      JSON.stringify(expectedValue)
+    )
+    expect(onChange).toHaveBeenLastCalledWith(expectedValue)
+  })
+
+  it("prevents line breaks and clears an unfinished query on blur in tags mode", async () => {
+    const onChange = vi.fn()
+    const user = userEvent.setup()
+    render(<ControlledPicker mode="tags" onChange={onChange} />)
+
+    const editor = await getEditor()
+    await user.click(editor)
+    await user.type(editor, "unknown")
+    await user.keyboard("{Enter}{Shift>}{Enter}{/Shift}")
+
+    expect(editor).toHaveTextContent("unknown")
+    expect(onChange).not.toHaveBeenCalled()
+
+    fireEvent.blur(editor)
+
+    await waitFor(() => expect(editor).toHaveTextContent(""))
+    expect(screen.getByTestId("picker-value")).toHaveTextContent("[]")
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it("replaces the longest matching phrase with a filter tag", async () => {
+    const user = userEvent.setup()
+    render(<ControlledPicker />)
+
+    const editor = await getEditor()
+    await user.click(editor)
+    await user.type(editor, "People in Customer support")
+
+    expect(
+      await screen.findByRole("option", { name: /Customer support agent/ })
+    ).toBeInTheDocument()
+    await user.keyboard("{Enter}")
+
+    expect(screen.getByTestId("picker-value")).toHaveTextContent(
+      JSON.stringify([
+        { type: "text", value: "People in " },
+        { type: "filter", filterKey: "role", value: "support" },
+        { type: "text", value: " " },
+      ])
+    )
+    expect(screen.getByTestId("filters-state")).toHaveTextContent(
+      JSON.stringify({ role: ["support"] })
+    )
+    expect(
+      screen.getByRole("button", {
+        name: "Remove Customer support agent from Role",
+      })
+    ).toBeInTheDocument()
+  })
+
+  it("navigates the flat results with arrows and selects with Enter", async () => {
+    const user = userEvent.setup()
+    render(<ControlledPicker />)
+
+    const editor = await getEditor()
+    await user.click(editor)
+    await user.type(editor, "a")
+    expect(editor).toHaveAttribute(
+      "aria-activedescendant",
+      screen.getAllByRole("option")[0].id
+    )
+    expect(screen.getAllByRole("option")[0]).toHaveAttribute(
+      "aria-selected",
+      "false"
+    )
+    await user.keyboard("{ArrowDown}{Enter}")
+
+    expect(screen.getByTestId("filters-state")).toHaveTextContent(
+      JSON.stringify({ location: ["madrid"] })
+    )
+  })
+
+  it("wraps upward from the first result", async () => {
+    const user = userEvent.setup()
+    render(<ControlledPicker />)
+
+    const editor = await getEditor()
+    await user.click(editor)
+    await user.type(editor, "d")
+    await user.keyboard("{ArrowUp}{Enter}")
+
+    expect(screen.getByTestId("filters-state")).toHaveTextContent(
+      JSON.stringify({ role: ["designer"] })
+    )
+  })
+
+  it("selects a result with the pointer interaction", async () => {
+    const user = userEvent.setup()
+    render(<ControlledPicker />)
+
+    const editor = await getEditor()
+    await user.click(editor)
+    await user.type(editor, "madrid")
+    await user.click(await screen.findByRole("option", { name: /Madrid/ }))
+
+    expect(screen.getByTestId("picker-value")).toHaveTextContent(
+      JSON.stringify([
+        { type: "filter", filterKey: "location", value: "madrid" },
+        { type: "text", value: " " },
+      ])
+    )
+  })
+
+  it("inserts a line break with Enter when no result is active", async () => {
+    const user = userEvent.setup()
+    render(<ControlledPicker />)
+
+    const editor = await getEditor()
+    await user.click(editor)
+    await user.type(editor, "unmatched{Enter}next")
+
+    expect(screen.getByTestId("picker-value")).toHaveTextContent(
+      JSON.stringify([{ type: "text", value: "unmatched\nnext" }])
+    )
+  })
+
+  it("mixes categories in one flat, color-distinguished list", async () => {
+    const user = userEvent.setup()
+    render(<ControlledPicker />)
+
+    const editor = await getEditor()
+    await user.click(editor)
+    await user.type(editor, "d")
+
+    const listbox = await screen.findByRole("listbox")
+    const options = within(listbox).getAllByRole("option")
+    expect(options.map((option) => option.textContent)).toEqual([
+      expect.stringContaining("Madrid"),
+      expect.stringContaining("Product designer"),
+    ])
+    expect(within(listbox).queryByRole("group")).not.toBeInTheDocument()
+    expect(
+      options.every((option) =>
+        Boolean(option.querySelector('[aria-hidden="true"][style]'))
+      )
+    ).toBe(true)
+  })
+
+  it("matches without accents and omits selected duplicates", async () => {
+    const user = userEvent.setup()
+    render(
+      <ControlledPicker
+        initialValue={[
+          { type: "filter", filterKey: "location", value: "madrid" },
+          { type: "text", value: " and malaga" },
+        ]}
+      />
+    )
+
+    const editor = await getEditor()
+    await user.click(editor)
+    moveCaretToEnd(editor)
+
+    expect(
+      await screen.findByRole("option", { name: /Málaga/ })
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByRole("option", { name: /Madrid/ })
+    ).not.toBeInTheDocument()
+  })
+
+  it("removes inline tags with their X and Backspace", async () => {
+    const user = userEvent.setup()
+    render(
+      <ControlledPicker
+        initialValue={[
+          { type: "text", value: "Based in " },
+          { type: "filter", filterKey: "location", value: "barcelona" },
+          { type: "text", value: " or " },
+          { type: "filter", filterKey: "location", value: "madrid" },
+        ]}
+      />
+    )
+
+    await user.click(
+      await screen.findByRole("button", {
+        name: "Remove Barcelona from Location",
+      })
+    )
+    expect(screen.getByTestId("filters-state")).toHaveTextContent(
+      JSON.stringify({ location: ["madrid"] })
+    )
+    expect(screen.getByTestId("picker-value")).toHaveTextContent(
+      JSON.stringify([
+        { type: "text", value: "Based in or " },
+        { type: "filter", filterKey: "location", value: "madrid" },
+      ])
+    )
+
+    const editor = await getEditor()
+    await user.click(editor)
+    moveCaretToEnd(editor)
+    fireEvent.keyDown(editor, { key: "Backspace" })
+
+    expect(screen.getByTestId("filters-state")).toHaveTextContent("{}")
+    expect(screen.getByTestId("picker-value")).toHaveTextContent(
+      JSON.stringify([{ type: "text", value: "Based in or " }])
+    )
+  })
+
+  it("removes a following tag with Delete", async () => {
+    render(
+      <ControlledPicker
+        initialValue={[
+          { type: "filter", filterKey: "location", value: "madrid" },
+          { type: "text", value: " remains editable" },
+        ]}
+      />
+    )
+
+    const editor = await getEditor()
+    fireEvent.focus(editor)
+    moveCaretToStart(editor)
+    fireEvent.keyDown(editor, { key: "Delete" })
+
+    expect(screen.getByTestId("picker-value")).toHaveTextContent(
+      JSON.stringify([{ type: "text", value: " remains editable" }])
+    )
+  })
+
+  it("keeps the caret active through controlled parent updates", async () => {
+    const user = userEvent.setup()
+    render(<ControlledPicker />)
+
+    const editor = await getEditor()
+    await user.click(editor)
+    await user.type(editor, "A natural sentence")
+    await user.type(editor, " that keeps growing")
+
+    expect(editor).toHaveFocus()
+    expect(screen.getByTestId("picker-value")).toHaveTextContent(
+      JSON.stringify([
+        { type: "text", value: "A natural sentence that keeps growing" },
+      ])
+    )
+  })
+
+  it("reflects externally controlled token updates", async () => {
+    const { rerender } = render(
+      <F0FilterTagPicker
+        filters={filters}
+        value={[]}
+        onChange={vi.fn()}
+        label="Filters"
+      />
+    )
+
+    await screen.findByRole("combobox", { name: "Filters" })
+    rerender(
+      <F0FilterTagPicker
+        filters={filters}
+        value={[
+          { type: "text", value: "A " },
+          { type: "filter", filterKey: "role", value: "designer" },
+        ]}
+        onChange={vi.fn()}
+        label="Filters"
+      />
+    )
+
+    expect(
+      await screen.findByRole("button", {
+        name: "Remove Product designer from Role",
+      })
+    ).toBeInTheDocument()
+    expect(screen.getByRole("combobox", { name: "Filters" })).toHaveTextContent(
+      "A Product designer"
+    )
+  })
+
+  it("closes suggestions with Escape without deleting free text", async () => {
+    const user = userEvent.setup()
+    render(<ControlledPicker />)
+
+    const editor = await getEditor()
+    await user.click(editor)
+    await user.type(editor, "madrid")
+    expect(editor).toHaveAttribute("aria-expanded", "true")
+
+    await user.keyboard("{Escape}")
+
+    expect(editor).toHaveAttribute("aria-expanded", "false")
+    expect(editor).toHaveTextContent("madrid")
+    expect(screen.getByTestId("picker-value")).toHaveTextContent(
+      JSON.stringify([{ type: "text", value: "madrid" }])
+    )
+  })
+
+  it("accepts only plain text when pasting", async () => {
+    const user = userEvent.setup()
+    render(<ControlledPicker />)
+
+    const editor = await getEditor()
+    await user.click(editor)
+    await user.paste("First line\nSecond line")
+
+    expect(screen.getByTestId("picker-value")).toHaveTextContent(
+      JSON.stringify([{ type: "text", value: "First line\nSecond line" }])
+    )
+    expect(editor.querySelector("script")).not.toBeInTheDocument()
+  })
+
+  it("discards rich clipboard markup in favor of text/plain", async () => {
+    render(<ControlledPicker />)
+
+    const editor = await getEditor()
+    fireEvent.focus(editor)
+    fireEvent.paste(editor, {
+      clipboardData: {
+        getData: (type: string) =>
+          type === "text/plain" ? "Safe text" : "<strong>Rich text</strong>",
+      },
+    })
+
+    expect(screen.getByTestId("picker-value")).toHaveTextContent(
+      JSON.stringify([{ type: "text", value: "Safe text" }])
+    )
+    expect(editor.querySelector("strong")).not.toBeInTheDocument()
+  })
+
+  it("waits for IME composition to end before opening suggestions", async () => {
+    const user = userEvent.setup()
+    render(<ControlledPicker />)
+
+    const editor = await getEditor()
+    await user.click(editor)
+    fireEvent.compositionStart(editor)
+    await user.type(editor, "mad")
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+
+    fireEvent.compositionEnd(editor)
+    expect(await screen.findByRole("listbox")).toBeInTheDocument()
+  })
+
+  it("writes hierarchical child selections to their declared filter key", async () => {
+    const hierarchicalFilters = {
+      office: {
+        type: "in",
+        label: "Office",
+        options: {
+          options: [
+            {
+              value: "barcelona-hq",
+              label: "Barcelona HQ",
+              children: {
+                filterKey: "space",
+                options: [{ value: "floor-1", label: "Floor 1" }],
+              },
+            },
+          ],
+        },
+      },
+      space: {
+        type: "in",
+        label: "Space",
+        options: { options: [] },
+      },
+    } satisfies F0FilterTagPickerFiltersDefinition
+    const user = userEvent.setup()
+
+    function HierarchicalPicker() {
+      const [value, setValue] = useState<
+        F0FilterTagPickerValue<typeof hierarchicalFilters>
+      >([])
+      return (
+        <>
+          <F0FilterTagPicker
+            filters={hierarchicalFilters}
+            value={value}
+            onChange={setValue}
+            label="Filters"
+          />
+          <output data-testid="hierarchical-state">
+            {JSON.stringify(filterTagPickerValueToFiltersState(value))}
+          </output>
+        </>
+      )
+    }
+
+    render(<HierarchicalPicker />)
+    const editor = await getEditor("Filters")
+    await user.click(editor)
+    await user.type(editor, "floor")
+    await user.keyboard("{Enter}")
+
+    expect(screen.getByTestId("hierarchical-state")).toHaveTextContent(
+      JSON.stringify({ space: ["floor-1"] })
+    )
+    expect(
+      screen.getByRole("button", {
+        name: "Remove Barcelona HQ › Floor 1 from Office",
+      })
+    ).toBeInTheDocument()
+  })
+
+  it("does not expose hierarchical child keys missing from the filter definition", async () => {
+    const invalidHierarchicalFilters = {
+      office: {
+        type: "in",
+        label: "Office",
+        options: {
+          options: [
+            {
+              value: "barcelona-hq",
+              label: "Barcelona HQ",
+              children: {
+                filterKey: "undeclared-space",
+                options: [{ value: "floor-1", label: "Floor 1" }],
+              },
+            },
+          ],
+        },
+      },
+    } satisfies F0FilterTagPickerFiltersDefinition
+    const user = userEvent.setup()
+
+    render(
+      <F0FilterTagPicker
+        filters={invalidHierarchicalFilters}
+        value={[]}
+        onChange={vi.fn()}
+        label="Filters"
+      />
+    )
+    const editor = await getEditor("Filters")
+    await user.click(editor)
+    await user.type(editor, "floor")
+
+    expect(
+      screen.queryByRole("option", { name: /Floor 1/ })
+    ).not.toBeInTheDocument()
+    await waitFor(() =>
+      expect(editor).toHaveAttribute("aria-expanded", "false")
+    )
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+  })
+
+  it("loads asynchronous options and retries a failed provider", async () => {
+    const loadOptions = vi
+      .fn<() => Promise<Array<{ value: string; label: string }>>>()
+      .mockRejectedValueOnce(new Error("Network unavailable"))
+      .mockResolvedValue([{ value: "platform", label: "Platform" }])
+    const asyncFilters = {
+      team: {
+        type: "in",
+        label: "Team",
+        options: { options: loadOptions },
+      },
+    } satisfies F0FilterTagPickerFiltersDefinition
+    const user = userEvent.setup()
+
+    function AsyncPicker() {
+      const [value, setValue] = useState<
+        F0FilterTagPickerValue<typeof asyncFilters>
+      >([])
+      return (
+        <F0FilterTagPicker
+          filters={asyncFilters}
+          value={value}
+          onChange={setValue}
+          label="Filters"
+        />
+      )
+    }
+
+    render(<AsyncPicker />)
+    const editor = await getEditor("Filters")
+    await user.click(editor)
+    await user.type(editor, "plat")
+
+    const retry = await screen.findByRole("option", { name: "Retry Team" })
+    await user.click(retry)
+
+    expect(
+      await screen.findByRole("option", { name: /Platform/ })
+    ).toBeInTheDocument()
+    expect(loadOptions).toHaveBeenCalledTimes(2)
+  })
+
+  it("announces loading and replaces it with async options", async () => {
+    let resolveOptions: (
+      options: Array<{ value: string; label: string }>
+    ) => void = () => {}
+    const loadingFilters = {
+      team: {
+        type: "in",
+        label: "Team",
+        options: {
+          options: () =>
+            new Promise<Array<{ value: string; label: string }>>((resolve) => {
+              resolveOptions = resolve
+            }),
+        },
+      },
+    } satisfies F0FilterTagPickerFiltersDefinition
+    const user = userEvent.setup()
+
+    function LoadingPicker() {
+      const [value, setValue] = useState<
+        F0FilterTagPickerValue<typeof loadingFilters>
+      >([])
+      return (
+        <F0FilterTagPicker
+          filters={loadingFilters}
+          value={value}
+          onChange={setValue}
+          label="Filters"
+        />
+      )
+    }
+
+    render(<LoadingPicker />)
+    const editor = await getEditor("Filters")
+    await user.click(editor)
+    await user.type(editor, "plat")
+    expect(screen.getByRole("status")).toHaveTextContent("Loading options")
+
+    await act(async () => {
+      resolveOptions([{ value: "platform", label: "Platform" }])
+    })
+
+    expect(
+      await screen.findByRole("option", { name: /Platform/ })
+    ).toBeInTheDocument()
+  })
+
+  it("closes the popover when loading finishes without options", async () => {
+    let resolveOptions: (
+      options: Array<{ value: string; label: string }>
+    ) => void = () => {}
+    const emptyFilters = {
+      team: {
+        type: "in",
+        label: "Team",
+        options: {
+          options: () =>
+            new Promise<Array<{ value: string; label: string }>>((resolve) => {
+              resolveOptions = resolve
+            }),
+        },
+      },
+    } satisfies F0FilterTagPickerFiltersDefinition
+    const user = userEvent.setup()
+
+    function EmptyPicker() {
+      const [value, setValue] = useState<
+        F0FilterTagPickerValue<typeof emptyFilters>
+      >([])
+      return (
+        <F0FilterTagPicker
+          filters={emptyFilters}
+          value={value}
+          onChange={setValue}
+          label="Filters"
+        />
+      )
+    }
+
+    render(<EmptyPicker />)
+    const editor = await getEditor("Filters")
+    await user.click(editor)
+    await user.type(editor, "unknown")
+    expect(screen.getByRole("status")).toHaveTextContent("Loading options")
+
+    await act(async () => resolveOptions([]))
+
+    await waitFor(() =>
+      expect(editor).toHaveAttribute("aria-expanded", "false")
+    )
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument()
+    expect(screen.queryByText("No matching options")).not.toBeInTheDocument()
+  })
+
+  it("searches every remote source only after two debounced characters", async () => {
+    type Employee = { id: number; name: string }
+    const firstFetch = vi.fn(async () => ({
+      records: [{ id: 1, name: "Ada Lovelace" }],
+    }))
+    const secondFetch = vi.fn(async () => ({
+      records: [{ id: 2, name: "Ada Platform" }],
+    }))
+    const sourceFilters = {
+      person: {
+        type: "in",
+        label: "Person",
+        options: {
+          source: createDataSourceDefinition<Employee>({
+            dataAdapter: { fetchData: firstFetch },
+          }),
+          mapOptions: (employee: Employee) => ({
+            value: employee.id,
+            label: employee.name,
+          }),
+        },
+      },
+      owner: {
+        type: "in",
+        label: "Owner",
+        options: {
+          source: createDataSourceDefinition<Employee>({
+            dataAdapter: { fetchData: secondFetch },
+          }),
+          mapOptions: (employee: Employee) => ({
+            value: employee.id,
+            label: employee.name,
+          }),
+        },
+      },
+    } satisfies F0FilterTagPickerFiltersDefinition
+    const user = userEvent.setup()
+
+    function RemotePicker() {
+      const [value, setValue] = useState<
+        F0FilterTagPickerValue<typeof sourceFilters>
+      >([])
+      return (
+        <F0FilterTagPicker
+          filters={sourceFilters}
+          value={value}
+          onChange={setValue}
+          label="Filters"
+        />
+      )
+    }
+
+    render(<RemotePicker />)
+    const editor = await getEditor("Filters")
+    await user.click(editor)
+    await user.type(editor, "a")
+    expect(firstFetch).not.toHaveBeenCalled()
+    expect(secondFetch).not.toHaveBeenCalled()
+
+    await user.type(editor, "d")
+    expect(
+      await screen.findByRole("option", { name: /Ada Lovelace/ })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole("option", { name: /Ada Platform/ })
+    ).toBeInTheDocument()
+    expect(firstFetch).toHaveBeenCalled()
+    expect(secondFetch).toHaveBeenCalled()
+  })
+
+  it("discards results from a stale remote query", async () => {
+    type Employee = { id: number; name: string }
+    const requests = new Map<
+      string,
+      (result: { records: Employee[] }) => void
+    >()
+    const fetchData = vi.fn(
+      ({ search }: { search?: string }) =>
+        new Promise<{ records: Employee[] }>((resolve) => {
+          requests.set(search ?? "", resolve)
+        })
+    )
+    const sourceFilters = {
+      person: {
+        type: "in",
+        label: "Person",
+        options: {
+          source: createDataSourceDefinition<Employee>({
+            dataAdapter: { fetchData },
+          }),
+          mapOptions: (employee: Employee) => ({
+            value: employee.id,
+            label: employee.name,
+          }),
+        },
+      },
+    } satisfies F0FilterTagPickerFiltersDefinition
+    const user = userEvent.setup()
+
+    function RemotePicker() {
+      const [value, setValue] = useState<
+        F0FilterTagPickerValue<typeof sourceFilters>
+      >([])
+      return (
+        <>
+          <F0FilterTagPicker
+            filters={sourceFilters}
+            value={value}
+            onChange={setValue}
+            label="Filters"
+          />
+          <button
+            type="button"
+            onClick={() => setValue([{ type: "text", value: "gr" }])}
+          >
+            Use Grace query
+          </button>
+        </>
+      )
+    }
+
+    render(<RemotePicker />)
+    const editor = await getEditor("Filters")
+    await user.click(editor)
+    await user.type(editor, "ad")
+    await waitFor(() => expect(requests.has("ad")).toBe(true))
+
+    await user.click(screen.getByRole("button", { name: "Use Grace query" }))
+    await user.click(editor)
+    moveCaretToEnd(editor)
+    await waitFor(() => expect(requests.has("gr")).toBe(true))
+
+    await act(async () => {
+      requests.get("gr")?.({ records: [{ id: 2, name: "Grace Hopper" }] })
+    })
+    expect(
+      await screen.findByRole("option", { name: /Grace Hopper/ })
+    ).toBeInTheDocument()
+
+    await act(async () => {
+      requests.get("ad")?.({ records: [{ id: 1, name: "Ada Lovelace" }] })
+    })
+    expect(
+      screen.queryByRole("option", { name: /Ada Lovelace/ })
+    ).not.toBeInTheDocument()
+  })
+
+  it("keeps successful remote results usable and retries a failed source", async () => {
+    type Employee = { id: number; name: string }
+    let shouldFail = true
+    const failingFetch = vi.fn(async () => {
+      if (shouldFail) throw new Error("Network unavailable")
+      return { records: [{ id: 1, name: "Ada Lovelace" }] }
+    })
+    const workingFetch = vi.fn(async () => ({
+      records: [{ id: 2, name: "People Platform" }],
+    }))
+    const sourceFilters = {
+      person: {
+        type: "in",
+        label: "Person",
+        options: {
+          source: createDataSourceDefinition<Employee>({
+            dataAdapter: { fetchData: failingFetch },
+          }),
+          mapOptions: (employee: Employee) => ({
+            value: employee.id,
+            label: employee.name,
+          }),
+        },
+      },
+      team: {
+        type: "in",
+        label: "Team",
+        options: {
+          source: createDataSourceDefinition<Employee>({
+            dataAdapter: { fetchData: workingFetch },
+          }),
+          mapOptions: (employee: Employee) => ({
+            value: employee.id,
+            label: employee.name,
+          }),
+        },
+      },
+    } satisfies F0FilterTagPickerFiltersDefinition
+    const user = userEvent.setup()
+
+    function RemoteErrorPicker() {
+      const [value, setValue] = useState<
+        F0FilterTagPickerValue<typeof sourceFilters>
+      >([])
+      return (
+        <F0FilterTagPicker
+          filters={sourceFilters}
+          value={value}
+          onChange={setValue}
+          label="Filters"
+        />
+      )
+    }
+
+    render(<RemoteErrorPicker />)
+    const editor = await getEditor("Filters")
+    await user.click(editor)
+    await user.type(editor, "pe")
+
+    expect(
+      await screen.findByRole("option", { name: /People Platform/ })
+    ).toBeInTheDocument()
+    shouldFail = false
+    await user.click(screen.getByRole("option", { name: "Retry Person" }))
+
+    expect(
+      await screen.findByRole("option", { name: /Ada Lovelace/ })
+    ).toBeInTheDocument()
+    expect(failingFetch.mock.calls.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it("surfaces a remote mapOptions failure as a retry row", async () => {
+    type Employee = { id: number; name: string }
+    const mappingFilters = {
+      person: {
+        type: "in",
+        label: "Person",
+        options: {
+          source: createDataSourceDefinition<Employee>({
+            dataAdapter: {
+              fetchData: async () => ({
+                records: [{ id: 1, name: "Ada Lovelace" }],
+              }),
+            },
+          }),
+          mapOptions: () => {
+            throw new Error("Invalid record")
+          },
+        },
+      },
+    } satisfies F0FilterTagPickerFiltersDefinition
+    const user = userEvent.setup()
+
+    function MappingErrorPicker() {
+      const [value, setValue] = useState<
+        F0FilterTagPickerValue<typeof mappingFilters>
+      >([])
+      return (
+        <F0FilterTagPicker
+          filters={mappingFilters}
+          value={value}
+          onChange={setValue}
+          label="Filters"
+        />
+      )
+    }
+
+    render(<MappingErrorPicker />)
+    const editor = await getEditor("Filters")
+    await user.click(editor)
+    await user.type(editor, "pe")
+
+    expect(
+      await screen.findByRole("option", { name: "Retry Person" })
+    ).toBeInTheDocument()
+  })
+
+  it("loads another remote page from a flat action row", async () => {
+    type Employee = { id: number; name: string }
+    const fetchData = vi.fn(
+      async ({ pagination }: { pagination: { cursor?: string | null } }) => {
+        const secondPage = pagination.cursor === "next"
+        return {
+          type: "infinite-scroll" as const,
+          cursor: secondPage ? null : "next",
+          perPage: 1,
+          hasMore: !secondPage,
+          records: secondPage
+            ? [{ id: 2, name: "Grace Hopper" }]
+            : [{ id: 1, name: "Ada Lovelace" }],
+          total: 2,
+        }
+      }
+    )
+    const sourceFilters = {
+      person: {
+        type: "in",
+        label: "Person",
+        options: {
+          source: createDataSourceDefinition<Employee>({
+            dataAdapter: {
+              paginationType: "infinite-scroll",
+              perPage: 1,
+              fetchData,
+            },
+          }),
+          mapOptions: (employee: Employee) => ({
+            value: employee.id,
+            label: employee.name,
+          }),
+        },
+      },
+    } satisfies F0FilterTagPickerFiltersDefinition
+    const user = userEvent.setup()
+
+    function PaginatedPicker() {
+      const [value, setValue] = useState<
+        F0FilterTagPickerValue<typeof sourceFilters>
+      >([])
+      return (
+        <>
+          <F0FilterTagPicker
+            filters={sourceFilters}
+            value={value}
+            onChange={setValue}
+            label="Filters"
+          />
+          <output data-testid="paginated-state">
+            {JSON.stringify(filterTagPickerValueToFiltersState(value))}
+          </output>
+        </>
+      )
+    }
+
+    render(<PaginatedPicker />)
+    const editor = await getEditor("Filters")
+    await user.click(editor)
+    await user.type(editor, "pe")
+    await user.click(
+      await screen.findByRole("option", { name: "Load more Person" })
+    )
+    await user.click(
+      await screen.findByRole("option", { name: /Grace Hopper/ })
+    )
+
+    expect(screen.getByTestId("paginated-state")).toHaveTextContent(
+      JSON.stringify({ person: [2] })
+    )
+  })
+
+  it("resolves labels for controlled remote values", async () => {
+    const getLabel = vi.fn(async (value: unknown) =>
+      value === 1 ? "Ada Lovelace" : String(value)
+    )
+    const labelFilters = {
+      person: {
+        type: "in",
+        label: "Person",
+        options: { options: [], getLabel },
+      },
+    } satisfies F0FilterTagPickerFiltersDefinition
+
+    render(
+      <F0FilterTagPicker
+        filters={labelFilters}
+        value={[{ type: "filter", filterKey: "person", value: 1 }]}
+        onChange={() => {}}
+        label="Filters"
+      />
+    )
+
+    expect(
+      await screen.findByRole("button", {
+        name: "Remove Ada Lovelace from Person",
+      })
+    ).toBeInTheDocument()
+    expect(getLabel).toHaveBeenCalledWith(1)
+  })
+
+  it("applies disabled, data test id, and combobox semantics", async () => {
+    render(
+      <F0FilterTagPicker
+        filters={filters}
+        value={[{ type: "filter", filterKey: "location", value: "madrid" }]}
+        onChange={vi.fn()}
+        label="Filters"
+        dataTestId="employee-filter-picker"
+        disabled
+      />
+    )
+
+    const editor = await getEditor("Filters")
+    expect(screen.getByTestId("employee-filter-picker")).toContainElement(
+      editor
+    )
+    expect(editor).toHaveAttribute("contenteditable", "false")
+    expect(editor).toHaveAttribute("aria-autocomplete", "list")
+    expect(editor).toHaveAttribute("aria-expanded", "false")
+    expect(editor).toHaveAttribute("aria-disabled", "true")
+    expect(
+      screen.getByRole("button", { name: "Remove Madrid from Location" })
+    ).toBeDisabled()
+  })
+
+  it("applies a custom placeholder and category color", async () => {
+    const { rerender } = render(
+      <F0FilterTagPicker
+        filters={filters}
+        value={[]}
+        onChange={vi.fn()}
+        label="Filters"
+        placeholder="Describe an audience"
+        categoryColors={{ location: "malibu" }}
+      />
+    )
+
+    const editor = await getEditor("Filters")
+    expect(editor.querySelector("[data-placeholder]")).toHaveAttribute(
+      "data-placeholder",
+      "Describe an audience"
+    )
+
+    rerender(
+      <F0FilterTagPicker
+        filters={filters}
+        value={[{ type: "filter", filterKey: "location", value: "madrid" }]}
+        onChange={vi.fn()}
+        label="Filters"
+        placeholder="Describe an audience"
+        categoryColors={{ location: "malibu" }}
+      />
+    )
+
+    const tag = await screen.findByLabelText("Location: Madrid")
+    expect(tag.querySelector('[aria-hidden="true"]')).toHaveStyle(
+      getCategoryDotStyle("malibu")
+    )
+  })
+})

--- a/packages/react/src/experimental/Forms/F0FilterTagPicker/colorStyles.ts
+++ b/packages/react/src/experimental/Forms/F0FilterTagPicker/colorStyles.ts
@@ -1,0 +1,37 @@
+import type { CSSProperties } from "react"
+
+import { baseColors } from "@factorialco/f0-core"
+
+import { tagDotColors, type NewColor } from "@/components/tags/F0TagDot/types"
+
+export function getDefaultCategoryColors(filterKeys: string[]) {
+  const usedColors = new Set<NewColor>()
+  const colors = new Map<string, NewColor>()
+
+  for (const filterKey of filterKeys) {
+    const hash = Array.from(filterKey).reduce(
+      (total, character) => total + character.charCodeAt(0),
+      0
+    )
+    let colorIndex = hash % tagDotColors.length
+
+    while (
+      usedColors.has(tagDotColors[colorIndex]) &&
+      usedColors.size < tagDotColors.length
+    ) {
+      colorIndex = (colorIndex + 1) % tagDotColors.length
+    }
+
+    const color = tagDotColors[colorIndex]
+    colors.set(filterKey, color)
+    usedColors.add(color)
+  }
+
+  return colors
+}
+
+export function getCategoryDotStyle(color: NewColor): CSSProperties {
+  return {
+    backgroundColor: `hsl(${baseColors[color][50]})`,
+  }
+}

--- a/packages/react/src/experimental/Forms/F0FilterTagPicker/components/CategoryFilterSelect.tsx
+++ b/packages/react/src/experimental/Forms/F0FilterTagPicker/components/CategoryFilterSelect.tsx
@@ -1,0 +1,93 @@
+"use client"
+
+import { useMemo } from "react"
+
+import { F0Select, type F0SelectItemObject } from "@/components/F0Select"
+
+import type { ResolvedFilterTagOption } from "../internal-types"
+import type {
+  F0FilterTagPickerFilterDefinition,
+  F0FilterTagPickerOptionValue,
+} from "../types"
+
+export interface CategoryFilterSelection {
+  filterKey: string
+  value: F0FilterTagPickerOptionValue
+}
+
+interface CategoryFilterSelectProps {
+  definition: F0FilterTagPickerFilterDefinition
+  disabled: boolean
+  loading: boolean
+  onChange: (values: string[], options: F0SelectItemObject<string>[]) => void
+  onOpenChange: (open: boolean) => void
+  options: ResolvedFilterTagOption[]
+  value: string[]
+}
+
+export function encodeCategoryFilterSelection(
+  selection: CategoryFilterSelection
+) {
+  return JSON.stringify(selection)
+}
+
+export function decodeCategoryFilterSelection(
+  selection: string
+): CategoryFilterSelection | null {
+  try {
+    const parsed = JSON.parse(selection) as Partial<CategoryFilterSelection>
+    if (
+      typeof parsed.filterKey !== "string" ||
+      (typeof parsed.value !== "string" && typeof parsed.value !== "number")
+    ) {
+      return null
+    }
+
+    return { filterKey: parsed.filterKey, value: parsed.value }
+  } catch {
+    return null
+  }
+}
+
+export function CategoryFilterSelect({
+  definition,
+  disabled,
+  loading,
+  onChange,
+  onOpenChange,
+  options,
+  value,
+}: CategoryFilterSelectProps) {
+  const selectOptions = useMemo(
+    () =>
+      options.map((option) => ({
+        label: option.displayLabel,
+        value: encodeCategoryFilterSelection({
+          filterKey: option.filterKey,
+          value: option.value,
+        }),
+      })),
+    [options]
+  )
+  const commonProps = {
+    clearable: true,
+    disableSelectAll: true,
+    disabled,
+    hideLabel: true,
+    label: definition.label,
+    multiple: true as const,
+    onChange: (
+      nextValue: string[],
+      _items: unknown[],
+      nextOptions: F0SelectItemObject<string>[]
+    ) => onChange(nextValue, nextOptions),
+    onOpenChange,
+    placeholder: definition.label,
+    preserveSelectionOnDatasetChange: true,
+    showSearchBox: true,
+    size: "sm" as const,
+    value,
+  }
+
+  return <F0Select {...commonProps} loading={loading} options={selectOptions} />
+}

--- a/packages/react/src/experimental/Forms/F0FilterTagPicker/components/FilterOptionsLoader.tsx
+++ b/packages/react/src/experimental/Forms/F0FilterTagPicker/components/FilterOptionsLoader.tsx
@@ -1,0 +1,106 @@
+"use client"
+
+import { useEffect, useMemo } from "react"
+
+import type { InFilterOptionItem } from "@/patterns/OneFilterPicker/filterTypes/InFilter/types"
+
+import { useLoadOptions } from "@/patterns/OneFilterPicker/filterTypes/InFilter/useLoadOptions"
+
+import type {
+  FilterTagOptionsState,
+  ResolvedFilterTagOption,
+} from "../internal-types"
+import type {
+  F0FilterTagPickerFilterDefinition,
+  F0FilterTagPickerOptionValue,
+} from "../types"
+
+interface FilterOptionsLoaderProps {
+  filterKey: string
+  definition: F0FilterTagPickerFilterDefinition
+  search?: string
+  onStateChange: (filterKey: string, state: FilterTagOptionsState) => void
+}
+
+function optionId(filterKey: string, value: F0FilterTagPickerOptionValue) {
+  return `${filterKey}:${typeof value}:${String(value)}`
+}
+
+export function flattenOptions(
+  options: InFilterOptionItem<F0FilterTagPickerOptionValue>[],
+  context: {
+    categoryKey: string
+    categoryLabel: string
+    filterKey: string
+    ancestors: string[]
+  }
+): ResolvedFilterTagOption[] {
+  return options.flatMap((option) => {
+    const path = [...context.ancestors, option.label]
+    const resolvedOption: ResolvedFilterTagOption = {
+      id: optionId(context.filterKey, option.value),
+      categoryKey: context.categoryKey,
+      categoryLabel: context.categoryLabel,
+      filterKey: context.filterKey,
+      label: option.label,
+      displayLabel: path.join(" › "),
+      value: option.value,
+    }
+
+    if (!option.children) {
+      return [resolvedOption]
+    }
+
+    return [
+      resolvedOption,
+      ...flattenOptions(option.children.options, {
+        ...context,
+        filterKey: option.children.filterKey,
+        ancestors: path,
+      }),
+    ]
+  })
+}
+
+export function FilterOptionsLoader({
+  filterKey,
+  definition,
+  search,
+  onStateChange,
+}: FilterOptionsLoaderProps) {
+  const { options, isLoading, error, loadMore, hasMore } = useLoadOptions({
+    schema: definition,
+    search,
+  })
+
+  const resolvedOptions = useMemo(
+    () =>
+      flattenOptions(options, {
+        categoryKey: filterKey,
+        categoryLabel: definition.label,
+        filterKey,
+        ancestors: [],
+      }),
+    [definition.label, filterKey, options]
+  )
+
+  useEffect(() => {
+    onStateChange(filterKey, {
+      options: resolvedOptions,
+      isLoading,
+      error,
+      hasMore,
+      loadMore,
+    })
+  }, [
+    error,
+    filterKey,
+    hasMore,
+    isLoading,
+    loadMore,
+    onStateChange,
+    resolvedOptions,
+  ])
+
+  return null
+}

--- a/packages/react/src/experimental/Forms/F0FilterTagPicker/components/FilterTag.tsx
+++ b/packages/react/src/experimental/Forms/F0FilterTagPicker/components/FilterTag.tsx
@@ -1,0 +1,72 @@
+import type { NewColor } from "@/components/tags/F0TagDot/types"
+
+import { F0Icon } from "@/components/F0Icon"
+import { CrossedCircle } from "@/icons/app"
+import { OneEllipsis } from "@/lib/OneEllipsis"
+import { cn, focusRing } from "@/lib/utils"
+
+import { getCategoryDotStyle } from "../colorStyles"
+
+interface FilterTagProps {
+  categoryLabel: string
+  label: string
+  color: NewColor
+  removeLabel: string
+  disabled?: boolean
+  selected?: boolean
+  onRemove: () => void
+}
+
+export function FilterTag({
+  categoryLabel,
+  label,
+  color,
+  removeLabel,
+  disabled,
+  selected,
+  onRemove,
+}: FilterTagProps) {
+  return (
+    <span
+      className={cn(
+        "group/filter-tag mx-0.5 my-0.5 inline-flex max-w-full items-center gap-0.5 rounded-full border border-solid border-f1-border-secondary py-0.5 pl-1 pr-1 font-medium text-f1-foreground align-middle",
+        selected && "border-f1-border-selected ring-1 ring-f1-special-ring"
+      )}
+      aria-label={`${categoryLabel}: ${label}`}
+      title={`${categoryLabel}: ${label}`}
+    >
+      <span
+        aria-hidden
+        className="m-1 h-2 w-2 shrink-0 rounded-full"
+        style={getCategoryDotStyle(color)}
+      />
+      <OneEllipsis tag="span" lines={1} className="max-w-52 text-base">
+        {label}
+      </OneEllipsis>
+      <span className="mx-1 text-f1-foreground-secondary">·</span>
+      <span className="text-base text-f1-foreground-secondary">
+        {categoryLabel}
+      </span>
+      <button
+        type="button"
+        className={cn(
+          "-mr-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full border-0 bg-transparent p-0 text-f1-icon-secondary opacity-90 transition-[color,opacity] hover:text-f1-icon group-hover/filter-tag:opacity-100 group-focus-within/filter-tag:opacity-100 [@media(pointer:coarse)]:opacity-100 disabled:cursor-not-allowed disabled:text-f1-icon-disabled",
+          focusRing()
+        )}
+        disabled={disabled}
+        onMouseDown={(event) => {
+          event.preventDefault()
+          event.stopPropagation()
+        }}
+        onClick={(event) => {
+          event.preventDefault()
+          event.stopPropagation()
+          onRemove()
+        }}
+      >
+        <F0Icon icon={CrossedCircle} size="sm" aria-hidden />
+        <span className="sr-only">{removeLabel}</span>
+      </button>
+    </span>
+  )
+}

--- a/packages/react/src/experimental/Forms/F0FilterTagPicker/components/FilterTagNode.tsx
+++ b/packages/react/src/experimental/Forms/F0FilterTagPicker/components/FilterTagNode.tsx
@@ -1,0 +1,84 @@
+import { mergeAttributes, Node } from "@tiptap/core"
+import {
+  NodeViewWrapper,
+  ReactNodeViewRenderer,
+  type NodeViewProps,
+} from "@tiptap/react"
+
+import { useI18n } from "@/lib/providers/i18n"
+
+import type { FilterTagNodeAttributes } from "../internal-types"
+
+import { FilterTag } from "./FilterTag"
+
+function FilterTagNodeView({
+  deleteNode,
+  editor,
+  node,
+  selected,
+}: NodeViewProps) {
+  const i18n = useI18n()
+  const attributes = node.attrs as FilterTagNodeAttributes
+
+  return (
+    <NodeViewWrapper as="span" contentEditable={false} className="inline">
+      <FilterTag
+        categoryLabel={attributes.categoryLabel}
+        label={attributes.label}
+        color={attributes.color}
+        removeLabel={i18n.t("filters.tagPicker.removeValue", {
+          value: attributes.label,
+          category: attributes.categoryLabel,
+        })}
+        disabled={!editor.isEditable}
+        selected={selected}
+        onRemove={() => {
+          deleteNode()
+          editor.commands.focus()
+        }}
+      />
+    </NodeViewWrapper>
+  )
+}
+
+export const FilterTagNode = Node.create({
+  name: "filterTag",
+  group: "inline",
+  inline: true,
+  atom: true,
+  selectable: true,
+
+  addAttributes() {
+    return {
+      filterKey: { default: "" },
+      value: { default: "" },
+      categoryKey: { default: "" },
+      categoryLabel: { default: "" },
+      color: { default: "smoke" },
+      label: { default: "" },
+    }
+  },
+
+  parseHTML() {
+    return [{ tag: "span[data-filter-tag]" }]
+  },
+
+  renderHTML({ HTMLAttributes, node }) {
+    const attributes = node.attrs as FilterTagNodeAttributes
+
+    return [
+      "span",
+      mergeAttributes(HTMLAttributes, {
+        "data-filter-tag": "",
+        "data-filter-key": attributes.filterKey,
+        "data-filter-value": String(attributes.value),
+        "data-filter-value-type": typeof attributes.value,
+      }),
+      attributes.label,
+    ]
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(FilterTagNodeView)
+  },
+})

--- a/packages/react/src/experimental/Forms/F0FilterTagPicker/index.tsx
+++ b/packages/react/src/experimental/Forms/F0FilterTagPicker/index.tsx
@@ -1,0 +1,13 @@
+import { experimentalComponent } from "@/lib/experimental"
+
+import { F0FilterTagPicker as F0FilterTagPickerComponent } from "./F0FilterTagPicker"
+
+export * from "./types"
+
+/**
+ * @experimental This component is under active validation and its API may change.
+ */
+export const F0FilterTagPicker = experimentalComponent(
+  "F0FilterTagPicker",
+  F0FilterTagPickerComponent
+)

--- a/packages/react/src/experimental/Forms/F0FilterTagPicker/internal-types.ts
+++ b/packages/react/src/experimental/Forms/F0FilterTagPicker/internal-types.ts
@@ -1,0 +1,39 @@
+import type { NewColor } from "@/components/tags/F0TagDot/types"
+
+import type { F0FilterTagPickerOptionValue } from "./types"
+
+export interface ResolvedFilterTagOption {
+  id: string
+  categoryKey: string
+  categoryLabel: string
+  filterKey: string
+  label: string
+  displayLabel: string
+  value: F0FilterTagPickerOptionValue
+}
+
+export interface FilterTagOptionsState {
+  options: ResolvedFilterTagOption[]
+  isLoading: boolean
+  error: Error | null
+  hasMore: boolean
+  loadMore?: () => void
+}
+
+export interface FilterTagMetadata {
+  categoryKey: string
+  categoryLabel: string
+  color: NewColor
+  label: string
+}
+
+export interface FilterTagNodeAttributes extends FilterTagMetadata {
+  filterKey: string
+  value: F0FilterTagPickerOptionValue
+}
+
+export interface ActiveTextRange {
+  from: number
+  query: string
+  to: number
+}

--- a/packages/react/src/experimental/Forms/F0FilterTagPicker/types.ts
+++ b/packages/react/src/experimental/Forms/F0FilterTagPicker/types.ts
@@ -1,0 +1,83 @@
+import type { NewColor } from "@/components/tags/F0TagDot/types"
+import type { WithDataTestIdProps } from "@/lib/data-testid"
+import type { InFilterDefinition } from "@/patterns/OneFilterPicker/filterTypes"
+import type { FiltersState } from "@/patterns/OneFilterPicker/types"
+
+export type F0FilterTagPickerOptionValue = string | number
+
+export const f0FilterTagPickerModes = ["mixed", "tags"] as const
+export type F0FilterTagPickerMode = (typeof f0FilterTagPickerModes)[number]
+
+export type F0FilterTagPickerFilterDefinition<
+  Value extends F0FilterTagPickerOptionValue = F0FilterTagPickerOptionValue,
+> = InFilterDefinition<Value>
+
+export type F0FilterTagPickerFiltersDefinition = Record<
+  string,
+  F0FilterTagPickerFilterDefinition
+>
+
+export interface F0FilterTagPickerTextToken {
+  /** Free-form text kept verbatim between filter tags. */
+  type: "text"
+  value: string
+}
+
+export type F0FilterTagPickerFilterToken<
+  Filters extends F0FilterTagPickerFiltersDefinition,
+> = {
+  [Key in keyof Filters & string]: Filters[Key] extends InFilterDefinition<
+    infer Value
+  >
+    ? {
+        /** A selected option from one of the supplied filter definitions. */
+        type: "filter"
+        filterKey: Key
+        value: Extract<Value, F0FilterTagPickerOptionValue>
+      }
+    : never
+}[keyof Filters & string]
+
+/** Ordered, implementation-independent representation of the editor content. */
+export type F0FilterTagPickerValue<
+  Filters extends F0FilterTagPickerFiltersDefinition,
+> = Array<F0FilterTagPickerTextToken | F0FilterTagPickerFilterToken<Filters>>
+
+export interface F0FilterTagPickerProps<
+  Filters extends F0FilterTagPickerFiltersDefinition,
+> extends WithDataTestIdProps {
+  /** Available option-based filter categories. */
+  filters: Filters
+  /** Ordered free text and selected filter tokens. */
+  value: F0FilterTagPickerValue<Filters>
+  /** Called immediately whenever text or a filter token changes. */
+  onChange: (value: F0FilterTagPickerValue<Filters>) => void
+  /** Whether free text is persisted alongside tags or used only as a transient search. */
+  mode?: F0FilterTagPickerMode
+  /** Visible and accessible label for the picker. */
+  label: string
+  /** Placeholder shown after the selected tags. */
+  placeholder?: string
+  /** Optional category color overrides. Defaults are stable for each filter key. */
+  categoryColors?: Partial<Record<keyof Filters, NewColor>>
+  /** Prevents searching, browsing, adding, and removing values. */
+  disabled?: boolean
+}
+
+/** Converts the editor value into the shared filters state shape. */
+export function filterTagPickerValueToFiltersState<
+  Filters extends F0FilterTagPickerFiltersDefinition,
+>(value: F0FilterTagPickerValue<Filters>): FiltersState<Filters> {
+  const filtersState: Record<string, F0FilterTagPickerOptionValue[]> = {}
+
+  for (const token of value) {
+    if (token.type !== "filter") continue
+
+    const currentValues = filtersState[token.filterKey] ?? []
+    if (!currentValues.some((item) => Object.is(item, token.value))) {
+      filtersState[token.filterKey] = [...currentValues, token.value]
+    }
+  }
+
+  return filtersState as FiltersState<Filters>
+}

--- a/packages/react/src/experimental/Forms/F0FilterTagPicker/value.ts
+++ b/packages/react/src/experimental/Forms/F0FilterTagPicker/value.ts
@@ -1,0 +1,151 @@
+import type { JSONContent } from "@tiptap/core"
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model"
+
+import type { FilterTagNodeAttributes } from "./internal-types"
+import type {
+  F0FilterTagPickerFilterToken,
+  F0FilterTagPickerFiltersDefinition,
+  F0FilterTagPickerMode,
+  F0FilterTagPickerValue,
+} from "./types"
+
+export function normalizeFilterTagPickerValue<
+  Filters extends F0FilterTagPickerFiltersDefinition,
+>(value: F0FilterTagPickerValue<Filters>): F0FilterTagPickerValue<Filters> {
+  const normalized: F0FilterTagPickerValue<Filters> = []
+
+  for (const token of value) {
+    if (token.type === "text") {
+      if (!token.value) continue
+
+      const previous = normalized.at(-1)
+      if (previous?.type === "text") {
+        previous.value += token.value
+      } else {
+        normalized.push({ type: "text", value: token.value })
+      }
+      continue
+    }
+
+    normalized.push({ ...token })
+  }
+
+  return normalized
+}
+
+export function normalizeFilterTagPickerValueForMode<
+  Filters extends F0FilterTagPickerFiltersDefinition,
+>(
+  value: F0FilterTagPickerValue<Filters>,
+  mode: F0FilterTagPickerMode
+): F0FilterTagPickerValue<Filters> {
+  const normalized = normalizeFilterTagPickerValue(value)
+  return mode === "tags"
+    ? normalized.filter((token) => token.type === "filter")
+    : normalized
+}
+
+export function areFilterTagPickerValuesEqual<
+  Filters extends F0FilterTagPickerFiltersDefinition,
+>(
+  first: F0FilterTagPickerValue<Filters>,
+  second: F0FilterTagPickerValue<Filters>
+) {
+  return (
+    JSON.stringify(normalizeFilterTagPickerValue(first)) ===
+    JSON.stringify(normalizeFilterTagPickerValue(second))
+  )
+}
+
+function textToEditorContent(value: string): JSONContent[] {
+  const lines = value.split("\n")
+
+  return lines.flatMap((line, index) => {
+    const content: JSONContent[] = []
+    if (line) content.push({ type: "text", text: line })
+    if (index < lines.length - 1) content.push({ type: "hardBreak" })
+    return content
+  })
+}
+
+export function filterTagPickerValueToEditorContent<
+  Filters extends F0FilterTagPickerFiltersDefinition,
+>(
+  value: F0FilterTagPickerValue<Filters>,
+  getTagAttributes: (
+    filterKey: string,
+    value: string | number
+  ) => FilterTagNodeAttributes
+): JSONContent {
+  const content = normalizeFilterTagPickerValue(value).flatMap<JSONContent>(
+    (token) => {
+      if (token.type === "text") return textToEditorContent(token.value)
+
+      return [
+        {
+          type: "filterTag",
+          attrs: getTagAttributes(token.filterKey, token.value),
+        },
+      ]
+    }
+  )
+
+  return {
+    type: "doc",
+    content: [{ type: "paragraph", content }],
+  }
+}
+
+export function editorDocumentToFilterTagPickerValue<
+  Filters extends F0FilterTagPickerFiltersDefinition,
+>(
+  document: ProseMirrorNode,
+  validFilterKeys: ReadonlySet<keyof Filters & string>
+): F0FilterTagPickerValue<Filters> {
+  const value: F0FilterTagPickerValue<Filters> = []
+
+  const appendText = (text: string) => {
+    if (!text) return
+
+    const previous = value.at(-1)
+    if (previous?.type === "text") {
+      previous.value += text
+    } else {
+      value.push({ type: "text", value: text })
+    }
+  }
+
+  document.forEach((block, _offset, blockIndex) => {
+    if (blockIndex > 0) appendText("\n")
+
+    block.forEach((node) => {
+      if (node.isText) {
+        appendText(node.text ?? "")
+        return
+      }
+
+      if (node.type.name === "hardBreak") {
+        appendText("\n")
+        return
+      }
+
+      if (node.type.name === "filterTag") {
+        const filterKey = node.attrs.filterKey
+        if (
+          typeof filterKey !== "string" ||
+          !validFilterKeys.has(filterKey as keyof Filters & string)
+        ) {
+          return
+        }
+
+        value.push({
+          type: "filter",
+          filterKey: filterKey as keyof Filters & string,
+          value: node.attrs.value as string | number,
+        } as unknown as F0FilterTagPickerFilterToken<Filters>)
+      }
+    })
+  })
+
+  return normalizeFilterTagPickerValue(value)
+}

--- a/packages/react/src/experimental/Forms/exports.tsx
+++ b/packages/react/src/experimental/Forms/exports.tsx
@@ -7,3 +7,4 @@ export * from "../../components/CardSelectable"
  */
 export * from "../../deprecated/EntitySelect/exports"
 export * from "./Fields/exports"
+export * from "./F0FilterTagPicker"

--- a/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
+++ b/packages/react/src/lib/providers/i18n/i18n-provider-defaults.ts
@@ -153,6 +153,22 @@ export const defaultTranslations = {
     inFilter: {
       searchPlaceholder: "Search options...",
     },
+    tagPicker: {
+      searchPlaceholder: "Describe people or type a location, role, team...",
+      tagsPlaceholder: "Search locations, roles, teams...",
+      availableOptions: "Available filter options",
+      removeValue: "Remove {{value}} from {{category}}",
+      loadingOptions: "Loading options...",
+      failedToLoad: "Failed to load {{category}} options",
+      retryCategory: "Retry {{category}}",
+      loadMoreCategory: "Load more {{category}}",
+      keyboardHint:
+        "Write freely. Use arrow keys to navigate suggestions, Enter to add a filter, Shift+Enter to insert a line break, Escape to close, and Backspace or Delete to remove tags.",
+      keyboardHintTags:
+        "Type to search. Use arrow keys to navigate suggestions, Enter to add a filter, Escape to close, and Backspace or Delete to remove tags.",
+      added: "{{value}} added to {{category}}",
+      removed: "{{value}} removed from {{category}}",
+    },
     activeFilters: "Active filters: {{filters}}",
     filteringBy: "Filtering by {{label}}",
     availableFilters: "Available filters",
@@ -528,6 +544,7 @@ export const defaultTranslations = {
     searchPlaceholder: "Search messages",
     closeSearch: "Close search",
     noResults: "No chats found",
+    online: "Online",
     backToLatest: "Jump to latest",
     muted: "Muted",
     mute: "Mute",

--- a/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/useLoadOptions.ts
+++ b/packages/react/src/patterns/OneFilterPicker/filterTypes/InFilter/useLoadOptions.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 
 import { RecordType, useData, useDataSource } from "@/hooks/datasource"
 
@@ -135,8 +135,27 @@ export function useLoadOptions<T, R extends RecordType = RecordType>({
     [source]
   )
 
-  const { data, isInitialLoading, loadMore, isLoadingMore, paginationInfo } =
-    useData({ ...dataSource, currentSearch: search }, {}, [source])
+  const {
+    data,
+    error: dataError,
+    isInitialLoading,
+    loadMore,
+    isLoadingMore,
+    paginationInfo,
+  } = useData({ ...dataSource, currentSearch: search }, {}, [source])
+
+  const sourceError = useMemo(() => {
+    if (!dataError) {
+      return null
+    }
+
+    const result = new Error(dataError.message)
+    if (dataError.cause !== undefined) {
+      const resultWithCause = result as Error & { cause?: unknown }
+      resultWithCause.cause = dataError.cause
+    }
+    return result
+  }, [dataError])
 
   const materializeOptions = useCallback(
     async (clearCache = false) => {
@@ -198,7 +217,7 @@ export function useLoadOptions<T, R extends RecordType = RecordType>({
   return {
     options,
     isLoading: isActuallyLoading,
-    error,
+    error: source ? (sourceError ?? error) : error,
     setOptions,
     loadOptions: materializeOptions,
     loadMore: source ? loadMore : undefined,

--- a/vendor/skills/f0-docs/references/component-status.md
+++ b/vendor/skills/f0-docs/references/component-status.md
@@ -4,7 +4,7 @@ This file tracks which components in `packages/react/src/components/` have MDX d
 
 Use this as a prioritization guide when deciding what to document next.
 
-**Last reviewed: 2026-04-08** — Update this date whenever you add or improve an MDX file.
+**Last reviewed: 2026-07-31** — Update this date whenever you add or improve an MDX file.
 
 ---
 
@@ -129,6 +129,7 @@ This file uses the shared documentation quality scale from `documentation-qualit
 | Component            | MDX File | Quality  | Notes        |
 | -------------------- | -------- | -------- | ------------ |
 | `Navigation/Sidebar` | None     | **None** | Flat stories |
+| `Navigation/Sidebar/ChatList` | `patterns/Navigation/Sidebar/Chats/index.mdx` | **Good** | Includes combined conversation statuses |
 
 ---
 


### PR DESCRIPTION
## Description

Adds `F0FilterTagPicker` as a new experimental form component without changing `F0FilterPickerContent`. It supports an inline TipTap editor with filter tags, optional free text, flat searchable suggestions, keyboard interaction, and category multiselects kept in sync with the inline tags.

The component supports local, asynchronous, remote, paginated, and hierarchical `in` filter options. Its ordered token value preserves free text for future processing and can be converted to the shared `FiltersState` shape. Stories cover Teams, Workplace, Location, and employee Role without Storybook play functions.

## Type of change

- [x] New component
- [x] Documentation

## Lifecycle phase

Added under `experimental/` following the F0 component lifecycle.

## Tests

- `pnpm --filter @factorialco/f0-react tsc --noEmit`
- `pnpm lint -- src/experimental/Forms/F0FilterTagPicker src/experimental/Forms/exports.tsx src/lib/providers/i18n/i18n-provider-defaults.ts src/patterns/OneFilterPicker/filterTypes/InFilter/useLoadOptions.ts`
- `pnpm --filter @factorialco/f0-react vitest --run src/experimental/Forms/F0FilterTagPicker/__tests__/F0FilterTagPicker.test.tsx` — 35 passed
- `pnpm exec oxfmt --check` on all changed files
- Pre-commit cycle dependency checks

## Implementation details

- Exposes mixed text and tags-only modes with controlled ordered tokens.
- Provides a flat caret-anchored result popover with DotTag styling.
- Keeps the inline editor and category F0Select multiselects synchronized.
- Handles keyboard selection, deletion, paste, IME, remote debounce, stale responses, retry, and pagination.
- Exports `filterTagPickerValueToFiltersState`.

---
> Factorial is conducting an analysis on the impact of the used skills. This was autogenerated, please do not delete:
> - factorial-pr
> - factorial-f0