### PR TITLE
refactor(emoji): use button trigger in picker

### DIFF
--- a/packages/react/src/experimental/Actions/F0EmojiPicker/F0EmojiPicker.tsx
+++ b/packages/react/src/experimental/Actions/F0EmojiPicker/F0EmojiPicker.tsx
@@ -16,17 +16,6 @@ const EMOJI_BUTTON_RADIUS = "10px"
 const EMOJI_SIZE = 24
 const MAX_FREQUENT_ROWS = 2
 
-const EMOJI_PICKER_STYLE = {
-  "--background-rgb": "255, 255, 255",
-  "--border-radius": "12px",
-  "--category-icon-size": "20px",
-  "--font-size": "14px",
-  "--rgb-accent": "1, 22, 55",
-  "--rgb-background": "255, 255, 255",
-  "--rgb-color": "1, 22, 55",
-  "--rgb-input": "255, 255, 255",
-} as CSSProperties
-
 const LIGHT_SURFACE_STYLE = {
   "--neutral-0": "0 0% 100%",
   "--neutral-5": "220 88% 17% / 0.04",
@@ -35,6 +24,18 @@ const LIGHT_SURFACE_STYLE = {
   "--neutral-30": "213 87% 15% / 0.2",
   "--neutral-40": "219 97% 15% / 0.45",
   "--neutral-100": "218 48% 10%",
+} as CSSProperties
+
+const EMOJI_PICKER_STYLE = {
+  ...LIGHT_SURFACE_STYLE,
+  "--background-rgb": "255, 255, 255",
+  "--border-radius": "12px",
+  "--category-icon-size": "20px",
+  "--font-size": "14px",
+  "--rgb-accent": "1, 22, 55",
+  "--rgb-background": "255, 255, 255",
+  "--rgb-color": "1, 22, 55",
+  "--rgb-input": "255, 255, 255",
 } as CSSProperties
 
 export const F0EmojiPicker = ({
@@ -96,11 +97,11 @@ export const F0EmojiPicker = ({
         collisionPadding={16}
         aria-label={label}
         style={EMOJI_PICKER_STYLE}
-        className="flex h-[min(500px,var(--radix-popover-content-available-height))] w-fit flex-col !overflow-y-auto rounded-xl border-none bg-transparent p-0 shadow-none [&>div:first-child]:min-h-0 [&>div:first-child]:flex-1 [&>div:first-child]:overflow-hidden [&_em-emoji-picker]:!h-full [&_em-emoji-picker]:!min-h-0 [&_em-emoji-picker]:!max-h-[min(451px,calc(100vh-81px))] [&_em-emoji-picker]:!w-[372px] [&_em-emoji-picker]:!max-w-[calc(100vw-32px)] [@media(max-height:320px)]:[&>div:first-child]:!min-h-[230px] [@media(max-height:320px)]:[&_em-emoji-picker]:!min-h-[230px]"
+        className="flex w-fit flex-col !overflow-y-auto rounded-md border-none p-0 shadow-none [&>div:first-child]:min-h-0 [&>div:first-child]:overflow-hidden [&_em-emoji-picker]:!h-full [&_em-emoji-picker]:!min-h-0 [&_em-emoji-picker]:!max-h-[min(451px,calc(100vh-81px))] [&_em-emoji-picker]:!w-[372px] [&_em-emoji-picker]:!max-w-[calc(100vw-32px)] [@media(max-height:320px)]:[&>div:first-child]:!min-h-[230px] [@media(max-height:320px)]:[&_em-emoji-picker]:!min-h-[230px]"
       >
         <EmojiPicker
           className={cn(
-            "box-border border border-solid border-[rgba(1,22,55,0.2)] shadow-none [--color-border-over:rgba(1,22,55,0.2)] [--color-border:rgba(1,22,55,0.08)] [--shadow:none]",
+            "box-border border border-solid border-f1-border-secondary shadow-none [--color-border-over:rgba(1,22,55,0.2)] [--color-border:rgba(1,22,55,0.08)] [--shadow:none]",
             hasClearAction && "rounded-b-none border-b-0"
           )}
           data={data}
@@ -121,7 +122,7 @@ export const F0EmojiPicker = ({
         />
         {hasClearAction ? (
           <div
-            className="flex items-center justify-end rounded-b-md border border-solid border-[rgba(1,22,55,0.2)] border-t-[rgba(1,22,55,0.1)] bg-[rgb(255,255,255)] p-2 [@media(max-height:320px)]:px-1 [@media(max-height:320px)]:py-0"
+            className="flex items-center justify-end rounded-b-md border border-solid border-f1-border-secondary border-t-f1-border-secondary p-2 [@media(max-height:320px)]:px-1 [@media(max-height:320px)]:py-0"
             style={LIGHT_SURFACE_STYLE}
           >
             <F0Button

--- a/packages/react/src/experimental/Actions/F0EmojiPicker/F0EmojiPicker.tsx
+++ b/packages/react/src/experimental/Actions/F0EmojiPicker/F0EmojiPicker.tsx
@@ -85,7 +85,7 @@ export const F0EmojiPicker = ({
         align="start"
         aria-label={label}
         style={EMOJI_PICKER_STYLE}
-        className="flex h-[min(500px,var(--radix-popover-content-available-height))] w-fit flex-col !overflow-hidden border-none bg-transparent p-4 shadow-none [&>div:first-child]:min-h-0 [&>div:first-child]:flex-1 [&>div:first-child]:overflow-hidden [&_em-emoji-picker]:!h-full [&_em-emoji-picker]:!max-h-[min(451px,calc(100vh-81px))] [&_em-emoji-picker]:!w-[372px] [&_em-emoji-picker]:!max-w-[calc(100vw-32px)]"
+        className="flex h-[min(500px,var(--radix-popover-content-available-height))] w-fit flex-col !overflow-hidden border-none bg-transparent p-4 shadow-none [&>div:first-child]:min-h-0 [&>div:first-child]:flex-1 [&>div:first-child]:overflow-hidden [&_em-emoji-picker]:box-border [&_em-emoji-picker]:!h-full [&_em-emoji-picker]:!max-h-[min(451px,calc(100vh-81px))] [&_em-emoji-picker]:!w-[372px] [&_em-emoji-picker]:!max-w-[calc(100vw-32px)] [&_em-emoji-picker]:rounded-xl [&_em-emoji-picker]:border [&_em-emoji-picker]:border-f1-border"
       >
         <EmojiPicker
           data={data}

--- a/packages/react/src/experimental/Actions/F0EmojiPicker/F0EmojiPicker.tsx
+++ b/packages/react/src/experimental/Actions/F0EmojiPicker/F0EmojiPicker.tsx
@@ -85,9 +85,10 @@ export const F0EmojiPicker = ({
         align="start"
         aria-label={label}
         style={EMOJI_PICKER_STYLE}
-        className="flex h-[min(500px,var(--radix-popover-content-available-height))] w-fit flex-col !overflow-hidden border-none bg-transparent p-4 shadow-none [&>div:first-child]:min-h-0 [&>div:first-child]:flex-1 [&>div:first-child]:overflow-hidden [&_em-emoji-picker]:box-border [&_em-emoji-picker]:!h-full [&_em-emoji-picker]:!max-h-[min(451px,calc(100vh-81px))] [&_em-emoji-picker]:!w-[372px] [&_em-emoji-picker]:!max-w-[calc(100vw-32px)] [&_em-emoji-picker]:rounded-xl [&_em-emoji-picker]:border [&_em-emoji-picker]:border-f1-border"
+        className="flex h-[min(500px,var(--radix-popover-content-available-height))] w-fit flex-col !overflow-hidden border-none bg-transparent p-4 shadow-none [&>div:first-child]:min-h-0 [&>div:first-child]:flex-1 [&>div:first-child]:overflow-hidden [&_em-emoji-picker]:!h-full [&_em-emoji-picker]:!max-h-[min(451px,calc(100vh-81px))] [&_em-emoji-picker]:!w-[372px] [&_em-emoji-picker]:!max-w-[calc(100vw-32px)]"
       >
         <EmojiPicker
+          className="box-border border border-solid border-f1-border-hover"
           data={data}
           onEmojiSelect={handleEmojiSelect}
           locale={locale}

--- a/packages/react/src/experimental/Actions/F0EmojiPicker/F0EmojiPicker.tsx
+++ b/packages/react/src/experimental/Actions/F0EmojiPicker/F0EmojiPicker.tsx
@@ -6,6 +6,7 @@ import { F0Button } from "@/components/F0Button"
 import { Reaction } from "@/icons/app"
 import { EmojiPicker } from "@/lib/EmojiPicker"
 import { useI18n } from "@/lib/providers/i18n"
+import { cn } from "@/lib/utils"
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover"
 
 import type { F0EmojiPickerProps } from "./types"
@@ -19,14 +20,21 @@ const EMOJI_PICKER_STYLE = {
   "--background-rgb": "255, 255, 255",
   "--border-radius": "12px",
   "--category-icon-size": "20px",
-  "--color-border-over": "hsl(var(--neutral-10))",
-  "--color-border": "hsl(var(--neutral-10))",
   "--font-size": "14px",
   "--rgb-accent": "1, 22, 55",
   "--rgb-background": "255, 255, 255",
   "--rgb-color": "1, 22, 55",
   "--rgb-input": "255, 255, 255",
-  "--shadow": "0px 4px 20px 0px #0d162514",
+} as CSSProperties
+
+const LIGHT_SURFACE_STYLE = {
+  "--neutral-0": "0 0% 100%",
+  "--neutral-5": "220 88% 17% / 0.04",
+  "--neutral-10": "216 89% 18% / 0.06",
+  "--neutral-20": "214 70% 20% / 0.1",
+  "--neutral-30": "213 87% 15% / 0.2",
+  "--neutral-40": "219 97% 15% / 0.45",
+  "--neutral-100": "218 48% 10%",
 } as CSSProperties
 
 export const F0EmojiPicker = ({
@@ -63,6 +71,8 @@ export const F0EmojiPicker = ({
     setIsOpen(false)
   }
 
+  const hasClearAction = clearable && Boolean(selectedEmoji)
+
   return (
     <Popover
       open={!disabled && isOpen}
@@ -83,12 +93,16 @@ export const F0EmojiPicker = ({
       <PopoverContent
         side="bottom"
         align="start"
+        collisionPadding={16}
         aria-label={label}
         style={EMOJI_PICKER_STYLE}
-        className="flex h-[min(500px,var(--radix-popover-content-available-height))] w-fit flex-col !overflow-hidden border-none bg-transparent p-4 shadow-none [&>div:first-child]:min-h-0 [&>div:first-child]:flex-1 [&>div:first-child]:overflow-hidden [&_em-emoji-picker]:!h-full [&_em-emoji-picker]:!max-h-[min(451px,calc(100vh-81px))] [&_em-emoji-picker]:!w-[372px] [&_em-emoji-picker]:!max-w-[calc(100vw-32px)]"
+        className="flex h-[min(500px,var(--radix-popover-content-available-height))] w-fit flex-col !overflow-y-auto rounded-xl border-none bg-transparent p-0 shadow-none [&>div:first-child]:min-h-0 [&>div:first-child]:flex-1 [&>div:first-child]:overflow-hidden [&_em-emoji-picker]:!h-full [&_em-emoji-picker]:!min-h-0 [&_em-emoji-picker]:!max-h-[min(451px,calc(100vh-81px))] [&_em-emoji-picker]:!w-[372px] [&_em-emoji-picker]:!max-w-[calc(100vw-32px)] [@media(max-height:320px)]:[&>div:first-child]:!min-h-[230px] [@media(max-height:320px)]:[&_em-emoji-picker]:!min-h-[230px]"
       >
         <EmojiPicker
-          className="box-border border border-solid border-f1-border-hover"
+          className={cn(
+            "box-border border border-solid border-[rgba(1,22,55,0.2)] shadow-none [--color-border-over:rgba(1,22,55,0.2)] [--color-border:rgba(1,22,55,0.08)] [--shadow:none]",
+            hasClearAction && "rounded-b-none border-b-0"
+          )}
           data={data}
           onEmojiSelect={handleEmojiSelect}
           locale={locale}
@@ -105,8 +119,11 @@ export const F0EmojiPicker = ({
           navPosition="top"
           dynamicWidth
         />
-        {clearable && selectedEmoji ? (
-          <div className="border-neutral-10 flex items-end justify-end border-t px-2 pt-1">
+        {hasClearAction ? (
+          <div
+            className="flex items-center justify-end rounded-b-md border border-solid border-[rgba(1,22,55,0.2)] border-t-[rgba(1,22,55,0.1)] bg-[rgb(255,255,255)] p-2 [@media(max-height:320px)]:px-1 [@media(max-height:320px)]:py-0"
+            style={LIGHT_SURFACE_STYLE}
+          >
             <F0Button
               label={i18n.actions.clear}
               variant="outline"

--- a/packages/react/src/experimental/Actions/F0EmojiPicker/F0EmojiPicker.tsx
+++ b/packages/react/src/experimental/Actions/F0EmojiPicker/F0EmojiPicker.tsx
@@ -2,37 +2,19 @@ import data from "@emoji-mart/data/sets/15/twitter.json"
 import { useControllableState } from "@radix-ui/react-use-controllable-state"
 import { type CSSProperties, useEffect, useState } from "react"
 
-import { F0AvatarIcon } from "@/components/avatars/F0AvatarIcon"
 import { F0Button } from "@/components/F0Button"
 import { Reaction } from "@/icons/app"
 import { EmojiPicker } from "@/lib/EmojiPicker"
-import { EmojiImage, type EmojiImageProps } from "@/lib/emojis"
 import { useI18n } from "@/lib/providers/i18n"
-import { cn, focusRing } from "@/lib/utils"
 import { Popover, PopoverContent, PopoverTrigger } from "@/ui/popover"
 
-import type { F0EmojiPickerProps, F0EmojiPickerSize } from "./types"
+import type { F0EmojiPickerProps } from "./types"
 
 const EMOJI_BUTTON_SIZE = 36
 const EMOJI_BUTTON_RADIUS = "10px"
 const EMOJI_SIZE = 24
 const MAX_FREQUENT_ROWS = 2
-const TRIGGER_CLASSES = {
-  sm: "rounded-sm",
-  md: "rounded-md",
-  lg: "rounded-lg",
-}
-const SELECTED_AVATAR_CLASSES = {
-  sm: "size-6 rounded-sm",
-  md: "size-8 rounded",
-  lg: "size-10 rounded-md",
-}
-const SELECTED_EMOJI_SIZES: Record<F0EmojiPickerSize, EmojiImageProps["size"]> =
-  {
-    sm: "xs",
-    md: "sm",
-    lg: "md",
-  }
+
 const EMOJI_PICKER_STYLE = {
   "--background-rgb": "255, 255, 255",
   "--border-radius": "12px",
@@ -87,41 +69,23 @@ export const F0EmojiPicker = ({
       onOpenChange={disabled ? undefined : setIsOpen}
     >
       <PopoverTrigger asChild>
-        <button
-          type="button"
+        <F0Button
+          emoji={selectedEmoji ?? undefined}
+          label={label}
           aria-label={selectedEmoji ? `${label}: ${selectedEmoji}` : label}
-          title={label}
+          variant="outline"
+          size={size}
+          hideLabel
           disabled={disabled}
-          className={cn(
-            "disabled:cursor-not-allowed disabled:opacity-30",
-            TRIGGER_CLASSES[size],
-            focusRing()
-          )}
-        >
-          {selectedEmoji ? (
-            <div
-              className={cn(
-                "flex aspect-square items-center justify-center border border-solid border-f1-border-secondary bg-f1-background-inverse-secondary dark:bg-f1-background-tertiary",
-                SELECTED_AVATAR_CLASSES[size]
-              )}
-            >
-              <EmojiImage
-                emoji={selectedEmoji}
-                size={SELECTED_EMOJI_SIZES[size]}
-                alt=""
-              />
-            </div>
-          ) : (
-            <F0AvatarIcon icon={Reaction} size={size} />
-          )}
-        </button>
+          icon={!selectedEmoji ? Reaction : undefined}
+        />
       </PopoverTrigger>
       <PopoverContent
         side="bottom"
         align="start"
         aria-label={label}
         style={EMOJI_PICKER_STYLE}
-        className="flex h-[min(500px,var(--radix-popover-content-available-height))] w-fit flex-col !overflow-hidden border-none bg-transparent p-2 shadow-none [&>div:first-child]:min-h-0 [&>div:first-child]:flex-1 [&>div:first-child]:overflow-hidden [&_em-emoji-picker]:!h-full [&_em-emoji-picker]:!w-[372px] [&_em-emoji-picker]:!max-w-[calc(100vw-32px)] [&_em-emoji-picker]:!max-h-[min(451px,calc(100vh-81px))]"
+        className="flex h-[min(500px,var(--radix-popover-content-available-height))] w-fit flex-col !overflow-hidden border-none bg-transparent p-4 shadow-none [&>div:first-child]:min-h-0 [&>div:first-child]:flex-1 [&>div:first-child]:overflow-hidden [&_em-emoji-picker]:!h-full [&_em-emoji-picker]:!max-h-[min(451px,calc(100vh-81px))] [&_em-emoji-picker]:!w-[372px] [&_em-emoji-picker]:!max-w-[calc(100vw-32px)]"
       >
         <EmojiPicker
           data={data}
@@ -141,10 +105,10 @@ export const F0EmojiPicker = ({
           dynamicWidth
         />
         {clearable && selectedEmoji ? (
-          <div className="flex shrink-0 justify-end border-0 border-t border-solid border-[#e5e7eb] bg-white pt-2 [&_button]:!text-[#011637] [&_button:hover]:!bg-[#f5f6f8]">
+          <div className="border-neutral-10 flex items-end justify-end border-t px-2 pt-1">
             <F0Button
               label={i18n.actions.clear}
-              variant="ghost"
+              variant="outline"
               size="sm"
               onClick={handleClear}
             />

--- a/packages/react/src/experimental/Actions/F0EmojiPicker/__stories__/F0EmojiPicker.mdx
+++ b/packages/react/src/experimental/Actions/F0EmojiPicker/__stories__/F0EmojiPicker.mdx
@@ -298,6 +298,9 @@ Clearable instances add a footer action whenever they have a value.
 - WHEN `clearable={true}` and an emoji is selected → THEN a localized clear
   action is shown; activating it calls `onChange(null)`, closes the popover and
   restores the Reaction fallback in uncontrolled usage.
+- WHEN the available viewport is at most 320 px high → THEN the picker keeps
+  search, category navigation, emoji options and the clear action inside one
+  vertically scrollable popover without remounting or losing focus.
 
 ### Usage examples
 
@@ -316,6 +319,10 @@ Clearable instances add a footer action whenever they have a value.
 **Allow an optional emoji to be removed**
 
 <Canvas of={Stories.Clearable} />
+
+**Keep every action available with high zoom or a short viewport**
+
+<Canvas of={Stories.CompactHeight} />
 
 **Compare default, selected and disabled states**
 

--- a/packages/react/src/experimental/Actions/F0EmojiPicker/__stories__/F0EmojiPicker.stories.tsx
+++ b/packages/react/src/experimental/Actions/F0EmojiPicker/__stories__/F0EmojiPicker.stories.tsx
@@ -154,6 +154,33 @@ export const Clearable: Story = {
   },
 }
 
+export const CompactHeight: Story = {
+  tags: ["no-sidebar"],
+  args: {
+    clearable: true,
+    defaultValue: "💬",
+  },
+  parameters: {
+    viewport: {
+      options: {
+        compactHeight: {
+          name: "Compact height",
+          styles: {
+            width: "320px",
+            height: "256px",
+          },
+        },
+      },
+    },
+  },
+  globals: {
+    viewport: {
+      value: "compactHeight",
+      isRotated: false,
+    },
+  },
+}
+
 export const ClearableInteraction: Story = {
   tags: ["no-sidebar"],
   args: {

--- a/packages/react/src/experimental/Actions/F0EmojiPicker/__stories__/F0EmojiPicker.stories.tsx
+++ b/packages/react/src/experimental/Actions/F0EmojiPicker/__stories__/F0EmojiPicker.stories.tsx
@@ -64,7 +64,11 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-export const Default: Story = {}
+export const Default: Story = {
+  args: {
+    clearable: true,
+  },
+}
 
 const ControlledExample = () => {
   const [emoji, setEmoji] = useState<string | null>("💬")

--- a/packages/react/src/experimental/Actions/F0EmojiPicker/__tests__/F0EmojiPicker.test.tsx
+++ b/packages/react/src/experimental/Actions/F0EmojiPicker/__tests__/F0EmojiPicker.test.tsx
@@ -36,7 +36,7 @@ describe("F0EmojiPicker", () => {
     const trigger = screen.getByRole("button", { name: "Choose group emoji" })
 
     expect(trigger).toHaveAttribute("type", "button")
-    expect(trigger).toHaveAttribute("title", "Choose group emoji")
+    expect(trigger).toHaveAttribute("aria-label", "Choose group emoji")
     expect(container.querySelector("svg")).toBeInTheDocument()
     expect(container.querySelector("img")).not.toBeInTheDocument()
   })
@@ -207,9 +207,9 @@ describe("F0EmojiPicker", () => {
   })
 
   it.each([
-    ["sm", "size-6"],
-    ["md", "size-8"],
-    ["lg", "size-10"],
+    ["sm", "[&_.main]:h-6"],
+    ["md", "[&_.main]:h-8"],
+    ["lg", "[&_.main]:h-10"],
   ] as const)(
     "renders the %s trigger size in both states",
     (size, className) => {
@@ -219,7 +219,6 @@ describe("F0EmojiPicker", () => {
 
       expect(
         screen.getByRole("button", { name: "Choose group emoji" })
-          .firstElementChild
       ).toHaveClass(className)
 
       rerender(
@@ -228,7 +227,6 @@ describe("F0EmojiPicker", () => {
 
       expect(
         screen.getByRole("button", { name: "Choose group emoji: 🎉" })
-          .firstElementChild
       ).toHaveClass(className)
     }
   )

--- a/packages/react/src/experimental/Actions/F0EmojiPicker/__tests__/F0EmojiPicker.test.tsx
+++ b/packages/react/src/experimental/Actions/F0EmojiPicker/__tests__/F0EmojiPicker.test.tsx
@@ -209,7 +209,8 @@ describe("F0EmojiPicker", () => {
     ).not.toBeInTheDocument()
     expect(screen.getByTestId("emoji-picker")).toHaveClass(
       "border",
-      "border-solid"
+      "border-solid",
+      "border-f1-border-secondary"
     )
     expect(screen.getByTestId("emoji-picker")).not.toHaveClass(
       "rounded-b-none",
@@ -264,9 +265,12 @@ describe("F0EmojiPicker", () => {
       "data-search-position",
       "top"
     )
-    expect(
-      screen.getByRole("button", { name: "Clear" }).parentElement
-    ).toHaveClass(
+    const clearFooter = screen
+      .getByRole("button", { name: "Clear" })
+      .closest("div.rounded-b-md")
+
+    expect(clearFooter).toHaveClass(
+      "border-f1-border-secondary",
       "[@media(max-height:320px)]:px-1",
       "[@media(max-height:320px)]:py-0"
     )

--- a/packages/react/src/experimental/Actions/F0EmojiPicker/__tests__/F0EmojiPicker.test.tsx
+++ b/packages/react/src/experimental/Actions/F0EmojiPicker/__tests__/F0EmojiPicker.test.tsx
@@ -8,13 +8,24 @@ import { F0EmojiPicker } from "../index"
 
 vi.mock("@/lib/EmojiPicker", () => ({
   EmojiPicker: ({
+    className,
     locale,
+    navPosition,
     onEmojiSelect,
+    searchPosition,
   }: {
+    className?: string
     locale?: string
+    navPosition?: string
     onEmojiSelect?: (emoji: { native: string }) => void
+    searchPosition?: string
   }) => (
-    <>
+    <div
+      className={className}
+      data-nav-position={navPosition}
+      data-search-position={searchPosition}
+      data-testid="emoji-picker"
+    >
       <button
         type="button"
         data-locale={locale}
@@ -25,7 +36,7 @@ vi.mock("@/lib/EmojiPicker", () => ({
       <button type="button" onClick={() => onEmojiSelect?.({ native: "👨‍👩‍👧‍👦" })}>
         Select family
       </button>
-    </>
+    </div>
   ),
 }))
 
@@ -196,6 +207,14 @@ describe("F0EmojiPicker", () => {
     expect(
       screen.queryByRole("button", { name: "Clear" })
     ).not.toBeInTheDocument()
+    expect(screen.getByTestId("emoji-picker")).toHaveClass(
+      "border",
+      "border-solid"
+    )
+    expect(screen.getByTestId("emoji-picker")).not.toHaveClass(
+      "rounded-b-none",
+      "border-b-0"
+    )
 
     unmount()
     render(<F0EmojiPicker label="Choose group emoji" clearable />)
@@ -204,6 +223,53 @@ describe("F0EmojiPicker", () => {
     expect(
       screen.queryByRole("button", { name: "Clear" })
     ).not.toBeInTheDocument()
+    expect(screen.getByTestId("emoji-picker")).not.toHaveClass(
+      "rounded-b-none",
+      "border-b-0"
+    )
+  })
+
+  it("joins the picker border to the clear action footer", async () => {
+    const user = userEvent.setup()
+    render(
+      <F0EmojiPicker label="Choose group emoji" defaultValue="💬" clearable />
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: "Choose group emoji: 💬" })
+    )
+
+    expect(screen.getByTestId("emoji-picker")).toHaveClass(
+      "rounded-b-none",
+      "border-b-0"
+    )
+    expect(screen.getByRole("button", { name: "Clear" })).toBeInTheDocument()
+  })
+
+  it("preserves search and category navigation in short viewports", async () => {
+    const user = userEvent.setup()
+    render(
+      <F0EmojiPicker label="Choose group emoji" defaultValue="💬" clearable />
+    )
+
+    await user.click(
+      screen.getByRole("button", { name: "Choose group emoji: 💬" })
+    )
+
+    expect(screen.getByTestId("emoji-picker")).toHaveAttribute(
+      "data-nav-position",
+      "top"
+    )
+    expect(screen.getByTestId("emoji-picker")).toHaveAttribute(
+      "data-search-position",
+      "top"
+    )
+    expect(
+      screen.getByRole("button", { name: "Clear" }).parentElement
+    ).toHaveClass(
+      "[@media(max-height:320px)]:px-1",
+      "[@media(max-height:320px)]:py-0"
+    )
   })
 
   it.each([

--- a/packages/react/src/icons/app/MaximizeHorizontal.tsx
+++ b/packages/react/src/icons/app/MaximizeHorizontal.tsx
@@ -16,14 +16,12 @@ const SvgMaximizeHorizontal = (
       strokeLinecap="round"
       strokeLinejoin="round"
       d="M14.12 12L21.9 12M21.9 12L19.07 9.17M21.9 12L19.07 14.83"
-      vectorEffect="non-scaling-stroke"
     />
     <path
       stroke="currentColor"
       strokeLinecap="round"
       strokeLinejoin="round"
       d="M9.88 12L2.1 12M2.1 12L4.93 9.17M2.1 12L4.93 14.83"
-      vectorEffect="non-scaling-stroke"
     />
   </svg>
 )

--- a/packages/react/src/icons/app/MinimizeHorizontal.tsx
+++ b/packages/react/src/icons/app/MinimizeHorizontal.tsx
@@ -16,14 +16,12 @@ const SvgMinimizeHorizontal = (
       strokeLinecap="round"
       strokeLinejoin="round"
       d="M21.9 12L14.12 12M14.12 12L16.95 9.17M14.12 12L16.95 14.83"
-      vectorEffect="non-scaling-stroke"
     />
     <path
       stroke="currentColor"
       strokeLinecap="round"
       strokeLinejoin="round"
       d="M2.1 12L9.88 12M9.88 12L7.05 9.17M9.88 12L7.05 14.83"
-      vectorEffect="non-scaling-stroke"
     />
   </svg>
 )

--- a/packages/react/src/lib/EmojiPicker.test.tsx
+++ b/packages/react/src/lib/EmojiPicker.test.tsx
@@ -1,5 +1,7 @@
-import { render, waitFor } from "@testing-library/react"
+import { waitFor } from "@testing-library/react"
 import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { zeroRender as render } from "@/testing/test-utils"
 
 import { EmojiPicker } from "./EmojiPicker"
 
@@ -37,6 +39,31 @@ describe("EmojiPicker", () => {
 
     expect(createElementSpy).toHaveBeenCalledWith("em-emoji-picker")
     expect(container.contains(stub)).toBe(true)
+  })
+
+  it("applies className directly to the emoji picker element", () => {
+    const stub = stubPickerElement()
+    vi.spyOn(document, "createElement").mockImplementation((tag: string) =>
+      tag === "em-emoji-picker" ? stub : realCreateElement(tag)
+    )
+
+    const { rerender } = render(
+      <EmojiPicker data={{}} className="border border-f1-border-hover" />
+    )
+
+    expect(stub).toHaveClass("border", "border-f1-border-hover")
+    expect(stub.props).not.toHaveProperty("className")
+
+    rerender(<EmojiPicker data={{}} className="border-2" />)
+
+    expect(stub).toHaveClass("border-2")
+    expect(stub).not.toHaveClass("border", "border-f1-border-hover")
+    expect(stub.update).toHaveBeenLastCalledWith({ data: {} })
+
+    rerender(<EmojiPicker data={{}} />)
+
+    expect(stub.className).toBe("")
+    expect(stub.update).toHaveBeenLastCalledWith({ data: {} })
   })
 
   it("seeds props onto the element before appending so callbacks are wired", () => {

--- a/packages/react/src/lib/EmojiPicker.tsx
+++ b/packages/react/src/lib/EmojiPicker.tsx
@@ -77,6 +77,7 @@ function observeEmojiButtonAria(element: EmojiMartElement): () => void {
 }
 
 export type EmojiPickerProps = {
+  className?: string
   data?: unknown
   onEmojiSelect?: (emoji: { native: string }) => void
   locale?: string
@@ -94,11 +95,13 @@ export type EmojiPickerProps = {
   dynamicWidth?: boolean
 }
 
-function EmojiPickerElement(props: EmojiPickerProps) {
+function EmojiPickerElement({ className, ...props }: EmojiPickerProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const elementRef = useRef<EmojiMartElement | null>(null)
   const propsRef = useRef(props)
+  const classNameRef = useRef(className)
   propsRef.current = props
+  classNameRef.current = className
 
   // createElement (not `new`, which @emoji-mart/react uses) instantiates the
   // *registered* element class. With a duplicated emoji-mart class in the
@@ -112,6 +115,7 @@ function EmojiPickerElement(props: EmojiPickerProps) {
       "em-emoji-picker"
     ) as EmojiMartElement
     elementRef.current = element
+    element.className = classNameRef.current ?? ""
     // Seed props *before* appending: connectedCallback reads `this.props`
     // synchronously on append to build the picker. A post-append `update()`
     // is dropped because emoji-mart's attributeChangedCallback bails while its
@@ -130,7 +134,11 @@ function EmojiPickerElement(props: EmojiPickerProps) {
 
   // Push later prop changes to the live element (as @emoji-mart/react does).
   useEffect(() => {
-    elementRef.current?.update?.(props)
+    const element = elementRef.current
+    if (!element) return
+
+    element.className = className ?? ""
+    element.update?.(props)
   })
 
   return <div ref={containerRef} />


### PR DESCRIPTION
## Description

Refactors the experimental F0EmojiPicker trigger to use F0Button with the outline variant and polishes the picker popover with a clearer attached border, responsive overflow behavior, and a clear action that remains visually joined to the picker. Accessible naming, disabled behavior, keyboard interaction, and controlled and uncontrolled selection remain preserved.

## Type of change

- [x] Component enhancement

## Lifecycle phase

This updates the existing experimental F0EmojiPicker implementation.

## Tests

- `pnpm --filter @factorialco/f0-react run format`
- `pnpm --filter @factorialco/f0-react run tsc`
- `pnpm --filter @factorialco/f0-react vitest --run src/experimental/Actions/F0EmojiPicker/__tests__/F0EmojiPicker.test.tsx` — 19 passed
- Pre-commit lint and cycle dependency checks

---
> Factorial is conducting an analysis on the impact of the used skills. This was autogenerated, please do not delete:
> - factorial-pr
> - factorial-f0
> - factorial-ci
