### PR TITLE
fix(OneDataCollection): make the header group collapse animate in tree tables

### DIFF
--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/NestedRow.tsx
@@ -34,6 +34,7 @@ import { FiltersDefinition } from "@/patterns/OneFilterPicker/types"
 
 import type {
   CellRendererProps,
+  ColId,
   RowWrapperProps,
   TableColumnDefinition,
 } from "../types"
@@ -99,6 +100,8 @@ export type RowProps<
   rowWrapper?: React.ComponentType<RowWrapperProps<R>>
   fromVisualization?: TableVisualizationType
   headerGroups: HeaderGroupEntry[] | null
+  /** Marker classes the collapse animation looks the cells up by. */
+  collapsingCellClasses?: ReadonlyMap<ColId, string>
   registerSelectable?: (id: SelectionId, item: R) => void
   unregisterSelectable?: (id: SelectionId) => void
 }

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/components/Row.tsx
@@ -253,6 +253,7 @@ const RowComponentInner = <
         cellRenderer={CellRenderer}
         rowWrapper={rowWrapper}
         headerGroups={headerGroups}
+        collapsingCellClasses={collapsingCellClasses}
         key={key}
         fromVisualization={fromVisualization}
         registerSelectable={registerSelectable}

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/__tests__/useColumnCollapseAnimation.test.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/__tests__/useColumnCollapseAnimation.test.ts
@@ -1,0 +1,109 @@
+import { renderHook } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useColumnCollapseAnimation } from "../useColumnCollapseAnimation"
+
+const CELL_CLASS = "f0-collapsing-group-0"
+/** What the table resolves for the column while nothing is pinned to zero. */
+const NATURAL_WIDTH = 120
+/** What a later cell would measure once an earlier one has been pinned. */
+const REFLOWED_WIDTH = 80
+
+type Recorded = { keyframes: Keyframe[]; options: KeyframeAnimationOptions }
+
+describe("useColumnCollapseAnimation", () => {
+  const originalAnimate = HTMLElement.prototype.animate
+  const originalGetBoundingClientRect =
+    HTMLElement.prototype.getBoundingClientRect
+  const originalGetComputedStyle = globalThis.getComputedStyle
+
+  let container: HTMLElement
+  let recorded: Recorded[]
+  /** Set once any cell is pinned to zero, standing in for the table reflow. */
+  let anyCellPinned: boolean
+
+  beforeEach(() => {
+    recorded = []
+    anyCellPinned = false
+
+    container = document.createElement("div")
+    // Three cells of one column: the header cell and two body cells.
+    for (let index = 0; index < 3; index++) {
+      const cell = document.createElement("div")
+      cell.className = CELL_CLASS
+      container.appendChild(cell)
+    }
+    document.body.appendChild(container)
+
+    HTMLElement.prototype.getBoundingClientRect = function () {
+      return {
+        width: anyCellPinned ? REFLOWED_WIDTH : NATURAL_WIDTH,
+      } as DOMRect
+    }
+
+    globalThis.getComputedStyle = (() => ({
+      paddingLeft: "12px",
+      paddingRight: "12px",
+    })) as unknown as typeof globalThis.getComputedStyle
+
+    HTMLElement.prototype.animate = function (
+      keyframes: Keyframe[],
+      options: KeyframeAnimationOptions
+    ) {
+      recorded.push({ keyframes, options })
+      anyCellPinned = true
+
+      return {
+        finished: Promise.resolve(),
+        cancel: vi.fn(),
+      } as unknown as Animation
+    } as typeof HTMLElement.prototype.animate
+  })
+
+  afterEach(() => {
+    HTMLElement.prototype.animate = originalAnimate
+    HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect
+    globalThis.getComputedStyle = originalGetComputedStyle
+    container.remove()
+  })
+
+  const renderOpening = () =>
+    renderHook(() =>
+      useColumnCollapseAnimation(
+        { current: container },
+        [{ groupId: "january", cellClass: CELL_CLASS, direction: "open" }],
+        vi.fn()
+      )
+    )
+
+  it("animates every cell of a column towards the same width", () => {
+    renderOpening()
+
+    // Two animations per cell: the size one first, then the fade.
+    const targets = recorded
+      .filter(({ keyframes }) => "width" in keyframes[0])
+      .map(({ keyframes }) => keyframes[1].width)
+
+    expect(targets).toEqual([
+      `${NATURAL_WIDTH}px`,
+      `${NATURAL_WIDTH}px`,
+      `${NATURAL_WIDTH}px`,
+    ])
+  })
+
+  it("reads every cell before pinning any of them", () => {
+    renderOpening()
+
+    // A cell measured after a sibling was pinned would carry the reflowed
+    // width, which is what leaves the header and the body out of step.
+    const sizeKeyframes = recorded.filter(
+      ({ keyframes }) => "width" in keyframes[0]
+    )
+
+    expect(
+      sizeKeyframes.some(
+        ({ keyframes }) => keyframes[1].width === `${REFLOWED_WIDTH}px`
+      )
+    ).toBe(false)
+  })
+})

--- a/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/useColumnCollapseAnimation.ts
+++ b/packages/react/src/patterns/OneDataCollection/visualizations/collection/Table/hooks/useColumnCollapseAnimation.ts
@@ -61,13 +61,27 @@ export const useColumnCollapseAnimation = (
         return
       }
 
+      // Every cell is read before any of them is written to. Starting an
+      // animation pins that cell at zero width, which reflows the table and
+      // leaves every later measurement short — the header and body cells of one
+      // column end up animating towards different widths, so the column comes
+      // apart while it moves.
+      const measurements = cells.map((cell) => {
+        const { paddingLeft, paddingRight } = getComputedStyle(cell)
+
+        return {
+          // The width the table resolved for the column, and the value the open
+          // direction needs.
+          width: cell.getBoundingClientRect().width,
+          paddingLeft,
+          paddingRight,
+        }
+      })
+
       const settled: Array<Promise<unknown>> = []
 
-      cells.forEach((cell) => {
-        // Measured before anything is touched: this is the width the table
-        // resolved for the column, and the value the open direction needs.
-        const width = cell.getBoundingClientRect().width
-        const { paddingLeft, paddingRight } = getComputedStyle(cell)
+      cells.forEach((cell, index) => {
+        const { width, paddingLeft, paddingRight } = measurements[index]
 
         const previousOverflow = cell.style.overflow
         cell.style.overflow = "hidden"


### PR DESCRIPTION
## Description

Collapsing a header group had no movement at all in a table with `itemsWithChildren`: the column header labels faded on schedule, the columns held their full width for the length of the animation, and then everything snapped in a single frame. Two separate defects, both in the collapse animation.

Frame-stepping a 3.7s screen recording of a 12-month table (60ms apart) showed the shape of it — expanded and full width at 1180ms, fully collapsed at 1240ms, no intermediate width in between.

### 1. The marker classes never reached the body cells

A row with children delegates to `NestedRow`, and `NestedRow` did not accept `collapsingCellClasses`, so the `Row` it renders got it as `undefined`. Only the header cells carried the marker class, so `querySelectorAll` in the animation found only them. The header cells faded and shrank, but a column's width is decided by its body cells, and those were never animated — hence the hold, then the snap when the group settled and the columns were dropped.

`NestedRow` now takes the map and both of its `Row` renders spread props, so the whole tree is covered.

### 2. Target widths were measured against an already-reflowed table

`useColumnCollapseAnimation` measured a cell and immediately started its animation, and starting it pins that cell at `width: 0`, reflowing the table. Every cell after the first read its width from the reflowed table. Measured in Chrome on one group of 3 hidden columns, header + 2 body rows:

```
before:  122.2 123.8 93.6 | 99.9 99.9 74.4 | 99.9 99.9 74.4   <- body ~18% short
after:   122.2 122.2 91   | 122.2 122.2 91 | 122.2 122.2 91
```

Split into a read phase and a write phase.

## Type of change

- [x] Bug fix

## Verification

- New `useColumnCollapseAnimation.test.ts` covers the measurement order; it fails on `main` with `expected [ '120px', '80px', '80px' ] to deeply equal [ '120px', '120px', '120px' ]`
- `pnpm vitest run src/patterns/OneDataCollection` — 63 files, 642 tests, all passing
- `pnpm format:check` and `pnpm lint` clean on all four files
- `pnpm tsc`: 36 errors, the same 36 as on `main` (pre-existing, `Kanban.stories.tsx` and `dotTag.stories.tsx`)

Fix 1 has no unit test — it is a dropped optional prop, and covering it properly means rendering the table. A story with a collapsible header group over a tree source would lock it in through Chromatic; I left the story file alone to avoid colliding with work in progress there.

## Known, not fixed here

The open direction still snaps on its last frame. Animating a cell towards its measured width does not converge: in an auto-layout table at `width: 100%` a declared width acts as a floor *and* claims a share of the leftover space, so a cell measured at 122.2px renders at 146.2px once that width is declared on it, then drops back when the animation stops applying — 23.3px in one frame against ~12px per frame during the animation. `fill: "both"` only defers the drop to when the animation is cancelled. A real fix likely means keeping the animated size off the table layout (an inner wrapper, or `table-layout: fixed`), which is more than this PR.