### PR TITLE
fix(icons): strip stale non-scaling-stroke from Maximize/MinimizeHorizontal

### DIFF
--- a/packages/react/src/icons/app/MaximizeHorizontal.tsx
+++ b/packages/react/src/icons/app/MaximizeHorizontal.tsx
@@ -16,14 +16,12 @@ const SvgMaximizeHorizontal = (
       strokeLinecap="round"
       strokeLinejoin="round"
       d="M14.12 12L21.9 12M21.9 12L19.07 9.17M21.9 12L19.07 14.83"
-      vectorEffect="non-scaling-stroke"
     />
     <path
       stroke="currentColor"
       strokeLinecap="round"
       strokeLinejoin="round"
       d="M9.88 12L2.1 12M2.1 12L4.93 9.17M2.1 12L4.93 14.83"
-      vectorEffect="non-scaling-stroke"
     />
   </svg>
 )

--- a/packages/react/src/icons/app/MinimizeHorizontal.tsx
+++ b/packages/react/src/icons/app/MinimizeHorizontal.tsx
@@ -16,14 +16,12 @@ const SvgMinimizeHorizontal = (
       strokeLinecap="round"
       strokeLinejoin="round"
       d="M21.9 12L14.12 12M14.12 12L16.95 9.17M14.12 12L16.95 14.83"
-      vectorEffect="non-scaling-stroke"
     />
     <path
       stroke="currentColor"
       strokeLinecap="round"
       strokeLinejoin="round"
       d="M2.1 12L9.88 12M9.88 12L7.05 9.17M9.88 12L7.05 14.83"
-      vectorEffect="non-scaling-stroke"
     />
   </svg>
 )


### PR DESCRIPTION
## Description

`main` is red right now: the `[⚛️ REACT] Unit Tests` job fails on push (`a2626bf70`) and on every PR, on `src/icons/__tests__/noNonScalingStroke.test.ts`. #4884 (`c0c0c5780`) was cut before #4944 removed the `addVectorEffect` svgo plugin and merged after it, so the two icons it added — `MaximizeHorizontal` and `MinimizeHorizontal` — were generated with the old config and still carry `vectorEffect="non-scaling-stroke"`, which renders too thin on Retina in recent Chrome and is exactly what the guard forbids. This regenerates both icons with today's pipeline; the diff is the four attribute removals and nothing else.

## Implementation details

- fix: regenerate `MaximizeHorizontal.tsx` and `MinimizeHorizontal.tsx` without `non-scaling-stroke`

  <details>
  <summary>Why regenerate instead of hand-editing, and why not the full generate-icons</summary>

  The SVG sources in `packages/core/assets` and `svgo.config.cjs` are already clean — 0 of 869 `.svg` files in the repo carry the attribute — so this is a stale generated artifact, not a config regression. Regenerating (`npx @svgr/cli` + `oxfmt`, the same steps `generate-icons` runs, scoped to the two files) proves the committed artifact matches current generator output: apart from the removed attributes it is byte-identical. A full `generate-icons` would `rm -fR` and rebuild every icon and flag, turning a 2-file unblock into a diff with any unrelated drift in it.
  </details>

## Verification

- `pnpm vitest --project=unit run src/icons/__tests__/noNonScalingStroke.test.ts` — passes, including its >400-files vacuity check
- `pnpm tsc`, `oxfmt --check` on the two files — clean
- Full unit suite running; will report in a comment if anything unexpected shows up

## Impact

Unblocks `main` and every open PR's unit job — #4989 plus the five stabilization PRs (#4931, #4954, #4962, #4964, #4977) are all either red or stale-green behind this.

Process note: #4884 merged on a stale-green run — its last CI predates #4944 on its base, and the sibling PRs above are stale-green the same way right now. Branch protection's "require branches to be up to date before merging" would have caught this at the gate; flagging for whoever administers the repo.